### PR TITLE
Re-introducing checking of Reason

### DIFF
--- a/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
@@ -17,7 +17,6 @@ use super::conflict_analysis::AnalysisStep;
 use super::conflict_analysis::ConflictAnalysisResult;
 use super::conflict_analysis::ResolutionConflictAnalyser;
 use super::propagation::store::PropagatorStore;
-use super::propagation::PropagatorId;
 use super::termination::TerminationCondition;
 use super::variables::IntegerVariable;
 use crate::basic_types::moving_averages::CumulativeMovingAverage;
@@ -1411,7 +1410,15 @@ impl ConstraintSatisfactionSolver {
             }
         };
         pumpkin_assert_extreme!(
-            self.debug_check_propagations(num_trail_entries_before, propagator_id),
+            DebugHelper::debug_check_propagations(
+                num_trail_entries_before,
+                propagator_id,
+                &self.assignments_integer,
+                &self.assignments_propositional,
+                &mut self.reason_store,
+                &self.variable_literal_mappings,
+                &self.cp_propagators
+            ),
             "Checking the propagations performed by the propagator led to inconsistencies!"
         );
         result
@@ -1430,44 +1437,6 @@ impl ConstraintSatisfactionSolver {
             // one
             Some(self.assumptions[self.assignments_propositional.get_decision_level() - 1])
         }
-    }
-
-    /// Checks whether the propagations of the propagator since `num_trail_entries_before` are
-    /// reproducible by performing 2 checks:
-    /// 1. Setting the reason for a propagation should lead to the same propagation when debug
-    ///    propagating from scratch
-    /// 2. Setting the reason for a propagation and the negation of that propagation should lead to
-    ///    failure
-    fn debug_check_propagations(
-        &mut self,
-        num_trail_entries_before: usize,
-        propagator_id: PropagatorId,
-    ) -> bool {
-        let mut result = true;
-        for trail_index in num_trail_entries_before..self.assignments_integer.num_trail_entries() {
-            let trail_entry = self.assignments_integer.get_trail_entry(trail_index);
-
-            let context =
-                PropagationContext::new(&self.assignments_integer, &self.assignments_propositional);
-
-            let reason = self.reason_store.get_or_compute(
-                trail_entry
-                    .reason
-                    .expect("Expected checked propagation to have a reason"),
-                &context,
-            );
-
-            result &= DebugHelper::debug_propagator_reason(
-                trail_entry.predicate.into(),
-                reason.expect("Expected reason to exist"),
-                &self.assignments_integer,
-                &self.assignments_propositional,
-                &self.variable_literal_mappings,
-                &self.cp_propagators[propagator_id],
-                propagator_id,
-            );
-        }
-        result
     }
 }
 

--- a/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
@@ -1870,69 +1870,6 @@ mod tests {
         (solver, vec![lit1, lit2])
     }
 
-    /// Warning: This test is potentially flaky due to its dependence on the propagation order of
-    /// the clausal propagator, please treat with caution.
-    // TODO: test does not work with the new checking of propagations
-    // #[test]
-    // fn test_synchronisation_view() {
-    //     let mut solver = ConstraintSatisfactionSolver::default();
-    //     let variable = solver.create_new_integer_variable(1, 5, None);
-    //     let other_variable = solver.create_new_integer_variable(3, 5, None);
-
-    //     // We create a test solver which propagates such that there is a jump across a hole in
-    // the     // domain and then we report a conflict based on the assigned values.
-    //     let propagator_constructor = TestPropagator::new(
-    //         vec![
-    //             (predicate!(variable != 2), conjunction!()),
-    //             (predicate!(variable <= 3), conjunction!()),
-    //             (predicate!(variable != 3), conjunction!()),
-    //             (predicate!(other_variable != 4), conjunction!()),
-    //             (predicate!(other_variable <= 4), conjunction!()),
-    //         ],
-    //         vec![conjunction!([other_variable == 3] & [variable == 1])],
-    //     );
-
-    //     let result = solver.add_propagator(propagator_constructor, None);
-    //     assert!(result.is_ok());
-
-    //     // We add the clause that will lead to the conflict in the SAT-solver
-    //     let result = solver.add_clause([
-    //         solver.get_literal(predicate![variable == 2]),
-    //         solver.get_literal(predicate![variable == 3]),
-    //         solver.get_literal(predicate![variable == 4]),
-    //         solver.get_literal(predicate![variable == 5]),
-    //     ]);
-    //     assert!(result.is_ok());
-
-    //     solver.declare_new_decision_level();
-
-    //     // We manually enqueue the propagator to mimic solver behaviour
-    //     solver
-    //         .propagator_queue
-    //         .enqueue_propagator(PropagatorId(0), 0);
-
-    //     // After propagating we expect that both the CP propagators and the SAT solver have found
-    // a     // conflict, however, the CP conflict explanation contains variables which are not
-    // assigned     // in the SAT view due to it finding a conflict. We expect the conflict info
-    // in the solver     // to contain the conflict found by the clausal propagator.
-    //     solver.propagate_enqueued();
-
-    //     assert!(solver.state.is_inconsistent());
-    //     assert_eq!(solver.get_assigned_integer_value(&variable), Some(1));
-
-    //     // We check whether the conflict which is returned is the conflict found by the
-    // SAT-solver     // rather than the one found by the CP solver.
-    //     assert!(matches!(
-    //         solver.state.internal_state,
-    //         CSPSolverStateInternal::Conflict {
-    //             conflict_info: StoredConflictInfo::Propagation {
-    //                 reference: _,
-    //                 literal: _,
-    //             },
-    //         }
-    //     ));
-    // }
-
     #[test]
     fn core_extraction_unit_core() {
         let mut solver = ConstraintSatisfactionSolver::default();

--- a/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
@@ -1403,7 +1403,7 @@ impl ConstraintSatisfactionSolver {
             propagator_id,
         );
 
-        match propagator.propagate(context) {
+        let result = match propagator.propagate(context) {
             // An empty domain conflict will be caught by the clausal propagator.
             Err(Inconsistency::EmptyDomain) => PropagationStatusOneStepCP::PropagationHappened,
 
@@ -1428,13 +1428,14 @@ impl ConstraintSatisfactionSolver {
             Ok(()) => {
                 let _ = self.process_domain_events();
 
-                pumpkin_assert_extreme!(
-                    self.debug_check_propagations(num_trail_entries_before, propagator_id)
-                );
-
                 PropagationStatusOneStepCP::PropagationHappened
             }
-        }
+        };
+        pumpkin_assert_extreme!(
+            self.debug_check_propagations(num_trail_entries_before, propagator_id),
+            "Checking the propagations performed by the propagator led to inconsistencies!"
+        );
+        result
     }
 
     fn are_all_assumptions_assigned(&self) -> bool {

--- a/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
@@ -1443,37 +1443,31 @@ impl ConstraintSatisfactionSolver {
         num_trail_entries_before: usize,
         propagator_id: PropagatorId,
     ) -> bool {
-        {
-            let mut result = true;
-            for trail_index in
-                num_trail_entries_before..self.assignments_integer.num_trail_entries()
-            {
-                let trail_entry = self.assignments_integer.get_trail_entry(trail_index);
+        let mut result = true;
+        for trail_index in num_trail_entries_before..self.assignments_integer.num_trail_entries() {
+            let trail_entry = self.assignments_integer.get_trail_entry(trail_index);
 
-                let context = PropagationContext::new(
-                    &self.assignments_integer,
-                    &self.assignments_propositional,
-                );
+            let context =
+                PropagationContext::new(&self.assignments_integer, &self.assignments_propositional);
 
-                let reason = self.reason_store.get_or_compute(
-                    trail_entry
-                        .reason
-                        .expect("Expected checked propagation to have a reason"),
-                    &context,
-                );
+            let reason = self.reason_store.get_or_compute(
+                trail_entry
+                    .reason
+                    .expect("Expected checked propagation to have a reason"),
+                &context,
+            );
 
-                result &= DebugHelper::debug_propagator_reason(
-                    trail_entry.predicate.into(),
-                    reason.expect("Expected reason to exist"),
-                    &self.assignments_integer,
-                    &self.assignments_propositional,
-                    &self.variable_literal_mappings,
-                    &self.cp_propagators[propagator_id],
-                    propagator_id,
-                );
-            }
-            result
+            result &= DebugHelper::debug_propagator_reason(
+                trail_entry.predicate.into(),
+                reason.expect("Expected reason to exist"),
+                &self.assignments_integer,
+                &self.assignments_propositional,
+                &self.variable_literal_mappings,
+                &self.cp_propagators[propagator_id],
+                propagator_id,
+            );
         }
+        result
     }
 }
 
@@ -2146,130 +2140,4 @@ mod tests {
             }
         }
     }
-
-    //     struct TestPropagator {
-    //     original_propagations: Vec<(DomainId, Predicate, PropositionalConjunction)>,
-    //     propagations: Vec<(DomainId, Predicate, PropositionalConjunction)>,
-    //     conflicts: Vec<PropositionalConjunction>,
-    //     is_in_root: bool,
-    // }
-
-    // impl TestPropagator {
-    //     pub(crate) fn new(
-    //         propagations: Vec<(Predicate, PropositionalConjunction)>,
-    //         conflicts: Vec<PropositionalConjunction>,
-    //     ) -> Self {
-    //         let propagations: Vec<(DomainId, Predicate, PropositionalConjunction)> = propagations
-    //             .iter()
-    //             .rev()
-    //             .map(|variable| {
-    //                 (
-    //                     variable.0.get_domain().unwrap(),
-    //                     variable.0,
-    //                     variable.1.clone(),
-    //                 )
-    //             })
-    //             .collect::<Vec<_>>();
-    //         TestPropagator {
-    //             original_propagations: propagations.clone(),
-    //             propagations,
-    //             conflicts: conflicts.into_iter().rev().collect::<Vec<_>>(),
-    //             is_in_root: true,
-    //         }
-    //     }
-    // }
-
-    // impl Propagator for TestPropagator {
-    //     fn initialise_at_root(
-    //         &mut self,
-    //         context: &mut PropagatorInitialisationContext,
-    //     ) -> Result<(), PropositionalConjunction> {
-    //         self.propagations
-    //             .iter()
-    //             .enumerate()
-    //             .for_each(|(index, variable)| {
-    //                 let _ = context.register(
-    //                     variable.0,
-    //                     DomainEvents::BOUNDS,
-    //                     LocalId::from(index as u32),
-    //                 );
-    //             });
-    //         Ok(())
-    //     }
-
-    //     fn name(&self) -> &str {
-    //         "TestPropagator"
-    //     }
-
-    //     fn propagate(&mut self, mut context: PropagationContextMut) -> PropagationStatusCP {
-    //         if self.is_in_root {
-    //             self.is_in_root = false;
-    //             return Ok(());
-    //         }
-
-    //         while let Some(propagation) = self.propagations.pop() {
-    //             match propagation.1 {
-    //                 Predicate::IntegerPredicate(integer_predicate) => match integer_predicate {
-    //                     IntegerPredicate::LowerBound {
-    //                         domain_id: _,
-    //                         lower_bound,
-    //                     } => {
-    //                         let result =
-    //                             context.set_lower_bound(&propagation.0, lower_bound,
-    // propagation.2);                         assert!(result.is_ok())
-    //                     }
-    //                     IntegerPredicate::UpperBound {
-    //                         domain_id: _,
-    //                         upper_bound,
-    //                     } => {
-    //                         let result =
-    //                             context.set_upper_bound(&propagation.0, upper_bound,
-    // propagation.2);                         assert!(result.is_ok())
-    //                     }
-    //                     IntegerPredicate::NotEqual {
-    //                         domain_id: _,
-    //                         not_equal_constant,
-    //                     } => {
-    //                         let result =
-    //                             context.remove(&propagation.0, not_equal_constant,
-    // propagation.2);                         assert!(result.is_ok())
-    //                     }
-    //                     IntegerPredicate::Equal {
-    //                         domain_id: _,
-    //                         equality_constant: _,
-    //                     } => todo!(),
-    //                 },
-    //                 _ => todo!(),
-    //             }
-    //         }
-
-    //         if let Some(conflict) = self.conflicts.pop() {
-    //             return Err(conflict.into());
-    //         }
-
-    //         Ok(())
-    //     }
-
-    //     fn debug_propagate_from_scratch(
-    //         &self,
-    //         context: PropagationContextMut,
-    //     ) -> PropagationStatusCP {
-    //         // This method detects when a debug propagation method is called and it attempts to
-    //         // return the correct result in this case
-    //         if self.conflicts.is_empty()
-    //             && self.original_propagations.iter().all(|propagation| {
-    //                 context.assignments_integer().does_integer_predicate_hold(
-    //                     propagation
-    //                         .1
-    //                         .try_into()
-    //                         .expect("Expected provided predicate to be integer"),
-    //                 )
-    //             })
-    //         {
-    //             Err(crate::basic_types::Inconsistency::EmptyDomain)
-    //         } else {
-    //             Ok(())
-    //         }
-    //     }
-    // }
 }

--- a/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-lib/src/engine/constraint_satisfaction_solver.rs
@@ -1812,7 +1812,6 @@ mod tests {
     ///
     /// It is assumed that the propagations do not lead to conflict, if the propagations do lead to
     /// a conflict then this method will panic.
-
     fn is_same_core(core1: &[Literal], core2: &[Literal]) -> bool {
         core1.len() == core2.len() && core2.iter().all(|lit| core1.contains(lit))
     }

--- a/pumpkin-lib/src/engine/cp/reason.rs
+++ b/pumpkin-lib/src/engine/cp/reason.rs
@@ -48,7 +48,6 @@ impl ReasonStore {
         let _ = self.trail.synchronise(level);
     }
 
-    #[cfg(test)]
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.trail.len()

--- a/pumpkin-lib/src/engine/debug_helper.rs
+++ b/pumpkin-lib/src/engine/debug_helper.rs
@@ -174,6 +174,20 @@ impl DebugHelper {
             .filter(|&predicate| predicate != Predicate::True)
             .collect();
 
+        if reason
+            .iter()
+            .any(|&predicate| predicate == Predicate::False)
+        {
+            panic!(
+                "The reason for propagation should not contain the trivially false predicate.
+                 Propagator: {},
+                 id: {propagator_id},
+                 The reported propagation reason: {reason},
+                 Propagated predicate: {propagated_predicate}",
+                propagator.name(),
+            );
+        }
+
         // Note that it could be the case that the reason contains the trivially false predicate in
         // case of lifting!
         //

--- a/pumpkin-lib/src/propagators/arithmetic/integer_multiplication.rs
+++ b/pumpkin-lib/src/propagators/arithmetic/integer_multiplication.rs
@@ -73,85 +73,79 @@ fn perform_propagation<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVari
     // First we propagate the signs
     propagate_signs(&mut context, a, b, c)?;
 
-    // Then we propagate on whether or not the variables are sign fixed
-    // For now we only propagate in the case where a, b, c >= 0
-    // TODO: We can likely perform much more propagation
-    if context.lower_bound(a) >= 0 && context.lower_bound(b) >= 0 {
-        let a_min = context.lower_bound(a);
-        let a_max = context.upper_bound(a);
-        let b_min = context.lower_bound(b);
-        let b_max = context.upper_bound(b);
-        let c_min = context.lower_bound(c);
-        let c_max = context.upper_bound(c);
+    let a_min = context.lower_bound(a);
+    let a_max = context.upper_bound(a);
+    let b_min = context.lower_bound(b);
+    let b_max = context.upper_bound(b);
+    let c_min = context.lower_bound(c);
+    let c_max = context.upper_bound(c);
 
+    if a_min >= 0 && b_min >= 0 {
         let new_max_c = a_max * b_max;
         let new_min_c = a_min * b_min;
 
         // c is smaller than the maximum value that a * b can take
-        if context.upper_bound(c) > new_max_c {
-            // We need the lower-bounds in the explanation as well because the reasoning does not
-            // hold in the case of a negative lower-bound
-            context.set_upper_bound(
-                c,
-                new_max_c,
-                conjunction!([a >= 0] & [a <= a_max] & [b >= 0] & [b <= b_max]),
-            )?;
-        }
+        //
+        // We need the lower-bounds in the explanation as well because the reasoning does not
+        // hold in the case of a negative lower-bound
+        context.set_upper_bound(
+            c,
+            new_max_c,
+            conjunction!([a >= 0] & [a <= a_max] & [b >= 0] & [b <= b_max]),
+        )?;
 
         // c is larger than the minimum value that a * b can take
-        if context.lower_bound(c) < new_min_c {
-            context.set_lower_bound(c, new_min_c, conjunction!([a >= a_min] & [b >= b_min]))?;
+        context.set_lower_bound(c, new_min_c, conjunction!([a >= a_min] & [b >= b_min]))?;
+    }
+
+    if b_min >= 0 && c_min >= 0 {
+        // a >= ceil(c.min / b.max)
+        if b_max >= 1 && c_min >= 1 {
+            let bound = div_ceil_pos(c_min, b_max);
+            if context.lower_bound(a) < bound {
+                context.set_lower_bound(
+                    a,
+                    bound,
+                    conjunction!([c >= c_min] & [b >= 0] & [b <= b_max]),
+                )?;
+            }
         }
 
-        if c_min >= 0 {
-            // a >= ceil(c.min / b.max)
-            if b_max >= 1 && c_min >= 1 {
-                let bound = div_ceil_pos(c_min, b_max);
-                if context.lower_bound(a) < bound {
-                    context.set_lower_bound(
-                        a,
-                        bound,
-                        conjunction!([c >= c_min] & [b >= 0] & [b <= b_max]),
-                    )?;
-                }
+        // a <= floor(c.max / b.min)
+        if b_min >= 1 && c_max >= 1 {
+            let bound = c_max / b_min;
+            if context.upper_bound(a) > bound {
+                context.set_upper_bound(
+                    a,
+                    bound,
+                    conjunction!([c >= 0] & [c <= c_max] & [b >= b_min]),
+                )?;
             }
+        }
 
-            // a <= floor(c.max / b.min)
-            if b_min >= 1 && c_max >= 1 {
-                let bound = c_max / b_min;
-                if context.upper_bound(a) > bound {
-                    context.set_upper_bound(
-                        a,
-                        bound,
-                        conjunction!([c >= 0] & [c <= c_max] & [b >= b_min]),
-                    )?;
-                }
+        // b <= floor(c.max / a.min)
+        if a_min >= 1 && c_max >= 1 {
+            let bound = c_max / a_min;
+            if context.upper_bound(b) > bound {
+                context.set_upper_bound(
+                    b,
+                    bound,
+                    conjunction!([c >= 1] & [c <= c_max] & [a >= a_min]),
+                )?;
             }
+        }
+    }
 
-            // b >= ceil(c.min / a.max)
-            if a_max >= 1 && c_min >= 1 {
-                let bound = div_ceil_pos(c_min, a_max);
+    // b >= ceil(c.min / a.max)
+    if a_max >= 1 && c_min >= 1 {
+        let bound = div_ceil_pos(c_min, a_max);
 
-                if context.lower_bound(b) < bound {
-                    context.set_lower_bound(
-                        b,
-                        bound,
-                        conjunction!([c >= c_min] & [a >= 0] & [a <= a_max]),
-                    )?;
-                }
-            }
-
-            // b <= floor(c.max / a.min)
-            if a_min >= 1 && c_max >= 1 {
-                let bound = c_max / a_min;
-                if context.upper_bound(b) > bound {
-                    context.set_upper_bound(
-                        b,
-                        bound,
-                        conjunction!([c >= 0] & [c <= c_max] & [a >= a_min]),
-                    )?;
-                }
-            }
+        if context.lower_bound(b) < bound {
+            context.set_lower_bound(
+                b,
+                bound,
+                conjunction!([c >= c_min] & [a >= 0] & [a <= a_max]),
+            )?;
         }
     }
 
@@ -347,7 +341,7 @@ mod tests {
         assert_eq!(conjunction!([a >= 1] & [c >= 1]), *reason_lb);
 
         let reason_ub = solver.get_reason_int(predicate![b <= 6].try_into().unwrap());
-        assert_eq!(conjunction!([a >= 2] & [c >= 0] & [c <= 12]), *reason_ub);
+        assert_eq!(conjunction!([a >= 2] & [c >= 1] & [c <= 12]), *reason_ub);
     }
 
     #[test]

--- a/pumpkin-lib/src/propagators/arithmetic/integer_multiplication.rs
+++ b/pumpkin-lib/src/propagators/arithmetic/integer_multiplication.rs
@@ -331,7 +331,7 @@ mod tests {
         assert_eq!(conjunction!([a >= 1] & [c >= 1]), *reason_lb);
 
         let reason_ub = solver.get_reason_int(predicate![b <= 6].try_into().unwrap());
-        assert_eq!(conjunction!([a >= 2] & [c >= 1] & [c <= 12]), *reason_ub);
+        assert_eq!(conjunction!([a >= 2] & [c >= 0] & [c <= 12]), *reason_ub);
     }
 
     #[test]

--- a/pumpkin-lib/src/propagators/arithmetic/integer_multiplication.rs
+++ b/pumpkin-lib/src/propagators/arithmetic/integer_multiplication.rs
@@ -98,41 +98,39 @@ fn perform_propagation<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVari
         context.set_lower_bound(c, new_min_c, conjunction!([a >= a_min] & [b >= b_min]))?;
     }
 
-    if b_min >= 0 && c_min >= 0 {
+    if b_min >= 0 && b_max >= 1 && c_min >= 1 {
         // a >= ceil(c.min / b.max)
-        if b_max >= 1 && c_min >= 1 {
-            let bound = div_ceil_pos(c_min, b_max);
-            if context.lower_bound(a) < bound {
-                context.set_lower_bound(
-                    a,
-                    bound,
-                    conjunction!([c >= c_min] & [b >= 0] & [b <= b_max]),
-                )?;
-            }
+        let bound = div_ceil_pos(c_min, b_max);
+        if context.lower_bound(a) < bound {
+            context.set_lower_bound(
+                a,
+                bound,
+                conjunction!([c >= c_min] & [b >= 0] & [b <= b_max]),
+            )?;
         }
+    }
 
+    if b_min >= 1 && c_min >= 0 && c_max >= 1 {
         // a <= floor(c.max / b.min)
-        if b_min >= 1 && c_max >= 1 {
-            let bound = c_max / b_min;
-            if context.upper_bound(a) > bound {
-                context.set_upper_bound(
-                    a,
-                    bound,
-                    conjunction!([c >= 0] & [c <= c_max] & [b >= b_min]),
-                )?;
-            }
+        let bound = c_max / b_min;
+        if context.upper_bound(a) > bound {
+            context.set_upper_bound(
+                a,
+                bound,
+                conjunction!([c >= 0] & [c <= c_max] & [b >= b_min]),
+            )?;
         }
+    }
 
+    if a_min >= 1 && c_min >= 0 && c_max >= 1 {
         // b <= floor(c.max / a.min)
-        if a_min >= 1 && c_max >= 1 {
-            let bound = c_max / a_min;
-            if context.upper_bound(b) > bound {
-                context.set_upper_bound(
-                    b,
-                    bound,
-                    conjunction!([c >= 1] & [c <= c_max] & [a >= a_min]),
-                )?;
-            }
+        let bound = c_max / a_min;
+        if context.upper_bound(b) > bound {
+            context.set_upper_bound(
+                b,
+                bound,
+                conjunction!([c >= 1] & [c <= c_max] & [a >= a_min]),
+            )?;
         }
     }
 
@@ -140,13 +138,11 @@ fn perform_propagation<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVari
     if a_max >= 1 && c_min >= 1 {
         let bound = div_ceil_pos(c_min, a_max);
 
-        if context.lower_bound(b) < bound {
-            context.set_lower_bound(
-                b,
-                bound,
-                conjunction!([c >= c_min] & [a >= 0] & [a <= a_max]),
-            )?;
-        }
+        context.set_lower_bound(
+            b,
+            bound,
+            conjunction!([c >= c_min] & [a >= 0] & [a <= a_max]),
+        )?;
     }
 
     if context.is_fixed(a)

--- a/pumpkin-lib/src/propagators/arithmetic/integer_multiplication.rs
+++ b/pumpkin-lib/src/propagators/arithmetic/integer_multiplication.rs
@@ -101,37 +101,31 @@ fn perform_propagation<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVari
     if b_min >= 0 && b_max >= 1 && c_min >= 1 {
         // a >= ceil(c.min / b.max)
         let bound = div_ceil_pos(c_min, b_max);
-        if context.lower_bound(a) < bound {
-            context.set_lower_bound(
-                a,
-                bound,
-                conjunction!([c >= c_min] & [b >= 0] & [b <= b_max]),
-            )?;
-        }
+        context.set_lower_bound(
+            a,
+            bound,
+            conjunction!([c >= c_min] & [b >= 0] & [b <= b_max]),
+        )?;
     }
 
     if b_min >= 1 && c_min >= 0 && c_max >= 1 {
         // a <= floor(c.max / b.min)
         let bound = c_max / b_min;
-        if context.upper_bound(a) > bound {
-            context.set_upper_bound(
-                a,
-                bound,
-                conjunction!([c >= 0] & [c <= c_max] & [b >= b_min]),
-            )?;
-        }
+        context.set_upper_bound(
+            a,
+            bound,
+            conjunction!([c >= 0] & [c <= c_max] & [b >= b_min]),
+        )?;
     }
 
     if a_min >= 1 && c_min >= 0 && c_max >= 1 {
         // b <= floor(c.max / a.min)
         let bound = c_max / a_min;
-        if context.upper_bound(b) > bound {
-            context.set_upper_bound(
-                b,
-                bound,
-                conjunction!([c >= 1] & [c <= c_max] & [a >= a_min]),
-            )?;
-        }
+        context.set_upper_bound(
+            b,
+            bound,
+            conjunction!([c >= 0] & [c <= c_max] & [a >= a_min]),
+        )?;
     }
 
     // b >= ceil(c.min / a.max)


### PR DESCRIPTION
For a while, the code for checking the reason for a propagation has been unused; likely due to the fact that the reasons which were provided to the method were not `PropositionalConjunction`s anymore.

This PR aims to address this by calculating the reason eagerly (if the assertion levels are set to extreme) and checking these reasons. This already led to an error becoming apparent in the integer multiplication propagator due to an off-by-one error!