### PR TITLE
Improve the element propagator with better explanations.

### DIFF
--- a/pumpkin-lib/src/engine/cp/propagation/propagation_context.rs
+++ b/pumpkin-lib/src/engine/cp/propagation/propagation_context.rs
@@ -183,8 +183,8 @@ pub(crate) trait ReadDomains: HasAssignments {
         var.contains(self.assignments(), value)
     }
 
-    fn describe_domain<Var: IntegerVariable>(&self, var: &Var) -> Vec<Predicate> {
-        var.describe_domain(self.assignments())
+    fn iterate_domain<Var: IntegerVariable>(&self, var: &Var) -> impl Iterator<Item = i32> {
+        var.iterate_domain(self.assignments())
     }
 }
 

--- a/pumpkin-lib/src/engine/variables/affine_view.rs
+++ b/pumpkin-lib/src/engine/variables/affine_view.rs
@@ -131,10 +131,10 @@ where
         }
     }
 
-    fn describe_domain(&self, assignment: &Assignments) -> Vec<Predicate> {
-        // The description should not actually change. It is a description of the domain as seen by
-        // the solver, not as seen by the user of this view.
-        self.inner.describe_domain(assignment)
+    fn iterate_domain(&self, assignment: &Assignments) -> impl Iterator<Item = i32> {
+        self.inner
+            .iterate_domain(assignment)
+            .map(|value| self.map(value))
     }
 
     fn remove(

--- a/pumpkin-lib/src/engine/variables/domain_id.rs
+++ b/pumpkin-lib/src/engine/variables/domain_id.rs
@@ -3,7 +3,6 @@ use enumset::EnumSet;
 use super::TransformableVariable;
 use crate::containers::StorageKey;
 use crate::engine::opaque_domain_event::OpaqueDomainEvent;
-use crate::engine::predicates::predicate::Predicate;
 use crate::engine::reason::ReasonRef;
 use crate::engine::variables::AffineView;
 use crate::engine::variables::IntegerVariable;
@@ -65,8 +64,8 @@ impl IntegerVariable for DomainId {
         assignment.is_value_in_domain_at_trail_position(*self, value, trail_position)
     }
 
-    fn describe_domain(&self, assignment: &Assignments) -> Vec<Predicate> {
-        assignment.get_domain_description(*self)
+    fn iterate_domain(&self, assignment: &Assignments) -> impl Iterator<Item = i32> {
+        assignment.get_domain_iterator(*self)
     }
 
     fn remove(

--- a/pumpkin-lib/src/engine/variables/integer_variable.rs
+++ b/pumpkin-lib/src/engine/variables/integer_variable.rs
@@ -2,7 +2,6 @@ use enumset::EnumSet;
 
 use super::TransformableVariable;
 use crate::engine::opaque_domain_event::OpaqueDomainEvent;
-use crate::engine::predicates::predicate::Predicate;
 use crate::engine::predicates::predicate_constructor::PredicateConstructor;
 use crate::engine::reason::ReasonRef;
 use crate::engine::Assignments;
@@ -43,13 +42,8 @@ pub trait IntegerVariable:
         trail_position: usize,
     ) -> bool;
 
-    /// Get a predicate description (bounds + holes) of the domain of this variable.
-    /// N.B. can be very expensive with large domains, and very large with holey domains
-    ///
-    /// This should not be used to explicitly check for holes in the domain, but only to build
-    /// explanations. If views change the observed domain, they will not change this description,
-    /// because it should be a description of the domain in the solver.
-    fn describe_domain(&self, assignment: &Assignments) -> Vec<Predicate>;
+    /// Iterate over the values of the domain.
+    fn iterate_domain(&self, assignment: &Assignments) -> impl Iterator<Item = i32>;
 
     /// Remove a value from the domain of this variable.
     fn remove(

--- a/pumpkin-lib/src/engine/variables/literal.rs
+++ b/pumpkin-lib/src/engine/variables/literal.rs
@@ -112,8 +112,11 @@ impl IntegerVariable for Literal {
         }
     }
 
-    fn describe_domain(&self, assignment: &Assignments) -> Vec<Predicate> {
-        assignment.get_domain_description(self.predicate.get_domain())
+    fn iterate_domain(&self, _assignment: &Assignments) -> impl Iterator<Item = i32> {
+        todo!("domain iterator for literals");
+
+        #[allow(unreachable_code)]
+        std::iter::empty()
     }
 
     fn remove(

--- a/pumpkin-lib/src/propagators/element.rs
+++ b/pumpkin-lib/src/propagators/element.rs
@@ -1,11 +1,7 @@
-use std::cell::OnceCell;
-use std::cmp::max;
-use std::cmp::min;
 use std::rc::Rc;
 
 use crate::basic_types::PropagationStatusCP;
 use crate::conjunction;
-use crate::engine::cp::propagation::ReadDomains;
 use crate::engine::domain_events::DomainEvents;
 use crate::engine::propagation::LocalId;
 use crate::engine::propagation::PropagationContext;
@@ -13,8 +9,12 @@ use crate::engine::propagation::PropagationContextMut;
 use crate::engine::propagation::Propagator;
 use crate::engine::propagation::PropagatorConstructor;
 use crate::engine::propagation::PropagatorConstructorContext;
+use crate::engine::propagation::ReadDomains;
+use crate::engine::reason::LazyReason;
 use crate::engine::variables::IntegerVariable;
 use crate::predicate;
+use crate::predicates::PredicateConstructor;
+use crate::predicates::PropositionalConjunction;
 
 pub(crate) struct ElementConstructor<VX, VI, VE> {
     pub(crate) array: Box<[VX]>,
@@ -34,35 +34,15 @@ pub(crate) struct ElementPropagator<VX, VI, VE> {
 
 const ID_INDEX: LocalId = LocalId::from(0);
 const ID_RHS: LocalId = LocalId::from(1);
+
 // local ids of array vars are shifted by ID_X_OFFSET
 const ID_X_OFFSET: u32 = 2;
 
-/// Iterator through the domain values of an IntegerVariable; keeps a reference to the context
-/// Use `for_domain_values!` if you want mutable access to the context while iterating
-fn iter_values<'c, Var: IntegerVariable>(
-    context: PropagationContext<'c>,
-    var: &'c Var,
-) -> impl Iterator<Item = i32> + 'c {
-    (context.lower_bound(var)..=context.upper_bound(var)).filter(move |i| context.contains(var, *i))
-}
-
-/// Helper to loop through the domain values of an IntegerVariable without keeping a reference to
-/// the context
-macro_rules! for_domain_values {
-    ($context:expr, $var:expr, |$val:ident| $body:expr) => {
-        for $val in ($context.lower_bound($var)..=$context.upper_bound($var)) {
-            if $context.contains($var, $val) {
-                $body
-            }
-        }
-    };
-}
-
-impl<
-        VX: IntegerVariable + 'static,
-        VI: IntegerVariable + 'static,
-        VE: IntegerVariable + 'static,
-    > PropagatorConstructor for ElementConstructor<VX, VI, VE>
+impl<VX, VI, VE> PropagatorConstructor for ElementConstructor<VX, VI, VE>
+where
+    VX: IntegerVariable + 'static,
+    VI: IntegerVariable + 'static,
+    VE: IntegerVariable + 'static,
 {
     type Propagator = ElementPropagator<VX, VI, VE>;
 
@@ -88,110 +68,13 @@ impl<
     }
 }
 
-impl<
-        VX: IntegerVariable + 'static,
-        VI: IntegerVariable + 'static,
-        VE: IntegerVariable + 'static,
-    > Propagator for ElementPropagator<VX, VI, VE>
+impl<VX, VI, VE> Propagator for ElementPropagator<VX, VI, VE>
+where
+    VX: IntegerVariable + 'static,
+    VI: IntegerVariable + 'static,
+    VE: IntegerVariable + 'static,
 {
-    fn propagate(&mut self, mut context: PropagationContextMut) -> PropagationStatusCP {
-        // Ensure index is non-negative
-        context.set_lower_bound(&self.index, 0, conjunction!())?;
-        // Ensure index <= no. of x_j
-        context.set_upper_bound(&self.index, self.array.len() as i32, conjunction!())?;
-
-        // For incremental solving: use the doubly linked list data-structure
-        if context.is_fixed(&self.index) {
-            // At this point, we should post x_i = e as a new constraint, but that's not an option
-            //  in Pumpkin right now. So instead we manually make them equal
-            let i = context.lower_bound(&self.index);
-            let x_i = &self.array[i as usize];
-
-            let lb = max(context.lower_bound(&self.rhs), context.lower_bound(x_i));
-            let ub = min(context.upper_bound(&self.rhs), context.upper_bound(x_i));
-
-            context.set_lower_bound(
-                &self.rhs,
-                lb,
-                conjunction!([self.index == i] & [x_i >= lb]),
-            )?;
-            context.set_lower_bound(x_i, lb, conjunction!([self.index == i] & [self.rhs >= lb]))?;
-            context.set_upper_bound(
-                &self.rhs,
-                ub,
-                conjunction!([self.index == i] & [x_i <= ub]),
-            )?;
-            context.set_upper_bound(x_i, ub, conjunction!([self.index == i] & [self.rhs <= ub]))?;
-
-            for v in lb..=ub {
-                if !context.contains(&self.rhs, v) && context.contains(x_i, v) {
-                    context.remove(x_i, v, conjunction!([self.index == i] & [self.rhs != v]))?;
-                } else if context.contains(&self.rhs, v) && !context.contains(x_i, v) {
-                    context.remove(
-                        &self.rhs,
-                        v,
-                        conjunction!([self.index == i] & [self.array[i as usize] != v]),
-                    )?;
-                }
-            }
-        } else {
-            // Remove values from i when for no values of e: x_i = e
-            let index_reason = OnceCell::new();
-            for_domain_values!(context, &self.index, |i| {
-                let x_i = &self.array[i as usize];
-                if !iter_values(context.as_readonly(), &self.rhs).any(|e| context.contains(x_i, e))
-                {
-                    // N.B. index_reason is loop-independent
-                    let reason_info = Rc::clone(index_reason.get_or_init(|| {
-                        Rc::new((
-                            context.describe_domain(&self.rhs),
-                            iter_values(context.as_readonly(), &self.rhs).collect::<Vec<_>>(),
-                        ))
-                    }));
-                    let x_i = (*x_i).clone();
-                    context.remove(&self.index, i, move |_context: &PropagationContext| {
-                        let mut reason = reason_info.0.clone();
-                        reason_info
-                            .1
-                            .iter()
-                            .for_each(|e| reason.push(predicate![x_i != *e]));
-                        reason.into()
-                    })?;
-                }
-            });
-
-            // Remove values from e when for no values of i: x_i = e
-            let rhs_reason = OnceCell::new();
-            for_domain_values!(context, &self.rhs, |e| {
-                if !iter_values(context.as_readonly(), &self.index)
-                    .map(|i| &self.array[i as usize])
-                    .any(|x_i| context.contains(x_i, e))
-                {
-                    // N.B. rhs_reason is loop-independent
-                    let reason_info = Rc::clone(rhs_reason.get_or_init(|| {
-                        Rc::new((
-                            context.describe_domain(&self.index),
-                            iter_values(context.as_readonly(), &self.index).collect::<Vec<_>>(),
-                        ))
-                    }));
-                    let array = Rc::clone(&self.array);
-                    context.remove(&self.rhs, e, move |_context: &PropagationContext| {
-                        let mut reason = reason_info.0.clone();
-                        reason_info
-                            .1
-                            .iter()
-                            .for_each(|i| reason.push(predicate![array[*i as usize] != e]));
-                        reason.into()
-                    })?;
-                }
-            });
-        }
-        Ok(())
-    }
-
     fn priority(&self) -> u32 {
-        // Priority higher than int_times/linear_eq/not_eq_propagator because it's much more
-        //  expensive looping over multiple domains
         2
     }
 
@@ -203,54 +86,158 @@ impl<
         &self,
         mut context: PropagationContextMut,
     ) -> PropagationStatusCP {
-        // Ensure index is non-negative
-        context.set_lower_bound(&self.index, 0, conjunction!())?;
-        // Ensure index <= no. of x_j
-        context.set_upper_bound(&self.index, self.array.len() as i32, conjunction!())?;
+        self.propagate_index_bounds_within_array(&mut context)?;
 
-        // Close to duplicate of `propagate` for now, without saving reason stuff...
+        self.propagate_rhs_bounds_based_on_array(&mut context)?;
+
+        self.propagate_index_based_on_domain_intersection_with_rhs(&mut context)?;
+
         if context.is_fixed(&self.index) {
-            let i = context.lower_bound(&self.index);
-            let x_i = &self.array[i as usize];
-
-            let lb = min(context.lower_bound(&self.rhs), context.lower_bound(x_i));
-            let ub = max(context.upper_bound(&self.rhs), context.upper_bound(x_i));
-
-            context.set_lower_bound(&self.rhs, lb, conjunction!())?;
-            context.set_lower_bound(x_i, lb, conjunction!())?;
-            context.set_upper_bound(&self.rhs, ub, conjunction!())?;
-            context.set_upper_bound(x_i, ub, conjunction!())?;
-
-            for_domain_values!(context, x_i, |e| {
-                if !context.contains(&self.rhs, e) {
-                    context.remove(x_i, e, conjunction!())?;
-                }
-            });
-            for_domain_values!(context, &self.rhs, |e| {
-                if !context.contains(x_i, e) {
-                    context.remove(&self.rhs, e, conjunction!())?;
-                }
-            });
-        } else {
-            // Remove values from i when for no values of e: x_i = e
-            for_domain_values!(context, &self.index, |i| {
-                let x_i = &self.array[i as usize];
-                if !iter_values(context.as_readonly(), &self.rhs).any(|e| context.contains(x_i, e))
-                {
-                    context.remove(&self.index, i, conjunction!())?;
-                }
-            });
-            // Remove values from e when for no values of i: x_i = e
-            for_domain_values!(context, &self.rhs, |e| {
-                if !iter_values(context.as_readonly(), &self.index)
-                    .map(|i| &self.array[i as usize])
-                    .any(|x_i| context.contains(x_i, e))
-                {
-                    context.remove(&self.rhs, e, conjunction!())?;
-                }
-            });
+            let idx = context.lower_bound(&self.index);
+            self.propagate_equality(&mut context, idx)?;
         }
+
         Ok(())
+    }
+}
+
+impl<VX, VI, VE> ElementPropagator<VX, VI, VE>
+where
+    VX: IntegerVariable + 'static,
+    VI: IntegerVariable + 'static,
+    VE: IntegerVariable + 'static,
+{
+    /// Propagate the bounds of `self.index` to be in the range `[0, self.array.len())`.
+    fn propagate_index_bounds_within_array(
+        &self,
+        context: &mut PropagationContextMut<'_>,
+    ) -> PropagationStatusCP {
+        context.set_lower_bound(&self.index, 0, conjunction!())?;
+        context.set_upper_bound(&self.index, self.array.len() as i32 - 1, conjunction!())?;
+        Ok(())
+    }
+
+    /// The lower bound (resp. upper bound) of the right-hand side can be the minimum lower
+    /// bound (res. maximum upper bound) of the elements.
+    fn propagate_rhs_bounds_based_on_array(
+        &self,
+        context: &mut PropagationContextMut<'_>,
+    ) -> PropagationStatusCP {
+        let (rhs_lb, rhs_ub) =
+            self.array
+                .iter()
+                .fold((i32::MAX, i32::MIN), |(rhs_lb, rhs_ub), element| {
+                    (
+                        i32::min(rhs_lb, context.lower_bound(element)),
+                        i32::max(rhs_ub, context.upper_bound(element)),
+                    )
+                });
+
+        context.set_lower_bound(
+            &self.rhs,
+            rhs_lb,
+            RightHandSideReason::new(Rc::clone(&self.array), Bound::Lower, rhs_lb),
+        )?;
+        context.set_upper_bound(
+            &self.rhs,
+            rhs_ub,
+            RightHandSideReason::new(Rc::clone(&self.array), Bound::Upper, rhs_ub),
+        )?;
+
+        Ok(())
+    }
+
+    /// Go through the array. For every element for which the domain does not intersect with the
+    /// right-hand side, remove it from index.
+    fn propagate_index_based_on_domain_intersection_with_rhs(
+        &self,
+        context: &mut PropagationContextMut<'_>,
+    ) -> PropagationStatusCP {
+        let rhs_lb = context.lower_bound(&self.rhs);
+        let rhs_ub = context.upper_bound(&self.rhs);
+        let mut to_remove = vec![];
+        for idx in context.iterate_domain(&self.index) {
+            let element = &self.array[idx as usize];
+
+            let element_ub = context.upper_bound(element);
+            let element_lb = context.lower_bound(element);
+
+            let reason = if rhs_lb > element_ub {
+                conjunction!([element <= rhs_lb - 1] & [self.rhs >= rhs_lb])
+            } else if rhs_ub < element_lb {
+                conjunction!([element >= rhs_ub + 1] & [self.rhs <= rhs_ub])
+            } else {
+                continue;
+            };
+
+            to_remove.push((idx, reason));
+        }
+
+        for (idx, reason) in to_remove.drain(..) {
+            context.remove(&self.index, idx, reason)?;
+        }
+
+        Ok(())
+    }
+
+    /// Propagate equality between lhs and rhs. This assumes the bounds of rhs have already been
+    /// tightened to the bounds of lhs, through a previous propagation rule.
+    fn propagate_equality(
+        &self,
+        context: &mut PropagationContextMut<'_>,
+        index: i32,
+    ) -> PropagationStatusCP {
+        let rhs_lb = context.lower_bound(&self.rhs);
+        let rhs_ub = context.upper_bound(&self.rhs);
+        let lhs = &self.array[index as usize];
+
+        context.set_lower_bound(
+            lhs,
+            rhs_lb,
+            conjunction!([self.rhs >= rhs_lb] & [self.index == index]),
+        )?;
+        context.set_upper_bound(
+            lhs,
+            rhs_ub,
+            conjunction!([self.rhs <= rhs_ub] & [self.index == index]),
+        )?;
+        Ok(())
+    }
+}
+
+enum Bound {
+    Lower,
+    Upper,
+}
+
+struct RightHandSideReason<Var> {
+    variables: Rc<[Var]>,
+    bound: Bound,
+    value: i32,
+}
+
+impl<Var> RightHandSideReason<Var> {
+    fn new(variables: Rc<[Var]>, bound: Bound, value: i32) -> Self {
+        Self {
+            variables,
+            bound,
+            value,
+        }
+    }
+}
+
+impl<Var> LazyReason for RightHandSideReason<Var>
+where
+    Var: PredicateConstructor<Value = i32>,
+{
+    fn compute(self: Box<Self>, _: &PropagationContext) -> PropositionalConjunction {
+        self.variables
+            .iter()
+            .map(|variable| match self.bound {
+                Bound::Lower => predicate![variable >= self.value],
+                Bound::Upper => predicate![variable <= self.value],
+            })
+            .collect()
     }
 }
 
@@ -259,96 +246,104 @@ mod tests {
     use super::*;
     use crate::conjunction;
     use crate::engine::test_solver::TestSolver;
+    use crate::predicate;
 
     #[test]
-    fn cocp_m4co_example() {
-        // source: https://user.it.uu.se/~pierref/courses/COCP/slides/T16-Propagators.pdf#Navigation24
+    fn elements_from_array_with_disjoint_domains_to_rhs_are_filtered_from_index() {
         let mut solver = TestSolver::default();
-        let x_0 = solver.new_variable(4, 4);
-        let x_1 = solver.new_variable(5, 5);
-        let x_2 = solver.new_variable(9, 9);
-        let x_3 = solver.new_variable(7, 7);
-        let index = solver.new_variable(1, 3);
-        let rhs = solver.new_variable(2, 8);
-        let array = vec![x_0, x_1, x_2, x_3].into_boxed_slice();
 
-        let mut propagator = solver
-            .new_propagator(ElementConstructor { array, index, rhs })
-            .expect("no empty domains");
-
-        solver.propagate(&mut propagator).expect("no empty domains");
-
-        assert_eq!(1, solver.lower_bound(index));
-        assert_eq!(3, solver.upper_bound(index));
-        assert!(!solver.contains(index, 2));
-        assert_eq!(5, solver.lower_bound(rhs));
-        assert_eq!(7, solver.upper_bound(rhs));
-        assert!(!solver.contains(rhs, 6));
-    }
-
-    #[test]
-    fn reason_test() {
-        let mut solver = TestSolver::default();
         let x_0 = solver.new_variable(4, 6);
-        let x_1 = solver.new_variable(7, 8);
+        let x_1 = solver.new_variable(2, 3);
         let x_2 = solver.new_variable(7, 9);
-        let x_3 = solver.new_variable(10, 11);
-        let index = solver.new_variable(1, 3);
+        let x_3 = solver.new_variable(14, 15);
+
+        let index = solver.new_variable(0, 3);
         let rhs = solver.new_variable(6, 9);
-        let array = vec![x_0, x_1, x_2, x_3].into_boxed_slice();
 
-        let mut propagator = solver
-            .new_propagator(ElementConstructor { array, index, rhs })
+        let _ = solver
+            .new_propagator(ElementConstructor {
+                array: vec![x_0, x_1, x_2, x_3].into(),
+                index,
+                rhs,
+            })
             .expect("no empty domains");
 
-        solver.propagate(&mut propagator).expect("no empty domains");
+        solver.assert_bounds(index, 0, 2);
 
-        let index_reason = solver.get_reason_int(predicate![index != 3]);
-        // reason for index removal 3 is that `x_3 != e`
         assert_eq!(
-            *index_reason,
-            conjunction!(
-                [rhs >= 6] & [rhs <= 9] & [x_3 != 6] & [x_3 != 7] & [x_3 != 8] & [x_3 != 9]
-            )
+            solver.get_reason_int(predicate![index != 3]),
+            &conjunction!([x_3 >= 10] & [rhs <= 9])
         );
 
-        let rhs_reason = solver.get_reason_int(predicate![rhs != 6]);
-        // reason for rhs removal 6 is that for all valid indices i `x_i != 6`
         assert_eq!(
-            *rhs_reason,
-            conjunction!([index >= 1] & [index <= 2] & [x_1 != 6] & [x_2 != 6])
+            solver.get_reason_int(predicate![index != 1]),
+            &conjunction!([x_1 <= 5] & [rhs >= 6])
         );
     }
 
     #[test]
-    fn reason_test_fixed_index() {
+    fn bounds_of_rhs_are_min_and_max_of_lower_and_upper_in_array() {
         let mut solver = TestSolver::default();
-        let x_0 = solver.new_variable(4, 6);
-        let x_1 = solver.new_variable(7, 10);
+
+        let x_0 = solver.new_variable(3, 10);
+        let x_1 = solver.new_variable(2, 3);
         let x_2 = solver.new_variable(7, 9);
-        let x_3 = solver.new_variable(10, 11);
+        let x_3 = solver.new_variable(14, 15);
+
+        let index = solver.new_variable(0, 3);
+        let rhs = solver.new_variable(0, 20);
+
+        let _ = solver
+            .new_propagator(ElementConstructor {
+                array: vec![x_0, x_1, x_2, x_3].into(),
+                index,
+                rhs,
+            })
+            .expect("no empty domains");
+
+        solver.assert_bounds(rhs, 2, 15);
+
+        assert_eq!(
+            solver.get_reason_int(predicate![rhs >= 2]),
+            &conjunction!([x_0 >= 2] & [x_1 >= 2] & [x_2 >= 2] & [x_3 >= 2])
+        );
+
+        assert_eq!(
+            solver.get_reason_int(predicate![rhs <= 15]),
+            &conjunction!([x_0 <= 15] & [x_1 <= 15] & [x_2 <= 15] & [x_3 <= 15])
+        );
+    }
+
+    #[test]
+    fn fixed_index_propagates_bounds_on_element() {
+        let mut solver = TestSolver::default();
+
+        let x_0 = solver.new_variable(3, 10);
+        let x_1 = solver.new_variable(0, 15);
+        let x_2 = solver.new_variable(7, 9);
+        let x_3 = solver.new_variable(14, 15);
+
         let index = solver.new_variable(1, 1);
         let rhs = solver.new_variable(6, 9);
-        solver.remove(rhs, 8).expect("no empty domains");
 
-        let array = vec![x_0, x_1, x_2, x_3].into_boxed_slice();
-
-        let mut propagator = solver
-            .new_propagator(ElementConstructor { array, index, rhs })
+        let _ = solver
+            .new_propagator(ElementConstructor {
+                array: vec![x_0, x_1, x_2, x_3].into(),
+                index,
+                rhs,
+            })
             .expect("no empty domains");
 
-        solver.propagate(&mut propagator).expect("no empty domains");
+        solver.assert_bounds(x_1, 6, 9);
 
-        let x1_ub_reason = solver.get_reason_int(predicate![x_1 <= 9]);
-        // reason for x_1 <= 9 is that `x_1 == e` and `e <= 9`
-        assert_eq!(*x1_ub_reason, conjunction!([index == 1] & [rhs <= 9]));
+        assert_eq!(
+            solver.get_reason_int(predicate![x_1 >= 6]),
+            &conjunction!([index == 1] & [rhs >= 6])
+        );
 
-        let x1_8_reason = solver.get_reason_int(predicate![x_1 != 8]);
-        // reason for x_1 removal 8 is that `x_1 == e` and `e != 8`
-        assert_eq!(*x1_8_reason, conjunction!([index == 1] & [rhs != 8]));
-
-        let rhs_reason = solver.get_reason_int(predicate![rhs >= 7]);
-        // reason for `rhs >= 7` is that `x_1 >= 7`
-        assert_eq!(*rhs_reason, conjunction!([index == 1] & [x_1 >= 7]));
+        assert_eq!(
+            solver.get_reason_int(predicate![x_1 <= 9]),
+            &conjunction!([index == 1] & [rhs <= 9])
+        );
     }
 }


### PR DESCRIPTION
The element propagator now makes use of lifted explanations, which are smaller than the ones we generated previously. For now we dropped domain consistency, however, in my experiments that does not show up as a detriment. We should consider adding it in again though.

Note: This is not into the master branch, but into the revamp branch.