### PR TITLE
Not using lazy reason for linear not equals

### DIFF
--- a/pumpkin-lib/src/propagators/arithmetic/linear_not_equal.rs
+++ b/pumpkin-lib/src/propagators/arithmetic/linear_not_equal.rs
@@ -182,19 +182,15 @@ where
                 // from the unfixed variable
                 self.unfixed_variable_has_been_updated = true;
 
-                // Then we remove the conflicting value from the unfixed variable
-                let terms = Rc::clone(&self.terms);
                 context.remove(
                     &self.terms[unfixed_x_i],
                     value_to_remove,
-                    move |context: &PropagationContext| {
-                        terms
-                            .iter()
-                            .enumerate()
-                            .filter(|&(i, _)| i != unfixed_x_i)
-                            .map(|(_, x_i)| predicate![x_i == context.lower_bound(x_i)])
-                            .collect()
-                    },
+                    self.terms
+                        .iter()
+                        .enumerate()
+                        .filter(|&(i, _)| i != unfixed_x_i)
+                        .map(|(_, x_i)| predicate![x_i == context.lower_bound(x_i)])
+                        .collect::<PropositionalConjunction>(),
                 )?;
             }
         } else if self.number_of_fixed_terms == self.terms.len() {


### PR DESCRIPTION
We thought that we could use a lazy reason for explaining the not equals constraint but we did not fix the underlying problem mentioned in #25 . This PR reverts to eager reason calculation!