### PR TITLE
fix: Take ownership of the propagation context in propagators

### DIFF
--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -1324,9 +1324,10 @@ impl ConstraintSatisfactionSolver {
         //      + allow incremental synchronisation
         //      + only call the subset of propagators that were notified since last backtrack
         for propagator in self.cp_propagators.iter_propagators_mut() {
-            let context =
-                PropagationContext::new(&self.assignments_integer, &self.assignments_propositional);
-            propagator.synchronise(&context);
+            propagator.synchronise(PropagationContext::new(
+                &self.assignments_integer,
+                &self.assignments_propositional,
+            ));
         }
 
         let _ = self.process_backtrack_events();

--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -280,7 +280,7 @@ impl ConstraintSatisfactionSolver {
                         &self.assignments_propositional,
                     );
 
-                    propagator.notify_backtrack(&context, propagator_var.variable, event.into())
+                    propagator.notify_backtrack(context, propagator_var.variable, event.into())
                 }
             }
         }

--- a/pumpkin-solver/src/engine/cp/propagation/propagator.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/propagator.rs
@@ -130,7 +130,7 @@ pub trait Propagator {
     /// update its internal data structures given the new variable domains.
     ///
     /// By default this function does nothing.
-    fn synchronise(&mut self, _context: &PropagationContext) {}
+    fn synchronise(&mut self, _context: PropagationContext) {}
 
     /// Returns the priority of the propagator represented as an integer. Lower values mean higher
     /// priority and the priority determines the order in which propagators will be asked to

--- a/pumpkin-solver/src/engine/cp/propagation/propagator.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/propagator.rs
@@ -106,7 +106,7 @@ pub trait Propagator {
     /// [`PropagatorInitialisationContext::register()`].
     fn notify_backtrack(
         &mut self,
-        _context: &PropagationContext,
+        _context: PropagationContext,
         _local_id: LocalId,
         _event: OpaqueDomainEvent,
     ) {

--- a/pumpkin-solver/src/propagators/arithmetic/linear_not_equal.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/linear_not_equal.rs
@@ -101,7 +101,7 @@ where
 
     fn notify_backtrack(
         &mut self,
-        _context: &PropagationContext,
+        _context: PropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) {

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_over_interval.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_over_interval.rs
@@ -91,7 +91,7 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTableOverIntervalPropaga
         propagate_based_on_timetable(&mut context, time_table.iter(), &self.parameters)
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         reset_bounds_clear_updated(
             context,
             &mut self.parameters.updated,

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_over_interval_incremental.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_over_interval_incremental.rs
@@ -162,7 +162,7 @@ impl<Var: IntegerVariable + 'static> Propagator
         propagate_based_on_timetable(&mut context, self.time_table.iter(), &self.parameters)
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         reset_bounds_clear_updated(
             context,
             &mut self.parameters.updated,

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point.rs
@@ -84,7 +84,7 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointPropagator<
         propagate_based_on_timetable(&mut context, time_table.values(), &self.parameters)
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         reset_bounds_clear_updated(
             context,
             &mut self.parameters.updated,

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point_incremental.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point_incremental.rs
@@ -167,7 +167,7 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointIncremental
         propagate_based_on_timetable(&mut context, self.time_table.values(), &self.parameters)
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         reset_bounds_clear_updated(
             context,
             &mut self.parameters.updated,

--- a/pumpkin-solver/src/propagators/cumulative/utils/util.rs
+++ b/pumpkin-solver/src/propagators/cumulative/utils/util.rs
@@ -72,7 +72,7 @@ pub(crate) fn update_bounds_task<Var: IntegerVariable + 'static>(
 ///
 /// This method is currently used during bactracking/synchronisation
 pub(crate) fn reset_bounds_clear_updated<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     updated: &mut Vec<UpdatedTaskInfo<Var>>,
     bounds: &mut Vec<(i32, i32)>,
     tasks: &[Rc<Task<Var>>],

--- a/pumpkin-solver/src/propagators/reified_propagator.rs
+++ b/pumpkin-solver/src/propagators/reified_propagator.rs
@@ -65,7 +65,7 @@ impl<WrappedPropagator: Propagator> Propagator for ReifiedPropagator<WrappedProp
 
     fn notify_backtrack(
         &mut self,
-        context: &PropagationContext,
+        context: PropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) {

--- a/pumpkin-solver/src/propagators/reified_propagator.rs
+++ b/pumpkin-solver/src/propagators/reified_propagator.rs
@@ -116,7 +116,7 @@ impl<WrappedPropagator: Propagator> Propagator for ReifiedPropagator<WrappedProp
         self.propagator.priority()
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         // We remove the inconsistency upon backtracking since it might be invalid now
         self.inconsistency = None;
 


### PR DESCRIPTION
Since `PropagationContext` is a collection of references, it can be safely copied. We have already implemented the `Copy` trait, and the final spots where the context is passed to the propagator as a reference have now been removed.