### PR TITLE
Adding more descriptive options

### DIFF
--- a/pumpkin-cli/Cargo.toml
+++ b/pumpkin-cli/Cargo.toml
@@ -3,10 +3,12 @@ name = "pumpkin-cli"
 version = "0.1.0"
 edition = "2021"
 publish = false
+authors = ["Emir Demirović", "Maarten Flippo", "Imko Marijnissen", "Konstantin Sidorov", "Jeff Smits"] # Ordered alphabetically based on last name!
+description = "The command-line interface for using the Pumpkin solver"
 
 [dependencies]
 pumpkin-lib = { path = "../pumpkin-lib" }
-clap = { version = "4.1.8", features = ["derive"] }
+clap = { version = "4.1.8", features = ["derive", "help"] }
 log = "0.4.18"
 env_logger = "0.10.0"
 thiserror = "1.0.40"

--- a/pumpkin-cli/src/main.rs
+++ b/pumpkin-cli/src/main.rs
@@ -40,7 +40,21 @@ use crate::flatzinc::FlatZincOptions;
 use crate::maxsat::wcnf_problem;
 
 #[derive(Debug, Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    help_template = "\
+{before-help}{name} {version}
+Authors: {author}
+About: {about}
+
+{usage-heading}\n{tab}{usage}
+
+{all-args}{after-help}
+",
+    author,
+    version,
+    about,
+    arg_required_else_help = true
+)]
 struct Args {
     /// The instance to solve. The file should have one of the following extensions:
     ///  - '*.cnf' for SAT instances, given in the DIMACS format,

--- a/pumpkin-cli/src/main.rs
+++ b/pumpkin-cli/src/main.rs
@@ -43,146 +43,290 @@ use crate::maxsat::wcnf_problem;
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// The instance to solve. The file should have one of the following extensions:
-    ///  * '.cnf' for SAT instances, given in the DIMACS format,
-    ///  * '.wcnf' for MaxSAT instances, given in the WDIMACS format.
+    ///  - '*.cnf' for SAT instances, given in the DIMACS format,
+    ///  - '*.wcnf' for MaxSAT instances, given in the WDIMACS format.
+    ///  - '*.fzn' for FlatZinc instances (see <https://docs.minizinc.dev/en/stable/flattening.html>).
+    #[clap(verbatim_doc_comment)]
     instance_path: PathBuf,
 
     /// The output path for the proof file.
     ///
     /// When solving a DIMACS instance, a DRAT proof is logged. In case of a FlatZinc model, a DRCP
     /// proof is logged.
-    #[arg(long)]
-    proof: Option<PathBuf>,
+    #[arg(long, verbatim_doc_comment)]
+    proof_path: Option<PathBuf>,
 
     /// The number of high lbd learned clauses that are kept in the database.
-    /// Learned clauses are kept based on the tiered system introduced by Chanseok Oh
-    #[arg(long = "learning-max-num-clauses", default_value_t = 4000)]
+    /// Learned clauses are kept based on the tiered system introduced in "Improving
+    /// SAT Solvers by Exploiting Empirical Characteristics of CDCL - Chanseok Oh (2016)".
+    ///
+    /// Possible values: u64
+    #[arg(
+        long = "learning-max-num-clauses",
+        default_value_t = 4000,
+        verbatim_doc_comment
+    )]
     learning_max_num_clauses: u64,
 
     /// Learned clauses with this threshold LBD or lower are kept permanently
-    /// Learned clauses are kept based on the tiered system introduced by Chanseok Oh
-    #[arg(long = "learning-lbd-threshold", default_value_t = 5)]
+    /// Learned clauses are kept based on the tiered system introduced "Improving
+    /// SAT Solvers by Exploiting Empirical Characteristics of CDCL - Chanseok Oh (2016)".
+    ///
+    /// Possible values: u32
+    #[arg(
+        long = "learning-lbd-threshold",
+        default_value_t = 5,
+        verbatim_doc_comment
+    )]
     learning_lbd_threshold: u32,
 
-    /// Decides which clauses will be removed when cleaning up the learned clauses.
+    /// Decides which clauses will be removed when cleaning up the learned clauses. Can either be
+    /// based on the LBD of a clause (the number of different decision levels) or on the activity
+    /// of a clause (how often it is used in conflict analysis).
+    ///
+    /// Possible values: ["lbd", "activity"]
     #[arg(
         short = 'l',
         long = "learning-sorting-strategy",
         value_parser = learned_clause_sorting_strategy_parser,
-        default_value_t = LearnedClauseSortingStrategy::Activity.into()
+        default_value_t = LearnedClauseSortingStrategy::Activity.into(), verbatim_doc_comment
     )]
     learning_sorting_strategy: CliArg<LearnedClauseSortingStrategy>,
 
     /// Decides whether learned clauses are minimised as a post-processing step after computing the
-    /// 1uip Minimisation is done according to the idea proposed by Van Gelder
+    /// 1-UIP Minimisation is done; according to the idea proposed in "Generalized Conflict-Clause
+    /// Strengthening for Satisfiability Solvers - Allen van Gelder (2011)".
+    ///
+    /// Possible values: bool
     #[arg(
         long = "learning-minimise",
-        value_parser = learned_clause_minimisation_parser,
-        default_value_t = true.into()
+        default_value_t = true,
+        verbatim_doc_comment
     )]
-    learning_clause_minimisation: CliArg<bool>,
+    learning_clause_minimisation: bool,
 
     /// Decides the sequence based on which the restarts are performed.
-    /// To be used in combination with "restarts-base-interval"
+    /// - The "constant" approach uses a constant number of conflicts before another restart is
+    ///   triggered
+    /// - The "geometric" approach uses a geometrically increasing sequence
+    /// - The "luby" approach uses a recursive sequence of the form 1, 1, 2, 1, 1, 2, 4, 1, 1, 2,
+    ///   1, 1, 2, 4, 8, 1, 1, 2.... (see "Optimal speedup of Las Vegas algorithms - Luby et al.
+    ///   (1993)")
+    ///
+    /// To be used in combination with "--restarts-base-interval".
+    ///
+    /// Possible values: ["constant", "geometric", "luby"]
     #[arg(
         long = "restart-sequence",
         value_parser = sequence_generator_parser,
-        default_value_t = SequenceGeneratorType::Constant.into()
+        default_value_t = SequenceGeneratorType::Constant.into(), verbatim_doc_comment
     )]
     restart_sequence_generator_type: CliArg<SequenceGeneratorType>,
 
     /// The base interval length is used as a multiplier to the restart sequence.
-    /// For example, constant restarts with base interval 100 means a retart is triggered every 100
+    /// - In the case of the "constant" restart sequence this argument indicates the constant which
+    ///   is used to determine when a restart occurs
+    /// - For the "geometric" approach this argument indicates the starting value of the sequence
+    /// - For the "luby" approach, the sequence is multiplied by this value
+    ///
+    /// For example, constant restarts with base interval 50 means a restart is triggered every 50
     /// conflicts.
-    #[arg(long = "restart-base-interval", default_value_t = 50)]
+    ///
+    /// Possible values: u64
+    #[arg(
+        long = "restart-base-interval",
+        default_value_t = 50,
+        verbatim_doc_comment
+    )]
     restart_base_interval: u64,
 
-    #[arg(long = "restart-min-initial-conflicts", default_value_t = 10000)]
-    restarts_min_num_conflicts_before_first_restart: u64,
+    /// Indicates the minimum number of initial conflicts before the first restart can occur. This
+    /// allows the solver to learn some things about the problem before a restart is allowed to
+    /// occur.
+    ///
+    /// Possible values: u64
+    #[arg(
+        long = "restart-min-initial-conflicts",
+        default_value_t = 10000,
+        verbatim_doc_comment
+    )]
+    restart_min_num_conflicts_before_first_restart: u64,
 
-    /// Used to determine if a restart should be forced (part of Glucose restarts).
-    /// The state is "bad" if the current LBD value is much greater than the global LBD average
-    /// A greater/lower value for lbd-coef means a less/more frequent restart policy
-    #[arg(long = "restart-lbd-coef", default_value_t = 1.25)]
+    /// Used to determine if a restart should be forced (see "Refining Restarts Strategies for SAT
+    /// and UNSAT - Audemard and Simon (2012)").
+    ///
+    /// The state is "bad" if the current LBD value is much greater than
+    /// the global LBD average. A greater (lower) value for lbd-coef means a less (more) frequent
+    /// restart policy. If the long-term average LBD multiplied by this coefficient is lower
+    /// than the short-term average LBD then a restart is performed.
+    ///
+    /// Possible values: f64
+    #[arg(
+        long = "restart-lbd-coef",
+        default_value_t = 1.25,
+        verbatim_doc_comment
+    )]
     restart_lbd_coef: f64,
 
-    /// Used to determine if a restart should be blocked (part of Glucose restarts).
-    /// To be used in combination with "restarts-num-assigned-window".
-    /// A restart is blocked if the number of assigned propositional variables is must greater than
-    /// the average number of assigned variables in the recent past A greater/lower value for
-    /// num-assigned-coef means fewer/more blocked restarts
-    #[arg(long = "restart-num-assigned-coef", default_value_t = 1.4)]
+    /// Used to determine if a restart should be blocked (see "Refining Restarts Strategies for SAT
+    /// and UNSAT - Audemard and Simon (2012)").
+    ///
+    /// To be used in combination with "--restarts-num-assigned-window".
+    ///
+    /// A restart is blocked if the number of assigned propositional variables is much greater than
+    /// the average number of assigned variables in the recent past. A greater (lower) value for
+    /// "--restart-num-assigned-coef" means fewer (more) blocked restarts.
+    ///
+    /// Possible values: f64
+    #[arg(
+        long = "restart-num-assigned-coef",
+        default_value_t = 1.4,
+        verbatim_doc_comment
+    )]
     restart_num_assigned_coef: f64,
 
     /// Used to determine the length of the recent past that should be considered when deciding on
-    /// blocking restarts (part of Glucose restarts). The solver considers the last
-    /// num-assigned-window conflicts as the reference point for the number of assigned variables
-    #[arg(long = "restart-num-assigned-window", default_value_t = 5000)]
+    /// blocking restarts (see "Refining Restarts Strategies for SAT
+    /// and UNSAT - Audemard and Simon (2012)").
+    ///
+    /// The solver considers the last "--restart_num_assigned_window" conflicts as the reference
+    /// point for the number of assigned variables.
+    ///
+    /// Possible values: u64
+    #[arg(
+        long = "restart-num-assigned-window",
+        default_value_t = 5000,
+        verbatim_doc_comment
+    )]
     restart_num_assigned_window: u64,
 
-    /// The coefficient in the geometric sequence x_i = x_{i-1} * geometric-coef, x_1 =
-    /// "restarts-base-interval" Used only if "restarts-sequence-generator" is assigned to
-    /// "geometric".
-    #[arg(long = "restart-geometric-coef")]
+    /// The coefficient in the geometric sequence `x_i = x_{i-1} * "--restart-geometric-coef"`
+    /// where `x_1 = "--restarts-base-interval"`. Used only if "--restarts-sequence-generator"
+    /// is assigned to "geometric".
+    ///
+    /// Possible values: f64 (Optional)
+    #[arg(long = "restart-geometric-coef", verbatim_doc_comment)]
     restart_geometric_coef: Option<f64>,
 
     /// The time budget for the solver, given in milliseconds.
-    #[arg(short = 't', long = "time-limit")]
+    ///
+    /// Possible values: u64 (Optional)
+    #[arg(short = 't', long = "time-limit", verbatim_doc_comment)]
     time_limit: Option<u64>,
 
-    /// The random seed to use for the PRNG. This influences the initial order of the variables.
-    #[arg(short = 'r', long = "random-seed", default_value_t = 42)]
+    /// The random seed to use for the Pseudo Random Number Generator.
+    ///
+    /// Randomisation can be used for aspects such as the variable/value generator or initial
+    /// ordering of variables.
+    ///
+    /// Possible values: u64
+    #[arg(
+        short = 'r',
+        long = "random-seed",
+        default_value_t = 42,
+        verbatim_doc_comment
+    )]
     random_seed: u64,
 
-    /// Enables log message output from the solver
-    #[arg(short = 'v', long = "verbose", default_value_t = false)]
+    /// Enables log message output from the solver.
+    ///
+    /// For printing statistics see the option "--log-statistics", and for printing all solutions
+    /// (in case of a satisfaction problem) or printing solutions of increasing quality (in case of
+    /// an optimization problem) see the option "--all-solutions".
+    ///
+    /// Possible values: bool
+    #[arg(
+        short = 'v',
+        long = "verbose",
+        default_value_t = false,
+        verbatim_doc_comment
+    )]
     verbose: bool,
 
-    /// Enables logging of statistics from the solver
-    #[arg(short = 's', long = "log-statistics", default_value_t = false)]
+    /// Enables logging of statistics from the solver.
+    ///
+    /// Possible values: bool
+    #[arg(
+        short = 's',
+        long = "log-statistics",
+        default_value_t = false,
+        verbatim_doc_comment
+    )]
     log_statistics: bool,
 
     /// Instructs the solver to perform free search when solving a MiniZinc model; this flag
     /// indicates that it is allowed to ignore the search annotations specified in the model.
-    /// See the [MiniZinc specification](https://www.minizinc.org/doc-2.6.3/en/fzn-spec.html#cmdoption-f)
+    ///
+    /// See the MiniZinc specification (<https://docs.minizinc.dev/en/stable/fzn-spec.html#cmdoption-f>)
     /// for more information.
-    #[arg(short = 'f', long = "free-search", default_value_t = false)]
+    ///
+    /// Possible values: bool
+    #[arg(
+        short = 'f',
+        long = "free-search",
+        default_value_t = false,
+        verbatim_doc_comment
+    )]
     free_search: bool,
 
     /// Instructs the solver to report all solutions in the case of satisfaction problems,
     /// or print intermediate solutions of increasing quality in the case of optimisation
     /// problems.
     ///
-    /// See the [MiniZinc specification](https://www.minizinc.org/doc-2.8.2/en/fzn-spec.html#cmdoption-a)
+    /// See the MiniZinc specification (<https://docs.minizinc.dev/en/stable/fzn-spec.html#cmdoption-a>)
     /// for more information.
-    #[arg(short = 'a', long = "all-solutions", default_value_t = false)]
+    ///
+    /// Possible values: bool
+    #[arg(
+        short = 'a',
+        long = "all-solutions",
+        default_value_t = false,
+        verbatim_doc_comment
+    )]
     all_solutions: bool,
 
-    /// If `--verbose` is enabled removes the timestamp information from the log messages
-    #[arg(long = "omit-timestamp", default_value_t = false)]
+    /// If `--verbose` is enabled then this option removes the timestamp information from the log
+    /// messages when set to true.
+    ///
+    /// Possible values: bool
+    #[arg(long = "omit-timestamp", default_value_t = false, verbatim_doc_comment)]
     omit_timestamp: bool,
 
-    /// If `--verbose` is enabled removes the call site information from the log messages.
-    /// Call site is the file and line in it that originated the message.
-    #[arg(long = "omit-call-site", default_value_t = false)]
+    /// If `--verbose` is enabled then this option removes the call site information from the log
+    /// messages when set to true. The call site is the file and line from which the message
+    /// originated.
+    ///
+    /// Possible values: bool
+    #[arg(long = "omit-call-site", default_value_t = false, verbatim_doc_comment)]
     omit_call_site: bool,
 
-    /// The encoding to use for the upper bound constraint in an optimisation problem.
+    /// The encoding to use for the upper bound constraint in a MaxSAT optimisation problem.
+    ///
+    /// The "gte" value specifies that the solver should use the Generalized Totalizer Encoding
+    /// (see "Generalized totalizer encoding for pseudo-boolean constraints - Saurabh et al.
+    /// (2015)"), and the "cne" value specifies that the solver should use the Cardinality Network
+    /// Encoding (see "Cardinality networks: a theoretical and empirical study - Asín et al.
+    /// (2011)").
+    ///
+    /// Possible values: ["gte", "cne"]
     #[arg(
         long = "upper-bound-encoding",
         value_parser = upper_bound_encoding_parser,
-        default_value_t = PseudoBooleanEncoding::GeneralizedTotalizer.into()
+        default_value_t = PseudoBooleanEncoding::GeneralizedTotalizer.into(), verbatim_doc_comment
     )]
     upper_bound_encoding: CliArg<PseudoBooleanEncoding>,
 
-    /// Determines whether to allow the cumulative propagator(s) to create holes in the domain
-    #[arg(long = "cumulative-allow-holes", default_value_t = false)]
+    /// Determines whether to allow the cumulative propagator(s) to create holes in the domain.
+    ///
+    /// If this option is set to false then only the lower- and upper-bounds are updated.
+    ///
+    /// Possible values: bool
+    #[arg(
+        long = "cumulative-allow-holes",
+        default_value_t = false,
+        verbatim_doc_comment
+    )]
     cumulative_allow_holes: bool,
-
-    /// Verify the reported solution is consistent with the instance, and, if applicable, verify
-    /// that it evaluates to the reported objective value.
-    #[arg(long = "verify", default_value_t = false)]
-    verify_solution: bool,
 }
 
 fn configure_logging(
@@ -307,7 +451,7 @@ fn run() -> PumpkinResult<()> {
         ..Default::default()
     };
 
-    let proof_log = if let Some(path_buf) = args.proof {
+    let proof_log = if let Some(path_buf) = args.proof_path {
         match file_format {
             FileFormat::CnfDimacsPLine => ProofLog::dimacs(&path_buf)?,
             FileFormat::WcnfDimacsPLine => {
@@ -324,14 +468,14 @@ fn run() -> PumpkinResult<()> {
             sequence_generator_type: args.restart_sequence_generator_type.inner,
             base_interval: args.restart_base_interval,
             min_num_conflicts_before_first_restart: args
-                .restarts_min_num_conflicts_before_first_restart,
+                .restart_min_num_conflicts_before_first_restart,
             lbd_coef: args.restart_lbd_coef,
             num_assigned_coef: args.restart_num_assigned_coef,
             num_assigned_window: args.restart_num_assigned_window,
             geometric_coef: args.restart_geometric_coef,
         },
         proof_log,
-        learning_clause_minimisation: args.learning_clause_minimisation.inner,
+        learning_clause_minimisation: args.learning_clause_minimisation,
         random_generator: SmallRng::seed_from_u64(args.random_seed),
     };
 
@@ -435,7 +579,7 @@ fn learned_clause_sorting_strategy_parser(
         "lbd" => Ok(LearnedClauseSortingStrategy::Lbd.into()),
         "activity" => Ok(LearnedClauseSortingStrategy::Activity.into()),
         value => Err(format!(
-            "'{value}' is not a valid learned clause sorting strategy"
+            "'{value}' is not a valid learned clause sorting strategy. Possible values: ['lbd', 'activity']"
         )),
     }
 }
@@ -444,19 +588,9 @@ fn upper_bound_encoding_parser(s: &str) -> Result<CliArg<PseudoBooleanEncoding>,
     match s {
         "gte" => Ok(PseudoBooleanEncoding::GeneralizedTotalizer.into()),
         "cne" => Ok(PseudoBooleanEncoding::CardinalityNetwork.into()),
-        value => Err(format!("'{value}' is not a valid upper bound encoding.")),
-    }
-}
-
-fn learned_clause_minimisation_parser(s: &str) -> Result<CliArg<bool>, String> {
-    if s == "1" || s.to_lowercase() == "true" {
-        Ok(true.into())
-    } else if s == "0" || s.to_lowercase() == "false" {
-        Ok(false.into())
-    } else {
-        Err(format!(
-            "'{s}' is not valid input for the learned clause minimisation parameter."
-        ))
+        value => Err(format!(
+            "'{value}' is not a valid upper bound encoding. Possible values: ['gte', 'cne']."
+        )),
     }
 }
 
@@ -465,7 +599,7 @@ fn sequence_generator_parser(s: &str) -> Result<CliArg<SequenceGeneratorType>, S
         "constant" => Ok(SequenceGeneratorType::Constant.into()),
         "geometric" => Ok(SequenceGeneratorType::Geometric.into()),
         "luby" => Ok(SequenceGeneratorType::Luby.into()),
-        value => Err(format!("'{value}' is not a valid sequence generator.")),
+        value => Err(format!("'{value}' is not a valid sequence generator. Possible values: ['constant', 'geometric', 'luby'].")),
     }
 }
 

--- a/pumpkin-cli/tests/helpers/mod.rs
+++ b/pumpkin-cli/tests/helpers/mod.rs
@@ -57,7 +57,7 @@ pub(crate) fn run_solver_with_options<'a>(
     let mut command = Command::new(solver);
 
     if with_proof {
-        let _ = command.arg("--proof").arg(&proof_file_path);
+        let _ = command.arg("--proof-path").arg(&proof_file_path);
     }
 
     for arg in args {


### PR DESCRIPTION
When running `pumpkin-cli --help`, the options are not necessarily clear; and (what is more bothersome), it is not clear from the output what the possible values are for the different options.

This PR aims to address this by adding more descriptive documentation for the different options in combination with clarifying what the possible values are for the different options. All of the documentation now uses the `verbatim_doc_comment` so that it is in line with the rest of our documentation (and more importantly, that clap doesn't perform any weird line-breaking).