### PR TITLE
fix: float stat into one line

### DIFF
--- a/pumpkin-solver/src/statistics/mod.rs
+++ b/pumpkin-solver/src/statistics/mod.rs
@@ -3,8 +3,6 @@ pub(crate) mod statistic_logger;
 pub(crate) mod statistic_logging;
 
 use std::fmt::Display;
-use std::fmt::Write;
-
 pub use statistic_logger::StatisticLogger;
 pub use statistic_logging::configure_statistic_logging;
 pub use statistic_logging::log_statistic;
@@ -26,8 +24,8 @@ pub trait Statistic {
 }
 
 impl<Value: Display> Statistic for Value {
-    fn log(&self, mut statistic_logger: StatisticLogger) {
-        write!(statistic_logger, "{self}").expect("Expected statistic to be logged");
+    fn log(&self, statistic_logger: StatisticLogger) {
+        statistic_logger.log_statistic(self);
     }
 }
 

--- a/pumpkin-solver/src/statistics/mod.rs
+++ b/pumpkin-solver/src/statistics/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod statistic_logger;
 pub(crate) mod statistic_logging;
 
 use std::fmt::Display;
+
 pub use statistic_logger::StatisticLogger;
 pub use statistic_logging::configure_statistic_logging;
 pub use statistic_logging::log_statistic;

--- a/pumpkin-solver/src/statistics/statistic_logger.rs
+++ b/pumpkin-solver/src/statistics/statistic_logger.rs
@@ -28,11 +28,8 @@ impl StatisticLogger {
             name_prefix: format!("{}_{}", self.name_prefix, addition_to_prefix),
         }
     }
-}
 
-impl std::fmt::Write for StatisticLogger {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        log_statistic(&self.name_prefix, s);
-        Ok(())
+    pub fn log_statistic(&self, value: impl Display) {
+        log_statistic(&self.name_prefix, value);
     }
 }


### PR DESCRIPTION
After a discussion with @ImkoMarijnissen, we came to the conclusion that for now #73 has a few limitations that are not directly easy to overcome. Therefore, this PR fixes the issue described there, without implementing a custom writer.

Repeating the PR description from that PR:

When testing statistics, I found float statistics to be divided into multiple lines:

 _engine_statistics_time_spent_in_solver=139
 _learned_clause_statistics_average_conflict_size=2
 _learned_clause_statistics_average_conflict_size=.
 _learned_clause_statistics_average_conflict_size=247863247863248
 _learned_clause_statistics_average_number_of_removed_literals_recursive=2
 _learned_clause_statistics_average_number_of_removed_literals_recursive=.
 _learned_clause_statistics_average_number_of_removed_literals_recursive=5555555555555554
The origin lies in the writer for a float: it writes it to the writer in multiple parts (core::fmt::write_formatted_parts). Currently, each of these parts would be interpreted as being a statistic, resulting in multiple lines.

I now removed the Write trait from StatisticLogger alltogether, and simply called the required functions directly. Given that log_statistic directly writes to stdout anyway, I don't think this compromises the extendability of the logger.