### PR TITLE
(Mini PR) Fixing unnecessary rebuilding

### DIFF
--- a/pumpkin-cli/build.rs
+++ b/pumpkin-cli/build.rs
@@ -20,9 +20,9 @@ fn run() -> Result<(), Box<dyn Error>> {
         "maxsat-checker",
     )?;
 
-    println!("cargo:rerun-if-changed=tests/**/*.c");
-    println!("cargo:rerun-if-changed=tests/**/*.h");
-    println!("cargo:rerun-if-changed=tests/**/*.cc");
+    println!("cargo:rerun-if-changed=tests/cnf/checkers/");
+    println!("cargo:rerun-if-changed=tests/wcnf/checkers/");
+
     println!("cargo:rerun-if-changed=build.rs");
 
     Ok(())


### PR DESCRIPTION
**The issue:**
Currently, the project is rebuilt even when nothing has changed; to reproduce on the current `main` branch run:
`cargo build --release`
Followed by:
`CARGO_LOG=cargo::core::compiler::fingerprint=info cargo build --release`
Even if there are no changes, the `build.rs` script will rerun because of the following output `stale: missing "<LOCAL_PATH>/Pumpkin/pumpkin-cli/tests/**/*.c"`.

I think this is because `rerun-if-changed` does not handle wildcards/regexes; however, we can point it to a directory. This PR thus changes the wildcards to the directories which contain all the files matched by the previous wildcards.
