### PR TITLE
Don't do complete search when combining branchers

### DIFF
--- a/pumpkin-cli/src/flatzinc/compiler/create_search_strategy.rs
+++ b/pumpkin-cli/src/flatzinc/compiler/create_search_strategy.rs
@@ -26,7 +26,7 @@ fn create_from_search_strategy(
     context: &mut CompilationContext,
     append_default_search: bool,
 ) -> Result<DynamicBrancher, FlatZincError> {
-    match strategy {
+    let mut brancher = match strategy {
         Search::Bool(SearchStrategy {
             variables,
             variable_selection_strategy,
@@ -46,25 +46,12 @@ fn create_from_search_strategy(
                     .collect::<Vec<_>>(),
                 other => panic!("Expected string or expression but got {other:?}"),
             };
-            let mut brancher = create_search_over_propositional_variables(
+
+            create_search_over_propositional_variables(
                 &search_variables,
                 variable_selection_strategy,
                 value_selection_strategy,
-            );
-
-            if append_default_search {
-                // MiniZinc specification specifies that we need to ensure that all variables are
-                // fixed; we ensure this by adding a brancher after the
-                // user-provided search which searches over the remainder of the
-                // variables
-                brancher.add_brancher(Box::new(
-                    context
-                        .solver
-                        .default_brancher_over_all_propositional_variables(),
-                ));
-            }
-
-            Ok(brancher)
+            )
         }
         Search::Int(SearchStrategy {
             variables,
@@ -79,62 +66,49 @@ fn create_from_search_strategy(
                 flatzinc::AnnExpr::Expr(expr) => context.resolve_integer_variable_array(expr)?,
                 other => panic!("Expected string or expression but got {other:?}"),
             };
-            let mut brancher = create_search_over_domains(
+            create_search_over_domains(
                 &search_variables,
                 variable_selection_strategy,
                 value_selection_strategy,
+            )
+        }
+        Search::Seq(search_strategies) => DynamicBrancher::new(
+            search_strategies
+                .iter()
+                .map(|strategy| {
+                    let downcast: Box<dyn Brancher> = Box::new(
+                        create_from_search_strategy(strategy, context, false)
+                            .expect("Expected nested sequential strategy to be able to be created"),
+                    );
+                    downcast
+                })
+                .collect::<Vec<_>>(),
+        ),
+
+        Search::Unspecified => {
+            assert!(
+                append_default_search,
+                "when no search is specified, we must add a default search"
             );
 
-            if append_default_search {
-                // MiniZinc specification specifies that we need to ensure that all variables are
-                // fixed; we ensure this by adding a brancher after the
-                // user-provided search which searches over the remainder of the
-                // variables
-                brancher.add_brancher(Box::new(
-                    context
-                        .solver
-                        .default_brancher_over_all_propositional_variables(),
-                ));
-            }
-
-            Ok(brancher)
+            // The default search will be added below, so we give an empty brancher here.
+            DynamicBrancher::new(vec![])
         }
-        Search::Seq(search_strategies) => {
-            // MiniZinc specification specifies that we need to ensure that all variables are fixed;
-            // we ensure this by adding a brancher after the user-provided search which searches
-            // over the remainder of the variables
-            let brancher_over_all_variables: Option<Box<dyn Brancher>> = if append_default_search {
-                Some(Box::new(
-                    context
-                        .solver
-                        .default_brancher_over_all_propositional_variables(),
-                ))
-            } else {
-                None
-            };
+    };
 
-            let brancher = DynamicBrancher::new(
-                search_strategies
-                    .iter()
-                    .map(|strategy| {
-                        let downcast: Box<dyn Brancher> = Box::new(
-                            create_from_search_strategy(strategy, context, false).expect(
-                                "Expected nested sequential strategy to be able to be created",
-                            ),
-                        );
-                        downcast
-                    })
-                    .chain(brancher_over_all_variables)
-                    .collect::<Vec<_>>(),
-            );
-            Ok(brancher)
-        }
-        Search::Unspecified => Ok(DynamicBrancher::new(vec![Box::new(
+    if append_default_search {
+        // MiniZinc specification specifies that we need to ensure that all variables are
+        // fixed; we ensure this by adding a brancher after the
+        // user-provided search which searches over the remainder of the
+        // variables
+        brancher.add_brancher(Box::new(
             context
                 .solver
                 .default_brancher_over_all_propositional_variables(),
-        )])),
+        ));
     }
+
+    Ok(brancher)
 }
 
 fn create_search_over_propositional_variables(

--- a/pumpkin-cli/tests/mzn_search/seq_search_1.expected
+++ b/pumpkin-cli/tests/mzn_search/seq_search_1.expected
@@ -1,0 +1,451 @@
+x = 6;
+y = 7;
+p = true;
+q = true;
+----------
+x = 6;
+y = 8;
+p = true;
+q = true;
+----------
+x = 6;
+y = 9;
+p = true;
+q = true;
+----------
+x = 6;
+y = 10;
+p = true;
+q = true;
+----------
+x = 7;
+y = 6;
+p = true;
+q = true;
+----------
+x = 7;
+y = 8;
+p = true;
+q = true;
+----------
+x = 7;
+y = 9;
+p = true;
+q = true;
+----------
+x = 7;
+y = 10;
+p = true;
+q = true;
+----------
+x = 8;
+y = 6;
+p = true;
+q = true;
+----------
+x = 8;
+y = 7;
+p = true;
+q = true;
+----------
+x = 8;
+y = 9;
+p = true;
+q = true;
+----------
+x = 8;
+y = 10;
+p = true;
+q = true;
+----------
+x = 9;
+y = 6;
+p = true;
+q = true;
+----------
+x = 9;
+y = 7;
+p = true;
+q = true;
+----------
+x = 9;
+y = 8;
+p = true;
+q = true;
+----------
+x = 9;
+y = 10;
+p = true;
+q = true;
+----------
+x = 10;
+y = 6;
+p = true;
+q = true;
+----------
+x = 10;
+y = 7;
+p = true;
+q = true;
+----------
+x = 10;
+y = 8;
+p = true;
+q = true;
+----------
+x = 10;
+y = 9;
+p = true;
+q = true;
+----------
+x = 6;
+y = 1;
+p = true;
+q = false;
+----------
+x = 6;
+y = 2;
+p = true;
+q = false;
+----------
+x = 6;
+y = 3;
+p = true;
+q = false;
+----------
+x = 6;
+y = 4;
+p = true;
+q = false;
+----------
+x = 6;
+y = 5;
+p = true;
+q = false;
+----------
+x = 7;
+y = 1;
+p = true;
+q = false;
+----------
+x = 7;
+y = 2;
+p = true;
+q = false;
+----------
+x = 7;
+y = 3;
+p = true;
+q = false;
+----------
+x = 7;
+y = 4;
+p = true;
+q = false;
+----------
+x = 7;
+y = 5;
+p = true;
+q = false;
+----------
+x = 8;
+y = 1;
+p = true;
+q = false;
+----------
+x = 8;
+y = 2;
+p = true;
+q = false;
+----------
+x = 8;
+y = 3;
+p = true;
+q = false;
+----------
+x = 8;
+y = 4;
+p = true;
+q = false;
+----------
+x = 8;
+y = 5;
+p = true;
+q = false;
+----------
+x = 9;
+y = 1;
+p = true;
+q = false;
+----------
+x = 9;
+y = 2;
+p = true;
+q = false;
+----------
+x = 9;
+y = 3;
+p = true;
+q = false;
+----------
+x = 9;
+y = 4;
+p = true;
+q = false;
+----------
+x = 9;
+y = 5;
+p = true;
+q = false;
+----------
+x = 10;
+y = 1;
+p = true;
+q = false;
+----------
+x = 10;
+y = 2;
+p = true;
+q = false;
+----------
+x = 10;
+y = 3;
+p = true;
+q = false;
+----------
+x = 10;
+y = 4;
+p = true;
+q = false;
+----------
+x = 10;
+y = 5;
+p = true;
+q = false;
+----------
+x = 1;
+y = 6;
+p = false;
+q = true;
+----------
+x = 1;
+y = 7;
+p = false;
+q = true;
+----------
+x = 1;
+y = 8;
+p = false;
+q = true;
+----------
+x = 1;
+y = 9;
+p = false;
+q = true;
+----------
+x = 1;
+y = 10;
+p = false;
+q = true;
+----------
+x = 2;
+y = 6;
+p = false;
+q = true;
+----------
+x = 2;
+y = 7;
+p = false;
+q = true;
+----------
+x = 2;
+y = 8;
+p = false;
+q = true;
+----------
+x = 2;
+y = 9;
+p = false;
+q = true;
+----------
+x = 2;
+y = 10;
+p = false;
+q = true;
+----------
+x = 3;
+y = 6;
+p = false;
+q = true;
+----------
+x = 3;
+y = 7;
+p = false;
+q = true;
+----------
+x = 3;
+y = 8;
+p = false;
+q = true;
+----------
+x = 3;
+y = 9;
+p = false;
+q = true;
+----------
+x = 3;
+y = 10;
+p = false;
+q = true;
+----------
+x = 4;
+y = 6;
+p = false;
+q = true;
+----------
+x = 4;
+y = 7;
+p = false;
+q = true;
+----------
+x = 4;
+y = 8;
+p = false;
+q = true;
+----------
+x = 4;
+y = 9;
+p = false;
+q = true;
+----------
+x = 4;
+y = 10;
+p = false;
+q = true;
+----------
+x = 5;
+y = 6;
+p = false;
+q = true;
+----------
+x = 5;
+y = 7;
+p = false;
+q = true;
+----------
+x = 5;
+y = 8;
+p = false;
+q = true;
+----------
+x = 5;
+y = 9;
+p = false;
+q = true;
+----------
+x = 5;
+y = 10;
+p = false;
+q = true;
+----------
+x = 1;
+y = 2;
+p = false;
+q = false;
+----------
+x = 1;
+y = 3;
+p = false;
+q = false;
+----------
+x = 1;
+y = 4;
+p = false;
+q = false;
+----------
+x = 1;
+y = 5;
+p = false;
+q = false;
+----------
+x = 2;
+y = 1;
+p = false;
+q = false;
+----------
+x = 2;
+y = 3;
+p = false;
+q = false;
+----------
+x = 2;
+y = 4;
+p = false;
+q = false;
+----------
+x = 2;
+y = 5;
+p = false;
+q = false;
+----------
+x = 3;
+y = 1;
+p = false;
+q = false;
+----------
+x = 3;
+y = 2;
+p = false;
+q = false;
+----------
+x = 3;
+y = 4;
+p = false;
+q = false;
+----------
+x = 3;
+y = 5;
+p = false;
+q = false;
+----------
+x = 4;
+y = 1;
+p = false;
+q = false;
+----------
+x = 4;
+y = 2;
+p = false;
+q = false;
+----------
+x = 4;
+y = 3;
+p = false;
+q = false;
+----------
+x = 4;
+y = 5;
+p = false;
+q = false;
+----------
+x = 5;
+y = 1;
+p = false;
+q = false;
+----------
+x = 5;
+y = 2;
+p = false;
+q = false;
+----------
+x = 5;
+y = 3;
+p = false;
+q = false;
+----------
+x = 5;
+y = 4;
+p = false;
+q = false;
+----------
+==========

--- a/pumpkin-cli/tests/mzn_search/seq_search_1.fzn
+++ b/pumpkin-cli/tests/mzn_search/seq_search_1.fzn
@@ -1,0 +1,10 @@
+var 1..10: x :: output_var;
+var 1..10: y :: output_var;
+var bool: p :: output_var;
+var bool: q :: output_var;
+
+constraint int_lin_ne([1,-1],[x,y],0);
+constraint int_le_reif(6,x,p):: defines_var(p);
+constraint int_le_reif(6,y,q):: defines_var(q);
+
+solve :: seq_search([bool_search([p,q],input_order,indomain_max,complete),int_search([x,y],input_order,indomain_min,complete)]) satisfy;

--- a/pumpkin-cli/tests/mzn_search_test.rs
+++ b/pumpkin-cli/tests/mzn_search_test.rs
@@ -24,5 +24,6 @@ macro_rules! mzn_search_unordered {
 
 mzn_search_ordered!(bool_search_provided_directly);
 mzn_search_ordered!(search_over_ints_no_propagators);
+mzn_search_ordered!(seq_search_1);
 mzn_search_unordered!(search_with_constants_in_search);
 mzn_search_unordered!(search_annotation_does_not_fix_all_variables);


### PR DESCRIPTION
When constructed a sequenced brancher, the individual branchers should not have the default brancher appended to them. This bug was triggered in the `seq_search_1.fzn` search test.