### PR TITLE
(Mini PR) Fix out-of-bounds is_restart_pointless for dynamic brancher

### DIFF
--- a/pumpkin-lib/src/branching/branchers/dynamic_brancher.rs
+++ b/pumpkin-lib/src/branching/branchers/dynamic_brancher.rs
@@ -3,6 +3,7 @@
 //!
 //! Note that this structure should be used if you want to use dynamic [`Brancher`]s but
 //! require a [`Sized`] object (e.g. when a function takes as input `impl Brancher`).
+use std::cmp::min;
 use std::fmt::Debug;
 
 use crate::basic_types::SolutionReference;
@@ -110,7 +111,8 @@ impl Brancher for DynamicBrancher {
     fn is_restart_pointless(&mut self) -> bool {
         // We return whether all of the branchers up and until this one are static; if this is not
         // the case then restarting could be useful!
-        self.branchers[..=self.brancher_index]
+        let current_brancher_index = min(self.brancher_index, self.branchers.len() - 1);
+        self.branchers[..=current_brancher_index]
             .iter_mut()
             .all(|brancher| brancher.is_restart_pointless())
     }


### PR DESCRIPTION
In the case that `brancher_index == branchers.len()`, the `is_restart_pointless` method encounters an out-of-bounds error; this PR addresses this by ensuring that the brancer index is in the correct range.

_Additionally, the decision level was raised if a restart was considered but not actually performed; while this does not lead to any (obvious) bugs, this has been fixed in this PR for accuracy_