### PR TITLE
Add fix for array of bools being parsed as array of int

### DIFF
--- a/pumpkin-cli/src/flatzinc/compiler/context.rs
+++ b/pumpkin-cli/src/flatzinc/compiler/context.rs
@@ -178,7 +178,6 @@ impl CompilationContext<'_> {
                         })
                 }
             }
-
             flatzinc::Expr::ArrayOfBool(array) => array
                 .iter()
                 .map(|elem| match elem {
@@ -187,6 +186,15 @@ impl CompilationContext<'_> {
                     }
                     flatzinc::BoolExpr::Bool(true) => Ok(self.constant_bool_true),
                     flatzinc::BoolExpr::Bool(false) => Ok(self.constant_bool_false),
+                })
+                .collect(),
+            flatzinc::Expr::ArrayOfInt(array) => array
+                .iter()
+                .map(|elem| match elem {
+                    flatzinc::IntExpr::VarParIdentifier(id) => {
+                        self.resolve_bool_variable_from_identifier(id)
+                    }
+                    _ => panic!("Bool search should not be over integer variable"),
                 })
                 .collect(),
             _ => Err(FlatZincError::UnexpectedExpr),

--- a/pumpkin-cli/tests/mzn_search/bool_search_provided_directly.expected
+++ b/pumpkin-cli/tests/mzn_search/bool_search_provided_directly.expected
@@ -1,0 +1,33 @@
+x1 = true;
+x2 = true;
+x3 = true;
+----------
+x1 = true;
+x2 = true;
+x3 = false;
+----------
+x1 = true;
+x2 = false;
+x3 = true;
+----------
+x1 = true;
+x2 = false;
+x3 = false;
+----------
+x1 = false;
+x2 = true;
+x3 = true;
+----------
+x1 = false;
+x2 = true;
+x3 = false;
+----------
+x1 = false;
+x2 = false;
+x3 = true;
+----------
+x1 = false;
+x2 = false;
+x3 = false;
+----------
+==========

--- a/pumpkin-cli/tests/mzn_search/bool_search_provided_directly.fzn
+++ b/pumpkin-cli/tests/mzn_search/bool_search_provided_directly.fzn
@@ -1,0 +1,5 @@
+var bool: x1 :: output_var;
+var bool: x2 :: output_var;
+var bool: x3 :: output_var;
+
+solve :: bool_search([x1, x2, x3], input_order, indomain_max) satisfy;

--- a/pumpkin-cli/tests/mzn_search_test.rs
+++ b/pumpkin-cli/tests/mzn_search_test.rs
@@ -22,6 +22,7 @@ macro_rules! mzn_search_unordered {
     };
 }
 
+mzn_search_ordered!(bool_search_provided_directly);
 mzn_search_ordered!(search_over_ints_no_propagators);
 mzn_search_unordered!(search_with_constants_in_search);
 mzn_search_unordered!(search_annotation_does_not_fix_all_variables);


### PR DESCRIPTION
This fixes the issue where the following fails to parse:

```
var bool: x1 :: output_var;
var bool: x2 :: output_var;
var bool: x3 :: output_var;

solve :: bool_search([x1, x2, x3], input_order, indomain_max) satisfy;
```

This was due to the fact that the flatzinc crate which we use does not know what the type of the provided array is and it then automatically parses it to an array of ints. The fix is to parse int arrays when parsing boolean array but only allowing boolean values in there.