### PR TITLE
fix: complete proof when propagator initialization identifies root-level conflict

### DIFF
--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -1922,9 +1922,7 @@ mod tests {
     use crate::engine::termination::indefinite::Indefinite;
     use crate::engine::variables::Literal;
     use crate::predicate;
-    use crate::propagators::linear_less_or_equal::LinearLessOrEqualPropagator;
     use crate::propagators::linear_not_equal::LinearNotEqualPropagator;
-    use crate::variables::TransformableVariable;
 
     /// A test propagator which propagates the stored propagations and then reports one of the
     /// stored conflicts. If multiple conflicts are stored then the next time it is called, it will
@@ -2271,31 +2269,11 @@ mod tests {
     fn check_can_compute_1uip_with_propagator_initialisation_conflict() {
         let mut solver = ConstraintSatisfactionSolver::default();
 
-        let p = solver.create_new_integer_variable(0, 3, None);
-        let q = solver.create_new_integer_variable(0, 3, None);
-        let r = solver.create_new_integer_variable(0, 3, None);
-        let s = solver.create_new_integer_variable(0, 3, None);
+        let x = solver.create_new_integer_variable(1, 1, None);
+        let y = solver.create_new_integer_variable(2, 2, None);
 
-        let propagator =
-            LinearLessOrEqualPropagator::new(Box::new([s.scaled(3), p.scaled(1), r.scaled(1)]), 1);
+        let propagator = LinearNotEqualPropagator::new(Box::new([x, y]), 3);
         let result = solver.add_propagator(propagator, None);
-        assert!(result.is_ok());
-
-        let mut all_different = Vec::new();
-        let variables = [p, q, r, s];
-
-        for i in 0..variables.len() {
-            for j in i + 1..variables.len() {
-                all_different.push(LinearNotEqualPropagator::new(
-                    Box::new([variables[i].scaled(1), variables[j].scaled(-1)]),
-                    0,
-                ));
-            }
-        }
-
-        let result = all_different
-            .into_iter()
-            .try_for_each(|c| solver.add_propagator(c, None));
         assert!(result.is_err());
     }
 }

--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -1922,6 +1922,9 @@ mod tests {
     use crate::engine::termination::indefinite::Indefinite;
     use crate::engine::variables::Literal;
     use crate::predicate;
+    use crate::propagators::linear_less_or_equal::LinearLessOrEqualPropagator;
+    use crate::propagators::linear_not_equal::LinearNotEqualPropagator;
+    use crate::variables::TransformableVariable;
 
     /// A test propagator which propagates the stored propagations and then reports one of the
     /// stored conflicts. If multiple conflicts are stored then the next time it is called, it will
@@ -2262,5 +2265,37 @@ mod tests {
                 )
             }
         }
+    }
+
+    #[test]
+    fn check_can_compute_1uip_with_propagator_initialisation_conflict() {
+        let mut solver = ConstraintSatisfactionSolver::default();
+
+        let p = solver.create_new_integer_variable(0, 3, None);
+        let q = solver.create_new_integer_variable(0, 3, None);
+        let r = solver.create_new_integer_variable(0, 3, None);
+        let s = solver.create_new_integer_variable(0, 3, None);
+
+        let propagator =
+            LinearLessOrEqualPropagator::new(Box::new([s.scaled(3), p.scaled(1), r.scaled(1)]), 1);
+        let result = solver.add_propagator(propagator, None);
+        assert!(result.is_ok());
+
+        let mut all_different = Vec::new();
+        let variables = [p, q, r, s];
+
+        for i in 0..variables.len() {
+            for j in i + 1..variables.len() {
+                all_different.push(LinearNotEqualPropagator::new(
+                    Box::new([variables[i].scaled(1), variables[j].scaled(-1)]),
+                    0,
+                ));
+            }
+        }
+
+        let result = all_different
+            .into_iter()
+            .try_for_each(|c| solver.add_propagator(c, None));
+        assert!(result.is_err());
     }
 }

--- a/pumpkin-solver/src/engine/debug_helper.rs
+++ b/pumpkin-solver/src/engine/debug_helper.rs
@@ -458,6 +458,23 @@ impl DebugHelper {
         // Then (!p1 || !p2 || !p3) should not lead to immediate failure
 
         // Empty reasons are by definition satisifed after negation
+        let failure_reason = failure_reason
+            .iter()
+            .filter(|predicate| match predicate {
+                Predicate::IntegerPredicate(integer_predicate) => {
+                    variable_literal_mappings.get_literal(
+                        *integer_predicate,
+                        assignments_propositional,
+                        assignments_integer,
+                    ) != assignments_propositional.true_literal
+                }
+                Predicate::Literal(literal) => *literal != assignments_propositional.true_literal,
+                Predicate::False => unreachable!(),
+                Predicate::True => false,
+            })
+            .copied()
+            .collect::<PropositionalConjunction>();
+
         if failure_reason.num_predicates() == 0 {
             return;
         }


### PR DESCRIPTION
Closes #79 

Currently, when a root-level conflict is found when adding a propagator, the state of the propagator does not contain the reported conflict.

However, this means that the `complete_proof` step cannot properly create the final learned clause; this PR addresses this by properly setting the state of the `ConstraintSatisfactionSolver` to be conflicting using the conflict returned by the propagator. 