### PR TITLE
Implement the pumpkin release pipeline

### DIFF
--- a/.github/workflows/post-release-pumpkin-solver.yml
+++ b/.github/workflows/post-release-pumpkin-solver.yml
@@ -5,7 +5,7 @@
 # The create-release job runs purely to initialize the GitHub release itself
 # and to output upload_url for the following job.
 #
-# The build-release job runs only once create-release is finished. It gets the
+# The attach-artifacts job runs only once create-release is finished. It gets the
 # release upload URL from create-release job outputs, then builds the release
 # executables for each supported platform and attaches them as release assets
 # to the previously created release.
@@ -59,7 +59,26 @@ jobs:
           release_name: ${{ env.RELEASE_NAME }}
           body_path: notes-${{ env.RELEASE_NAME }}.md
 
-  build-release:
+  publish-crate:
+    name: Publish pumpkin-solver to crates.io
+    needs: create-release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+
+    - name: Publish
+      run: cargo publish --package pumpkin-solver --token ${CRATES_TOKEN}
+      env:
+        CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
+  attach-artifacts:
     name: Build Artifacts and Upload
     needs: create-release
     strategy:

--- a/.github/workflows/post-release-pumpkin-solver.yml
+++ b/.github/workflows/post-release-pumpkin-solver.yml
@@ -1,0 +1,118 @@
+# This workflow is used to create and publish releases for the pumpkin-solver crate.
+#
+# The way this works is the following:
+#
+# The create-release job runs purely to initialize the GitHub release itself
+# and to output upload_url for the following job.
+#
+# The build-release job runs only once create-release is finished. It gets the
+# release upload URL from create-release job outputs, then builds the release
+# executables for each supported platform and attaches them as release assets
+# to the previously created release.
+#
+# The key here is that we create the release only once.
+#
+# Reference:
+# https://eugene-babichenko.github.io/blog/2020/05/09/github-actions-cross-platform-auto-releases/
+
+name: post-release
+on:
+  push:
+    tags:
+      - "pumpkin-solver-v*"
+env:
+  BIN_NAME: pumpkin-solver
+
+jobs:
+  # Create a GitHub release based on the tag. Extract the appropriate changes from 
+  # the CHANGELOG.md to serve as the release body.
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.release.outputs.upload_url }}
+      release_version: ${{ env.RELEASE_NAME }}
+    steps:
+      - name: Get the release version from the tag
+        shell: bash
+        if: env.RELEASE_NAME == ''
+        run: |
+          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+          echo "RELEASE_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "version is: ${{ env.RELEASE_NAME }}"
+            
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate Release Notes
+        run: |
+          ./.github/workflows/release-notes.py --tag ${{ env.RELEASE_NAME }} --output notes-${{ env.RELEASE_VERSION }}.md
+          cat notes-${{ env.RELEASE_NAME }}.md
+
+      - name: Create GitHub release
+        id: release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_NAME }}
+          release_name: ${{ env.RELEASE_NAME }}
+          body_path: notes-${{ env.RELEASE_NAME }}.md
+
+  build-release:
+    name: Build Artifacts and Upload
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [linux, macos, win-msvc]
+        include:
+          - build: linux
+            os: ubuntu-20.04
+            rust: stable
+            target: x86_64-unknown-linux-gnu
+          - build: macos
+            os: macos-latest
+            rust: stable
+            target: x86_64-apple-darwin
+          - build: win-msvc
+            os: windows-2019
+            rust: stable
+            target: x86_64-pc-windows-msvc
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ matrix.rust }}
+        targets: ${{ matrix.target }}
+
+    - name: Build release binary
+      run: cargo build --package pumpkin-solver --target ${{ matrix.target }} --verbose --release
+
+    - name: Build archive
+      shell: bash
+      run: |
+        out_bin_name="${{ env.BIN_NAME }}-${{ needs.create-release.outputs.release_version }}-${{ matrix.target }}"
+        if [ "${{ matrix.os }}" = "windows-2019" ]; then
+          cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}.exe" "$out_bin_name.exe"
+          echo "ASSET=$out_bin_name.exe" >> $GITHUB_ENV
+        else
+          cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}" "$out_bin_name"
+          echo "ASSET=$out_bin_name" >> $GITHUB_ENV
+        fi
+      
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET }}
+        asset_name: ${{ env.ASSET }}
+        asset_content_type: application/octet-stream

--- a/.github/workflows/post-release-pumpkin-solver.yml
+++ b/.github/workflows/post-release-pumpkin-solver.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Generate Release Notes
         run: |
-          ./.github/workflows/release-notes.py --tag ${{ env.RELEASE_NAME }} --output notes-${{ env.RELEASE_VERSION }}.md
+          ./.github/workflows/release-notes.py --tag ${{ env.RELEASE_NAME }} --output notes-${{ env.RELEASE_NAME }}.md
           cat notes-${{ env.RELEASE_NAME }}.md
 
       - name: Create GitHub release

--- a/.github/workflows/release-notes.py
+++ b/.github/workflows/release-notes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import sys
+
+
+_STDIO = pathlib.Path("-")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("-o", "--output", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+
+    [package, version] = args.tag.rsplit("-", 1)
+    version = version.lstrip("v")
+
+    print(f"Parsing {package} release notes for version {version}", file=sys.stderr)
+
+    changelog_path = pathlib.Path(f"{package}/CHANGELOG.md")
+    with changelog_path.open() as fh:
+        lines = fh.readlines()
+
+    note_lines = []
+    for line in lines:
+        if line.startswith("## ") and version in line:
+            note_lines.append(line)
+        elif note_lines and line.startswith("## "):
+            break
+        elif note_lines:
+            note_lines.append(line)
+
+    notes = "".join(note_lines).strip()
+    if args.output == _STDIO:
+        print(notes)
+    else:
+        args.output.write_text(notes)
+
+
+if __name__ == "__main__":
+    main()

--- a/drcp-format/CHANGELOG.md
+++ b/drcp-format/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-10-16
+
+### Added
+
+- Parsing/reading of DRCP files.
+- Writing of DRCP files.
+- Reading of literal definition files.
+- Writing of literal definition files.


### PR DESCRIPTION
When pushing a tag in the format `pumpkin-solver-v<version>`, the github action will:
- Create a github release
- Attach the solver binaries for linux, macos and windows
- Publish to crates.io