### PR TITLE
Minizinc: Use cumulative for disjunctive constraint

### DIFF
--- a/minizinc/lib/fzn_disjunctive.mzn
+++ b/minizinc/lib/fzn_disjunctive.mzn
@@ -1,0 +1,12 @@
+include "fzn_cumulative.mzn";
+
+predicate fzn_disjunctive(array[int] of var int: s,
+                          array[int] of var int: d) =
+        forall(i in index_set(d))(d[i] >= 0)
+    /\  if is_fixed(d) then
+            pumpkin_cumulative(s, fix(d), [1 | i in index_set(s)], 1)
+        else
+            forall(i, j in index_set(d) where i < j) (
+              s[i] + d[i] <= s[j] \/ s[j] + d[j] <= s[i]
+            )
+        endif


### PR DESCRIPTION
Similar to Chuffed, we can use the cumulative to redefine the disjunctive; this PR adds this support since we would expect this to be lead to stronger reasoning than the simple decomposition