### PR TITLE
Add tagging of constraints and propagators

### DIFF
--- a/pumpkin-cli/src/flatzinc/compiler/post_constraints.rs
+++ b/pumpkin-cli/src/flatzinc/compiler/post_constraints.rs
@@ -243,7 +243,7 @@ fn compile_cumulative(
         resource_capacity,
         options.cumulative_allow_holes,
     )
-    .post(context.solver);
+    .post(context.solver, None);
     Ok(post_result.is_ok())
 }
 
@@ -257,7 +257,7 @@ fn compile_array_int_maximum(
     let array = context.resolve_integer_variable_array(&exprs[1])?;
 
     Ok(constraints::maximum(array.as_ref(), rhs)
-        .post(context.solver)
+        .post(context.solver, None)
         .is_ok())
 }
 
@@ -271,7 +271,7 @@ fn compile_array_int_minimum(
     let array = context.resolve_integer_variable_array(&exprs[1])?;
 
     Ok(constraints::minimum(array.iter().copied(), rhs)
-        .post(context.solver)
+        .post(context.solver, None)
         .is_ok())
 }
 
@@ -336,7 +336,7 @@ fn compile_set_in_reif(
                 .collect::<Vec<_>>();
 
             constraints::clause(clause)
-                .reify(context.solver, reif)
+                .reify(context.solver, reif, None)
                 .is_ok()
         }
     };
@@ -355,7 +355,7 @@ fn compile_array_var_int_element(
     let rhs = context.resolve_integer_variable(&exprs[2])?;
 
     Ok(constraints::element(index, array.as_ref(), rhs)
-        .post(context.solver)
+        .post(context.solver, None)
         .is_ok())
 }
 
@@ -480,7 +480,7 @@ fn compile_bool_or(
     let r = context.resolve_bool_variable(&exprs[1])?;
 
     Ok(constraints::clause(clause.as_ref())
-        .reify(context.solver, r)
+        .reify(context.solver, r, None)
         .is_ok())
 }
 
@@ -561,7 +561,7 @@ fn compile_array_bool_and(
     let r = context.resolve_bool_variable(&exprs[1])?;
 
     Ok(constraints::conjunction(conjunction.as_ref())
-        .reify(context.solver, r)
+        .reify(context.solver, r, None)
         .is_ok())
 }
 
@@ -579,7 +579,7 @@ fn compile_ternary_int_predicate<C: Constraint>(
     let c = context.resolve_integer_variable(&exprs[2])?;
 
     let constraint = create_constraint(a, b, c);
-    Ok(constraint.post(context.solver).is_ok())
+    Ok(constraint.post(context.solver, None).is_ok())
 }
 
 fn compile_binary_int_predicate<C: Constraint>(
@@ -595,7 +595,7 @@ fn compile_binary_int_predicate<C: Constraint>(
     let b = context.resolve_integer_variable(&exprs[1])?;
 
     let constraint = create_constraint(a, b);
-    Ok(constraint.post(context.solver).is_ok())
+    Ok(constraint.post(context.solver, None).is_ok())
 }
 
 fn compile_reified_binary_int_predicate<C: NegatableConstraint>(
@@ -612,7 +612,7 @@ fn compile_reified_binary_int_predicate<C: NegatableConstraint>(
     let reif = context.resolve_bool_variable(&exprs[2])?;
 
     let constraint = create_constraint(a, b);
-    Ok(constraint.reify(context.solver, reif).is_ok())
+    Ok(constraint.reify(context.solver, reif, None).is_ok())
 }
 
 fn weighted_vars(weights: Rc<[i32]>, vars: Rc<[DomainId]>) -> Box<[AffineView<DomainId>]> {
@@ -638,7 +638,7 @@ fn compile_int_lin_predicate<C: Constraint>(
     let terms = weighted_vars(weights, vars);
 
     let constraint = create_constraint(terms, rhs);
-    Ok(constraint.post(context.solver).is_ok())
+    Ok(constraint.post(context.solver, None).is_ok())
 }
 
 fn compile_reified_int_lin_predicate<C: NegatableConstraint>(
@@ -658,7 +658,7 @@ fn compile_reified_int_lin_predicate<C: NegatableConstraint>(
     let terms = weighted_vars(weights, vars);
 
     let constraint = create_constraint(terms, rhs);
-    Ok(constraint.reify(context.solver, reif).is_ok())
+    Ok(constraint.reify(context.solver, reif, None).is_ok())
 }
 
 fn compile_bool_lin_eq_predicate(
@@ -673,7 +673,7 @@ fn compile_bool_lin_eq_predicate(
 
     Ok(
         constraints::boolean_equals(weights.as_ref(), bools.as_ref(), rhs)
-            .post(context.solver)
+            .post(context.solver, None)
             .is_ok(),
     )
 }
@@ -690,7 +690,7 @@ fn compile_bool_lin_le_predicate(
 
     Ok(
         constraints::boolean_less_than_or_equals(weights.as_ref(), bools.as_ref(), rhs)
-            .post(context.solver)
+            .post(context.solver, None)
             .is_ok(),
     )
 }
@@ -704,6 +704,6 @@ fn compile_all_different(
 
     let variables = context.resolve_integer_variable_array(&exprs[0])?.to_vec();
     Ok(constraints::all_different(variables)
-        .post(context.solver)
+        .post(context.solver, None)
         .is_ok())
 }

--- a/pumpkin-lib/examples/disjunctive_scheduling.rs
+++ b/pumpkin-lib/examples/disjunctive_scheduling.rs
@@ -58,12 +58,12 @@ fn main() {
             // literal => s_y - s_x <= -p_y)
             let _ =
                 constraints::less_than_or_equals(variables.clone(), -(processing_times[y] as i32))
-                    .implied_by(&mut solver, literal);
+                    .implied_by(&mut solver, literal, None);
 
             //-literal => -s_y + s_x <= p_y)
             let variables = vec![start_variables[y].scaled(-1), start_variables[x].scaled(1)];
             let _ = constraints::less_than_or_equals(variables.clone(), processing_times[y] as i32)
-                .implied_by(&mut solver, literal);
+                .implied_by(&mut solver, literal, None);
 
             // Either x starts before y or y start before x
             let _ = solver.add_clause([literal, precedence_literals[y][x]]);

--- a/pumpkin-lib/src/api/solver.rs
+++ b/pumpkin-lib/src/api/solver.rs
@@ -650,6 +650,17 @@ impl Solver {
         self.satisfaction_solver.add_clause(clause)
     }
 
+    /// Adds a propagator with a tag, which is used to identify inferences made by this propagator
+    /// in the proof log.
+    pub(crate) fn add_tagged_propagator(
+        &mut self,
+        propagator: impl Propagator + 'static,
+        tag: NonZero<u32>,
+    ) -> Result<(), ConstraintOperationError> {
+        self.satisfaction_solver
+            .add_propagator(propagator, Some(tag))
+    }
+
     /// Post a new propagator to the solver. If unsatisfiability can be immediately determined
     /// through propagation, this will return a [`ConstraintOperationError`]. A tag can be
     /// provided which will be used to identify what constraint caused an inference in the proof
@@ -665,9 +676,8 @@ impl Solver {
     pub(crate) fn add_propagator(
         &mut self,
         propagator: impl Propagator + 'static,
-        tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
-        self.satisfaction_solver.add_propagator(propagator, tag)
+        self.satisfaction_solver.add_propagator(propagator, None)
     }
 }
 

--- a/pumpkin-lib/src/api/solver.rs
+++ b/pumpkin-lib/src/api/solver.rs
@@ -1,3 +1,5 @@
+use std::num::NonZero;
+
 use super::results::OptimisationResult;
 use super::results::SatisfactionResult;
 use super::results::SatisfactionResultUnderAssumptions;
@@ -649,7 +651,9 @@ impl Solver {
     }
 
     /// Post a new propagator to the solver. If unsatisfiability can be immediately determined
-    /// through propagation, this will return a [`ConstraintOperationError`].
+    /// through propagation, this will return a [`ConstraintOperationError`]. A tag can be
+    /// provided which will be used to identify what constraint caused an inference in the proof
+    /// log.
     ///
     /// The caller should ensure the solver is in the root state before calling this, either
     /// because no call to [`Self::solve()`] has been made, or because
@@ -661,8 +665,9 @@ impl Solver {
     pub(crate) fn add_propagator(
         &mut self,
         propagator: impl Propagator + 'static,
+        tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
-        self.satisfaction_solver.add_propagator(propagator)
+        self.satisfaction_solver.add_propagator(propagator, tag)
     }
 }
 

--- a/pumpkin-lib/src/api/solver.rs
+++ b/pumpkin-lib/src/api/solver.rs
@@ -662,9 +662,7 @@ impl Solver {
     }
 
     /// Post a new propagator to the solver. If unsatisfiability can be immediately determined
-    /// through propagation, this will return a [`ConstraintOperationError`]. A tag can be
-    /// provided which will be used to identify what constraint caused an inference in the proof
-    /// log.
+    /// through propagation, this will return a [`ConstraintOperationError`].
     ///
     /// The caller should ensure the solver is in the root state before calling this, either
     /// because no call to [`Self::solve()`] has been made, or because

--- a/pumpkin-lib/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-lib/src/constraints/arithmetic/equality.rs
@@ -1,3 +1,5 @@
+use std::num::NonZero;
+
 use super::less_than_or_equals;
 use crate::constraints::Constraint;
 use crate::constraints::NegatableConstraint;
@@ -59,15 +61,19 @@ impl<Var> Constraint for EqualConstraint<Var>
 where
     Var: IntegerVariable + Clone + 'static,
 {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
-        less_than_or_equals(self.terms.clone(), self.rhs).post(solver)?;
+    fn post(
+        self,
+        solver: &mut Solver,
+        tag: Option<NonZero<u32>>,
+    ) -> Result<(), ConstraintOperationError> {
+        less_than_or_equals(self.terms.clone(), self.rhs).post(solver, tag)?;
 
         let negated = self
             .terms
             .iter()
             .map(|var| var.scaled(-1))
             .collect::<Box<[_]>>();
-        less_than_or_equals(negated, -self.rhs).post(solver)?;
+        less_than_or_equals(negated, -self.rhs).post(solver, tag)?;
 
         Ok(())
     }
@@ -76,16 +82,20 @@ where
         self,
         solver: &mut Solver,
         reification_literal: Literal,
+        tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
-        less_than_or_equals(self.terms.clone(), self.rhs)
-            .implied_by(solver, reification_literal)?;
+        less_than_or_equals(self.terms.clone(), self.rhs).implied_by(
+            solver,
+            reification_literal,
+            tag,
+        )?;
 
         let negated = self
             .terms
             .iter()
             .map(|var| var.scaled(-1))
             .collect::<Box<[_]>>();
-        less_than_or_equals(negated, -self.rhs).implied_by(solver, reification_literal)?;
+        less_than_or_equals(negated, -self.rhs).implied_by(solver, reification_literal, tag)?;
 
         Ok(())
     }
@@ -114,16 +124,25 @@ impl<Var> Constraint for NotEqualConstraint<Var>
 where
     Var: IntegerVariable + Clone + 'static,
 {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
-        LinearNotEqualPropagator::new(self.terms, self.rhs).post(solver)
+    fn post(
+        self,
+        solver: &mut Solver,
+        tag: Option<NonZero<u32>>,
+    ) -> Result<(), ConstraintOperationError> {
+        LinearNotEqualPropagator::new(self.terms, self.rhs).post(solver, tag)
     }
 
     fn implied_by(
         self,
         solver: &mut Solver,
         reification_literal: Literal,
+        tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
-        LinearNotEqualPropagator::new(self.terms, self.rhs).implied_by(solver, reification_literal)
+        LinearNotEqualPropagator::new(self.terms, self.rhs).implied_by(
+            solver,
+            reification_literal,
+            tag,
+        )
     }
 }
 

--- a/pumpkin-lib/src/constraints/arithmetic/inequality.rs
+++ b/pumpkin-lib/src/constraints/arithmetic/inequality.rs
@@ -1,3 +1,5 @@
+use std::num::NonZero;
+
 use crate::constraints::Constraint;
 use crate::constraints::NegatableConstraint;
 use crate::propagators::linear_less_or_equal::LinearLessOrEqualPropagator;
@@ -44,17 +46,25 @@ struct Inequality<Var> {
 }
 
 impl<Var: IntegerVariable + 'static> Constraint for Inequality<Var> {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
-        LinearLessOrEqualPropagator::new(self.terms, self.rhs).post(solver)
+    fn post(
+        self,
+        solver: &mut Solver,
+        tag: Option<NonZero<u32>>,
+    ) -> Result<(), ConstraintOperationError> {
+        LinearLessOrEqualPropagator::new(self.terms, self.rhs).post(solver, tag)
     }
 
     fn implied_by(
         self,
         solver: &mut Solver,
         reification_literal: crate::variables::Literal,
+        tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
-        LinearLessOrEqualPropagator::new(self.terms, self.rhs)
-            .implied_by(solver, reification_literal)
+        LinearLessOrEqualPropagator::new(self.terms, self.rhs).implied_by(
+            solver,
+            reification_literal,
+            tag,
+        )
     }
 }
 

--- a/pumpkin-lib/src/constraints/boolean.rs
+++ b/pumpkin-lib/src/constraints/boolean.rs
@@ -1,3 +1,5 @@
+use std::num::NonZero;
+
 use super::equals;
 use super::less_than_or_equals;
 use super::Constraint;
@@ -42,20 +44,25 @@ struct BooleanLessThanOrEqual {
 }
 
 impl Constraint for BooleanLessThanOrEqual {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(
+        self,
+        solver: &mut Solver,
+        tag: Option<NonZero<u32>>,
+    ) -> Result<(), ConstraintOperationError> {
         let domains = self.create_domains(solver);
 
-        less_than_or_equals(domains, self.rhs).post(solver)
+        less_than_or_equals(domains, self.rhs).post(solver, tag)
     }
 
     fn implied_by(
         self,
         solver: &mut Solver,
         reification_literal: Literal,
+        tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
         let domains = self.create_domains(solver);
 
-        less_than_or_equals(domains, self.rhs).implied_by(solver, reification_literal)
+        less_than_or_equals(domains, self.rhs).implied_by(solver, reification_literal, tag)
     }
 }
 
@@ -91,20 +98,25 @@ struct BooleanEqual {
 }
 
 impl Constraint for BooleanEqual {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(
+        self,
+        solver: &mut Solver,
+        tag: Option<NonZero<u32>>,
+    ) -> Result<(), ConstraintOperationError> {
         let domains = self.create_domains(solver);
 
-        equals(domains, 0).post(solver)
+        equals(domains, 0).post(solver, tag)
     }
 
     fn implied_by(
         self,
         solver: &mut Solver,
         reification_literal: Literal,
+        tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
         let domains = self.create_domains(solver);
 
-        equals(domains, 0).implied_by(solver, reification_literal)
+        equals(domains, 0).implied_by(solver, reification_literal, tag)
     }
 }
 

--- a/pumpkin-lib/src/constraints/clause.rs
+++ b/pumpkin-lib/src/constraints/clause.rs
@@ -1,3 +1,5 @@
+use std::num::NonZero;
+
 use super::Constraint;
 use super::NegatableConstraint;
 use crate::variables::Literal;
@@ -21,7 +23,13 @@ pub fn conjunction(literals: impl Into<Vec<Literal>>) -> impl NegatableConstrain
 struct Clause(Vec<Literal>);
 
 impl Constraint for Clause {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(
+        self,
+        solver: &mut Solver,
+        tag: Option<NonZero<u32>>,
+    ) -> Result<(), ConstraintOperationError> {
+        assert!(tag.is_none(), "tagging clauses is not implemented");
+
         solver.add_clause(self.0)
     }
 
@@ -29,7 +37,10 @@ impl Constraint for Clause {
         self,
         solver: &mut Solver,
         reification_literal: Literal,
+        tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
+        assert!(tag.is_none(), "tagging clauses is not implemented");
+
         solver.add_clause(
             self.0
                 .into_iter()
@@ -49,7 +60,13 @@ impl NegatableConstraint for Clause {
 struct Conjunction(Vec<Literal>);
 
 impl Constraint for Conjunction {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(
+        self,
+        solver: &mut Solver,
+        tag: Option<NonZero<u32>>,
+    ) -> Result<(), ConstraintOperationError> {
+        assert!(tag.is_none(), "tagging clauses is not implemented");
+
         self.0
             .into_iter()
             .try_for_each(|lit| solver.add_clause([lit]))
@@ -59,7 +76,10 @@ impl Constraint for Conjunction {
         self,
         solver: &mut Solver,
         reification_literal: Literal,
+        tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
+        assert!(tag.is_none(), "tagging clauses is not implemented");
+
         self.0
             .into_iter()
             .try_for_each(|lit| solver.add_clause([!reification_literal, lit]))

--- a/pumpkin-lib/src/constraints/mod.rs
+++ b/pumpkin-lib/src/constraints/mod.rs
@@ -84,7 +84,11 @@ where
         solver: &mut Solver,
         tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
-        solver.add_propagator(self, tag)
+        if let Some(tag) = tag {
+            solver.add_tagged_propagator(self, tag)
+        } else {
+            solver.add_propagator(self)
+        }
     }
 
     fn implied_by(
@@ -93,7 +97,11 @@ where
         reification_literal: Literal,
         tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
-        solver.add_propagator(ReifiedPropagator::new(self, reification_literal), tag)
+        if let Some(tag) = tag {
+            solver.add_tagged_propagator(ReifiedPropagator::new(self, reification_literal), tag)
+        } else {
+            solver.add_propagator(ReifiedPropagator::new(self, reification_literal))
+        }
     }
 }
 

--- a/pumpkin-lib/src/constraints/mod.rs
+++ b/pumpkin-lib/src/constraints/mod.rs
@@ -56,6 +56,9 @@ pub trait Constraint {
     ///
     /// This method returns a [`ConstraintOperationError`] if the addition of the [`Constraint`] led
     /// to a root-level conflict.
+    ///
+    /// The `tag` allows inferences to be traced to the constraint that implies them. They will
+    /// show up in the proof log.
     fn post(
         self,
         solver: &mut Solver,
@@ -67,6 +70,9 @@ pub trait Constraint {
     ///
     /// This method returns a [`ConstraintOperationError`] if the addition of the [`Constraint`] led
     /// to a root-level conflict.
+    ///
+    /// The `tag` allows inferences to be traced to the constraint that implies them. They will
+    /// show up in the proof log.
     fn implied_by(
         self,
         solver: &mut Solver,
@@ -141,6 +147,9 @@ pub trait NegatableConstraint: Constraint {
     ///
     /// This method returns a [`ConstraintOperationError`] if the addition of the [`Constraint`] led
     /// to a root-level conflict.
+    ///
+    /// The `tag` allows inferences to be traced to the constraint that implies them. They will
+    /// show up in the proof log.
     fn reify(
         self,
         solver: &mut Solver,

--- a/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
@@ -5,6 +5,7 @@ use std::cmp::min;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::marker::PhantomData;
+use std::num::NonZero;
 use std::time::Instant;
 
 use log::warn;
@@ -1451,6 +1452,7 @@ impl ConstraintSatisfactionSolver {
     pub fn add_propagator(
         &mut self,
         propagator_to_add: impl Propagator + 'static,
+        _tag: Option<NonZero<u32>>,
     ) -> Result<(), ConstraintOperationError> {
         if self.state.is_inconsistent() {
             return Err(ConstraintOperationError::InfeasiblePropagator);
@@ -1960,7 +1962,7 @@ mod tests {
             vec![conjunction!([other_variable == 3] & [variable == 1])],
         );
 
-        let result = solver.add_propagator(propagator_constructor);
+        let result = solver.add_propagator(propagator_constructor, None);
         assert!(result.is_ok());
 
         // We add the clause that will lead to the conflict in the SAT-solver


### PR DESCRIPTION
In the proof log we want to identify which constraint implies any inference. To do so, we add an option to tag propagators with a `NonZero<u32>`. This PR does not actually implement this functionality, it just changes the API so that the tag can be passed through.