### PR TITLE
fix: take ownership of the propagation context in propagators

### DIFF
--- a/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -201,7 +201,7 @@ impl ConflictAnalysisContext<'_> {
         let propagator = self.reason_store.get_propagator(reason_ref);
         let reason = self
             .reason_store
-            .get_or_compute(reason_ref, &propagation_context)
+            .get_or_compute(reason_ref, propagation_context)
             .expect("reason reference should not be stale");
         // create the explanation clause
         //  allocate a fresh vector each time might be a performance bottleneck

--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -280,7 +280,7 @@ impl ConstraintSatisfactionSolver {
                         &self.assignments_propositional,
                     );
 
-                    propagator.notify_backtrack(&context, propagator_var.variable, event.into())
+                    propagator.notify_backtrack(context, propagator_var.variable, event.into())
                 }
             }
         }
@@ -1329,7 +1329,7 @@ impl ConstraintSatisfactionSolver {
         for propagator in self.cp_propagators.iter_propagators_mut() {
             let context =
                 PropagationContext::new(&self.assignments_integer, &self.assignments_propositional);
-            propagator.synchronise(&context);
+            propagator.synchronise(context);
         }
 
         let _ = self.process_backtrack_events();
@@ -1513,7 +1513,7 @@ impl ConstraintSatisfactionSolver {
                 .reason_store
                 .get_or_compute(
                     reason,
-                    &PropagationContext::new(
+                    PropagationContext::new(
                         &self.assignments_integer,
                         &self.assignments_propositional,
                     ),

--- a/pumpkin-solver/src/engine/cp/propagation/propagation_context.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/propagation_context.rs
@@ -81,7 +81,7 @@ impl<'a> PropagationContextMut<'a> {
                     Reason::Eager(conjunction)
                 }
                 Reason::Lazy(callback) => {
-                    Reason::Lazy(Box::new(move |context: &PropagationContext| {
+                    Reason::Lazy(Box::new(move |context: PropagationContext| {
                         let mut conjunction = callback.compute(context);
                         conjunction.add(reification_literal.into());
                         conjunction

--- a/pumpkin-solver/src/engine/cp/propagation/propagator.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/propagator.rs
@@ -106,7 +106,7 @@ pub trait Propagator {
     /// [`PropagatorInitialisationContext::register()`].
     fn notify_backtrack(
         &mut self,
-        _context: &PropagationContext,
+        _context: PropagationContext,
         _local_id: LocalId,
         _event: OpaqueDomainEvent,
     ) {
@@ -130,7 +130,7 @@ pub trait Propagator {
     /// update its internal data structures given the new variable domains.
     ///
     /// By default this function does nothing.
-    fn synchronise(&mut self, _context: &PropagationContext) {}
+    fn synchronise(&mut self, _context: PropagationContext) {}
 
     /// Returns the priority of the propagator represented as an integer. Lower values mean higher
     /// priority and the priority determines the order in which propagators will be asked to

--- a/pumpkin-solver/src/engine/cp/test_helper.rs
+++ b/pumpkin-solver/src/engine/cp/test_helper.rs
@@ -199,7 +199,7 @@ impl TestSolver {
         let context =
             PropagationContext::new(&self.assignments_integer, &self.assignments_propositional);
         self.reason_store
-            .get_or_compute(reason_ref, &context)
+            .get_or_compute(reason_ref, context)
             .expect("reason_ref should not be stale")
     }
 
@@ -214,7 +214,7 @@ impl TestSolver {
         let context =
             PropagationContext::new(&self.assignments_integer, &self.assignments_propositional);
         self.reason_store
-            .get_or_compute(reason_ref, &context)
+            .get_or_compute(reason_ref, context)
             .expect("reason_ref should not be stale")
     }
 

--- a/pumpkin-solver/src/engine/debug_helper.rs
+++ b/pumpkin-solver/src/engine/debug_helper.rs
@@ -186,7 +186,7 @@ impl DebugHelper {
                 trail_entry
                     .reason
                     .expect("Expected checked propagation to have a reason"),
-                &context,
+                context,
             );
 
             result &= Self::debug_propagator_reason(

--- a/pumpkin-solver/src/propagators/arithmetic/linear_not_equal.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/linear_not_equal.rs
@@ -101,7 +101,7 @@ where
 
     fn notify_backtrack(
         &mut self,
-        _context: &PropagationContext,
+        _context: PropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) {
@@ -147,8 +147,8 @@ where
             );
         });
 
-        self.recalculate_fixed_variables(context);
-        self.check_for_conflict(context)?;
+        self.recalculate_fixed_variables(context.as_readonly());
+        self.check_for_conflict(context.as_readonly())?;
         Ok(())
     }
 
@@ -156,7 +156,7 @@ where
         // If the left-hand side is out of date then we simply recalculate from scratch; we only do
         // this when we can propagate or check for a conflict
         if self.should_recalculate_lhs && self.number_of_fixed_terms >= self.terms.len() - 1 {
-            self.recalculate_fixed_variables(&context.as_readonly());
+            self.recalculate_fixed_variables(context.as_readonly());
             self.should_recalculate_lhs = false;
         }
         pumpkin_assert_extreme!(self.is_propagator_state_consistent(context.as_readonly()));
@@ -196,7 +196,7 @@ where
         } else if self.number_of_fixed_terms == self.terms.len() {
             pumpkin_assert_simple!(!self.should_recalculate_lhs);
             // Otherwise we check for a conflict
-            self.check_for_conflict(&context.as_readonly())?;
+            self.check_for_conflict(context.as_readonly())?;
         }
 
         Ok(())
@@ -265,7 +265,7 @@ impl<Var: IntegerVariable + 'static> LinearNotEqualPropagator<Var> {
     /// Note that this method always sets the `unfixed_variable_has_been_updated` to true; this
     /// might be too lenient as it could be the case that synchronisation does not lead to the
     /// re-adding of the removed value.
-    fn recalculate_fixed_variables<Context: ReadDomains>(&mut self, context: &Context) {
+    fn recalculate_fixed_variables(&mut self, context: PropagationContext) {
         self.unfixed_variable_has_been_updated = false;
         (self.fixed_lhs, self.number_of_fixed_terms) =
             self.terms
@@ -283,9 +283,9 @@ impl<Var: IntegerVariable + 'static> LinearNotEqualPropagator<Var> {
     }
 
     /// Determines whether a conflict has occurred and calculate the reason for the conflict
-    fn check_for_conflict<Context: ReadDomains>(
+    fn check_for_conflict(
         &self,
-        context: &Context,
+        context: PropagationContext,
     ) -> Result<(), PropositionalConjunction> {
         pumpkin_assert_simple!(!self.should_recalculate_lhs);
         if self.number_of_fixed_terms == self.terms.len() && self.fixed_lhs == self.rhs {

--- a/pumpkin-solver/src/propagators/cumulative/time_table/explanations/big_step.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/explanations/big_step.rs
@@ -62,7 +62,7 @@ where
 pub(crate) fn create_big_step_predicate_propagating_task_upper_bound_propagation<Var>(
     task: &Rc<Task<Var>>,
     profile: &ResourceProfile<Var>,
-    context: &PropagationContext,
+    context: PropagationContext,
 ) -> Predicate
 where
     Var: IntegerVariable + 'static,

--- a/pumpkin-solver/src/propagators/cumulative/time_table/explanations/mod.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/explanations/mod.rs
@@ -72,7 +72,7 @@ pub(crate) fn create_predicate_propagating_task_lower_bound_propagation<
     Var: IntegerVariable + 'static,
 >(
     explanation_type: CumulativeExplanationType,
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     profile: &ResourceProfile<Var>,
     time_point: Option<i32>,
@@ -94,7 +94,7 @@ pub(crate) fn create_predicate_propagating_task_lower_bound_propagation<
 pub(crate) fn add_propagating_task_predicate_lower_bound<Var: IntegerVariable + 'static>(
     mut explanation: PropositionalConjunction,
     explanation_type: CumulativeExplanationType,
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     profile: &ResourceProfile<Var>,
     time_point: Option<i32>,
@@ -114,7 +114,7 @@ pub(crate) fn create_predicate_propagating_task_upper_bound_propagation<
     Var: IntegerVariable + 'static,
 >(
     explanation_type: CumulativeExplanationType,
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     profile: &ResourceProfile<Var>,
     time_point: Option<i32>,
@@ -138,7 +138,7 @@ pub(crate) fn create_predicate_propagating_task_upper_bound_propagation<
 pub(crate) fn add_propagating_task_predicate_upper_bound<Var: IntegerVariable + 'static>(
     mut explanation: PropositionalConjunction,
     explanation_type: CumulativeExplanationType,
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     profile: &ResourceProfile<Var>,
     time_point: Option<i32>,

--- a/pumpkin-solver/src/propagators/cumulative/time_table/explanations/naive.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/explanations/naive.rs
@@ -11,9 +11,9 @@ use crate::variables::IntegerVariable;
 
 /// Creates the propagation explanation using the naive approach (see
 /// [`CumulativeExplanationType::Naive`])
-pub(crate) fn create_naive_propagation_explanation<'a, Var: IntegerVariable + 'static>(
-    profile: &'a ResourceProfile<Var>,
-    context: &'a PropagationContext,
+pub(crate) fn create_naive_propagation_explanation<Var: IntegerVariable + 'static>(
+    profile: &ResourceProfile<Var>,
+    context: PropagationContext,
 ) -> PropositionalConjunction {
     profile
         .profile_tasks
@@ -61,7 +61,7 @@ where
 }
 
 pub(crate) fn create_naive_predicate_propagating_task_lower_bound_propagation<Var>(
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
 ) -> Predicate
 where
@@ -71,7 +71,7 @@ where
 }
 
 pub(crate) fn create_naive_predicate_propagating_task_upper_bound_propagation<Var>(
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
 ) -> Predicate
 where

--- a/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/debug.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/debug.rs
@@ -21,11 +21,11 @@ use crate::variables::IntegerVariable;
 ///      - The profile tasks should be the same; note that we do not check whether the order is the
 ///        same!
 pub(crate) fn time_tables_are_the_same_interval<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     time_table: &OverIntervalTimeTableType<Var>,
     parameters: &CumulativeParameters<Var>,
 ) -> bool {
-    let time_table_scratch = create_time_table_over_interval_from_scratch(*context, parameters)
+    let time_table_scratch = create_time_table_over_interval_from_scratch(context, parameters)
         .expect("Expected no error");
 
     if time_table.is_empty() {

--- a/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
@@ -201,7 +201,7 @@ impl<Var: IntegerVariable + 'static> TimeTableOverIntervalIncrementalPropagator<
 
             // And we clear all of the updates since they have now necessarily been processed
             self.updatable_structures
-                .reset_all_bounds_and_remove_fixed(context, &self.parameters);
+                .reset_all_bounds_and_remove_fixed(context.as_readonly(), &self.parameters);
 
             return Ok(());
         }
@@ -290,7 +290,7 @@ impl<Var: IntegerVariable + 'static> Propagator
     fn propagate(&mut self, mut context: PropagationContextMut) -> PropagationStatusCP {
         pumpkin_assert_advanced!(
             check_bounds_equal_at_propagation(
-                &context.as_readonly(),
+                context.as_readonly(),
                 &self.parameters.tasks,
                 self.updatable_structures.get_stored_bounds(),
             ),
@@ -301,7 +301,7 @@ impl<Var: IntegerVariable + 'static> Propagator
 
         pumpkin_assert_extreme!(
             debug::time_tables_are_the_same_interval(
-                &context.as_readonly(),
+                context.as_readonly(),
                 &self.time_table,
                 &self.parameters,
             ),
@@ -338,7 +338,7 @@ impl<Var: IntegerVariable + 'static> Propagator
             &self.parameters,
             &self.updatable_structures,
             &updated_task,
-            &context,
+            context,
             self.time_table.is_empty(),
         );
 
@@ -347,7 +347,7 @@ impl<Var: IntegerVariable + 'static> Propagator
         insert_update(&updated_task, &mut self.updatable_structures, result.update);
 
         update_bounds_task(
-            &context,
+            context,
             self.updatable_structures.get_stored_bounds_mut(),
             &updated_task,
         );
@@ -364,7 +364,7 @@ impl<Var: IntegerVariable + 'static> Propagator
 
     fn notify_backtrack(
         &mut self,
-        context: &PropagationContext,
+        context: PropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) {
@@ -389,7 +389,7 @@ impl<Var: IntegerVariable + 'static> Propagator
         }
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         // We now recalculate the time-table from scratch if necessary and reset all of the bounds
         // *if* incremental backtracking is disabled
         if !self.parameters.options.incremental_backtracking {
@@ -425,7 +425,7 @@ impl<Var: IntegerVariable + 'static> Propagator
 
         // First we store the bounds in the parameters
         self.updatable_structures
-            .reset_all_bounds_and_remove_fixed(context, &self.parameters);
+            .reset_all_bounds_and_remove_fixed(context.as_readonly(), &self.parameters);
 
         // Then we do normal propagation
         self.time_table =

--- a/pumpkin-solver/src/propagators/cumulative/time_table/propagation_handler.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/propagation_handler.rs
@@ -62,7 +62,7 @@ impl CumulativePropagationHandler {
                 for profile in profiles {
                     let explanation = match self.explanation_type {
                         CumulativeExplanationType::Naive => {
-                            create_naive_propagation_explanation(profile, &context.as_readonly())
+                            create_naive_propagation_explanation(profile, context.as_readonly())
                         }
                         CumulativeExplanationType::BigStep => {
                             create_big_step_propagation_explanation(profile)
@@ -79,7 +79,7 @@ impl CumulativePropagationHandler {
                 let full_explanation = add_propagating_task_predicate_lower_bound(
                     full_explanation,
                     self.explanation_type,
-                    &context.as_readonly(),
+                    context.as_readonly(),
                     propagating_task,
                     profiles[0],
                     None,
@@ -104,7 +104,7 @@ impl CumulativePropagationHandler {
                             profiles[current_profile_index],
                         ),
                         CumulativeExplanationType::PointWise,
-                        &context.as_readonly(),
+                        context.as_readonly(),
                         propagating_task,
                         profiles[current_profile_index],
                         Some(time_point),
@@ -168,7 +168,7 @@ impl CumulativePropagationHandler {
                 for profile in profiles {
                     let explanation = match self.explanation_type {
                         CumulativeExplanationType::Naive => {
-                            create_naive_propagation_explanation(profile, &context.as_readonly())
+                            create_naive_propagation_explanation(profile, context.as_readonly())
                         }
                         CumulativeExplanationType::BigStep => {
                             create_big_step_propagation_explanation(profile)
@@ -185,7 +185,7 @@ impl CumulativePropagationHandler {
                 let full_explanation = add_propagating_task_predicate_upper_bound(
                     full_explanation,
                     self.explanation_type,
-                    &context.as_readonly(),
+                    context.as_readonly(),
                     propagating_task,
                     profiles[profiles.len() - 1],
                     None,
@@ -209,7 +209,7 @@ impl CumulativePropagationHandler {
                             profiles[current_profile_index],
                         ),
                         CumulativeExplanationType::PointWise,
-                        &context.as_readonly(),
+                        context.as_readonly(),
                         propagating_task,
                         profiles[current_profile_index],
                         Some(time_point),
@@ -275,7 +275,7 @@ impl CumulativePropagationHandler {
                 let lower_bound_predicate_propagating_task =
                     create_predicate_propagating_task_lower_bound_propagation(
                         self.explanation_type,
-                        &context.as_readonly(),
+                        context.as_readonly(),
                         propagating_task,
                         profile,
                         None,
@@ -283,7 +283,7 @@ impl CumulativePropagationHandler {
                 context.set_lower_bound(
                     &propagating_task.start_variable,
                     profile.end + 1,
-                    move |_context: &PropagationContext| {
+                    move |_context: PropagationContext| {
                         let mut reason = (*explanation).clone();
                         reason.add(lower_bound_predicate_propagating_task);
                         reason
@@ -299,7 +299,7 @@ impl CumulativePropagationHandler {
                         let explanation = add_propagating_task_predicate_lower_bound(
                             create_pointwise_propagation_explanation(profile.end, profile),
                             CumulativeExplanationType::PointWise,
-                            &context.as_readonly(),
+                            context.as_readonly(),
                             propagating_task,
                             profile,
                             Some(profile.end),
@@ -316,7 +316,7 @@ impl CumulativePropagationHandler {
                     let explanation = add_propagating_task_predicate_lower_bound(
                         create_pointwise_propagation_explanation(time_point, profile),
                         CumulativeExplanationType::PointWise,
-                        &context.as_readonly(),
+                        context.as_readonly(),
                         propagating_task,
                         profile,
                         Some(time_point),
@@ -359,7 +359,7 @@ impl CumulativePropagationHandler {
                 let upper_bound_predicate_propagating_task =
                     create_predicate_propagating_task_upper_bound_propagation(
                         self.explanation_type,
-                        &context.as_readonly(),
+                        context.as_readonly(),
                         propagating_task,
                         profile,
                         None,
@@ -367,7 +367,7 @@ impl CumulativePropagationHandler {
                 context.set_upper_bound(
                     &propagating_task.start_variable,
                     profile.start - propagating_task.processing_time,
-                    move |_context: &PropagationContext| {
+                    move |_context: PropagationContext| {
                         let mut reason = (*explanation).clone();
                         reason.add(upper_bound_predicate_propagating_task);
                         reason
@@ -382,7 +382,7 @@ impl CumulativePropagationHandler {
                         let explanation = add_propagating_task_predicate_upper_bound(
                             create_pointwise_propagation_explanation(profile.start, profile),
                             CumulativeExplanationType::PointWise,
-                            &context.as_readonly(),
+                            context.as_readonly(),
                             propagating_task,
                             profile,
                             Some(profile.start),
@@ -398,7 +398,7 @@ impl CumulativePropagationHandler {
                     let explanation = add_propagating_task_predicate_upper_bound(
                         create_pointwise_propagation_explanation(time_point, profile),
                         CumulativeExplanationType::PointWise,
-                        &context.as_readonly(),
+                        context.as_readonly(),
                         propagating_task,
                         profile,
                         Some(time_point),
@@ -466,7 +466,7 @@ impl CumulativePropagationHandler {
                     context.remove(
                         &propagating_task.start_variable,
                         time_point,
-                        move |_context: &PropagationContext| (*explanation).clone(),
+                        move |_context: PropagationContext| (*explanation).clone(),
                     )?;
                 }
                 CumulativeExplanationType::PointWise => {
@@ -521,7 +521,7 @@ impl CumulativePropagationHandler {
             Rc::new(
                 match self.explanation_type {
                     CumulativeExplanationType::Naive => {
-                        create_naive_propagation_explanation(profile, &context.as_readonly())
+                        create_naive_propagation_explanation(profile, context.as_readonly())
                     },
                     CumulativeExplanationType::BigStep => {
                         create_big_step_propagation_explanation(profile)
@@ -849,7 +849,7 @@ pub(crate) mod test_propagation_handler {
                 PropagationContext::new(&self.assignments_integer, &self.assignments_propositional);
             let reason = self
                 .reason_store
-                .get_or_compute(reason_ref, &context)
+                .get_or_compute(reason_ref, context)
                 .expect("reason_ref should not be stale");
             reason.clone()
         }

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_over_interval.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_over_interval.rs
@@ -103,7 +103,7 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTableOverIntervalPropaga
         )
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         self.dynamic_structures
             .reset_all_bounds_and_remove_fixed(context, &self.parameters);
     }
@@ -124,11 +124,11 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTableOverIntervalPropaga
             &self.parameters,
             &self.dynamic_structures,
             &updated_task,
-            &context,
+            context,
             self.is_time_table_empty,
         );
         update_bounds_task(
-            &context,
+            context,
             self.dynamic_structures.get_stored_bounds_mut(),
             &updated_task,
         );
@@ -156,7 +156,7 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTableOverIntervalPropaga
         context: &mut PropagatorInitialisationContext,
     ) -> Result<(), PropositionalConjunction> {
         self.dynamic_structures
-            .initialise_bounds_and_remove_fixed(context, &self.parameters);
+            .initialise_bounds_and_remove_fixed(context.as_readonly(), &self.parameters);
         register_tasks(&self.parameters.tasks, context, false);
 
         Ok(())
@@ -428,7 +428,7 @@ pub(crate) fn debug_propagate_from_scratch_time_table_interval<Var: IntegerVaria
         context,
         time_table.iter(),
         parameters,
-        &mut dynamic_structures.recreate_from_context(&context.as_readonly(), parameters),
+        &mut dynamic_structures.recreate_from_context(context.as_readonly(), parameters),
     )
 }
 

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point.rs
@@ -96,7 +96,7 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointPropagator<
         )
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         self.dynamic_structures
             .reset_all_bounds_and_remove_fixed(context, &self.parameters)
     }
@@ -117,14 +117,14 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointPropagator<
             &self.parameters,
             &self.dynamic_structures,
             &updated_task,
-            &context,
+            context,
             self.is_time_table_empty,
         );
 
         // Note that the non-incremental proapgator does not make use of `result.updated` since it
         // propagates from scratch anyways
         update_bounds_task(
-            &context,
+            context,
             self.dynamic_structures.get_stored_bounds_mut(),
             &updated_task,
         );
@@ -152,7 +152,7 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointPropagator<
         context: &mut PropagatorInitialisationContext,
     ) -> Result<(), PropositionalConjunction> {
         self.dynamic_structures
-            .initialise_bounds_and_remove_fixed(context, &self.parameters);
+            .initialise_bounds_and_remove_fixed(context.as_readonly(), &self.parameters);
         register_tasks(&self.parameters.tasks, context, false);
 
         Ok(())
@@ -237,7 +237,7 @@ pub(crate) fn debug_propagate_from_scratch_time_table_point<Var: IntegerVariable
         context,
         time_table.values(),
         parameters,
-        &mut dynamic_structures.recreate_from_context(&context.as_readonly(), parameters),
+        &mut dynamic_structures.recreate_from_context(context.as_readonly(), parameters),
     )
 }
 

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point_incremental.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point_incremental.rs
@@ -204,7 +204,7 @@ impl<Var: IntegerVariable + 'static + Debug> TimeTablePerPointIncrementalPropaga
 
             // And we clear all of the updates since they have now necessarily been processed
             self.updatable_structures
-                .reset_all_bounds_and_remove_fixed(context, &self.parameters);
+                .reset_all_bounds_and_remove_fixed(context.as_readonly(), &self.parameters);
 
             return Ok(());
         }
@@ -293,7 +293,7 @@ impl<Var: IntegerVariable + 'static + Debug> Propagator
     fn propagate(&mut self, mut context: PropagationContextMut) -> PropagationStatusCP {
         pumpkin_assert_advanced!(
             check_bounds_equal_at_propagation(
-                &context.as_readonly(),
+                context.as_readonly(),
                 &self.parameters.tasks,
                 self.updatable_structures.get_stored_bounds(),
             ),
@@ -339,7 +339,7 @@ impl<Var: IntegerVariable + 'static + Debug> Propagator
             &self.parameters,
             &self.updatable_structures,
             &updated_task,
-            &context,
+            context,
             self.time_table.is_empty(),
         );
 
@@ -348,7 +348,7 @@ impl<Var: IntegerVariable + 'static + Debug> Propagator
         insert_update(&updated_task, &mut self.updatable_structures, result.update);
 
         update_bounds_task(
-            &context,
+            context,
             self.updatable_structures.get_stored_bounds_mut(),
             &updated_task,
         );
@@ -365,7 +365,7 @@ impl<Var: IntegerVariable + 'static + Debug> Propagator
 
     fn notify_backtrack(
         &mut self,
-        context: &PropagationContext,
+        context: PropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) {
@@ -388,7 +388,7 @@ impl<Var: IntegerVariable + 'static + Debug> Propagator
         }
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         // We now recalculate the time-table from scratch if necessary and reset all of the bounds
         // *if* incremental backtracking is disabled
         if !self.parameters.options.incremental_backtracking {
@@ -416,7 +416,7 @@ impl<Var: IntegerVariable + 'static + Debug> Propagator
     ) -> Result<(), PropositionalConjunction> {
         register_tasks(&self.parameters.tasks, context, true);
         self.updatable_structures
-            .reset_all_bounds_and_remove_fixed(context, &self.parameters);
+            .reset_all_bounds_and_remove_fixed(context.as_readonly(), &self.parameters);
 
         // Then we do normal propagation
         self.time_table =

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_util.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_util.rs
@@ -46,7 +46,7 @@ pub(crate) fn should_enqueue<Var: IntegerVariable + 'static>(
     parameters: &CumulativeParameters<Var>,
     dynamic_structures: &UpdatableStructures<Var>,
     updated_task: &Rc<Task<Var>>,
-    context: &PropagationContext,
+    context: PropagationContext,
     empty_time_table: bool,
 ) -> ShouldEnqueueResult<Var> {
     pumpkin_assert_extreme!(
@@ -107,7 +107,7 @@ pub(crate) fn should_enqueue<Var: IntegerVariable + 'static>(
 }
 
 pub(crate) fn has_mandatory_part<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
 ) -> bool {
     context.upper_bound(&task.start_variable)
@@ -117,7 +117,7 @@ pub(crate) fn has_mandatory_part<Var: IntegerVariable + 'static>(
 /// Checks whether a specific task (indicated by id) has a mandatory part which overlaps with the
 /// interval [start, end]
 pub(crate) fn has_mandatory_part_in_interval<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     start: i32,
     end: i32,
@@ -134,7 +134,7 @@ pub(crate) fn has_mandatory_part_in_interval<Var: IntegerVariable + 'static>(
 
 /// Checks whether the lower and upper bound of a task overlap with the provided interval
 pub(crate) fn task_has_overlap_with_interval<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     start: i32,
     end: i32,
@@ -370,7 +370,7 @@ fn propagate_sequence_of_profiles<'a, Var: IntegerVariable + 'static>(
 
             // Then we check what propagations can be performed
             if lower_bound_can_be_propagated_by_profile(
-                &context.as_readonly(),
+                context.as_readonly(),
                 task,
                 profile,
                 parameters.capacity,
@@ -380,7 +380,7 @@ fn propagate_sequence_of_profiles<'a, Var: IntegerVariable + 'static>(
                 let last_index = find_index_last_profile_which_propagates_lower_bound(
                     profile_index,
                     &time_table,
-                    &context.as_readonly(),
+                    context.as_readonly(),
                     task,
                     parameters.capacity,
                 );
@@ -399,7 +399,7 @@ fn propagate_sequence_of_profiles<'a, Var: IntegerVariable + 'static>(
             }
 
             if upper_bound_can_be_propagated_by_profile(
-                &context.as_readonly(),
+                context.as_readonly(),
                 task,
                 profile,
                 parameters.capacity,
@@ -410,7 +410,7 @@ fn propagate_sequence_of_profiles<'a, Var: IntegerVariable + 'static>(
                 let first_index = find_index_last_profile_which_propagates_upper_bound(
                     profile_index,
                     &time_table,
-                    &context.as_readonly(),
+                    context.as_readonly(),
                     task,
                     parameters.capacity,
                 );
@@ -449,7 +449,7 @@ fn propagate_sequence_of_profiles<'a, Var: IntegerVariable + 'static>(
 fn find_index_last_profile_which_propagates_lower_bound<Var: IntegerVariable + 'static>(
     profile_index: usize,
     time_table: &[&ResourceProfile<Var>],
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     capacity: i32,
 ) -> usize {
@@ -472,7 +472,7 @@ fn find_index_last_profile_which_propagates_lower_bound<Var: IntegerVariable + '
 fn find_index_last_profile_which_propagates_upper_bound<Var: IntegerVariable + 'static>(
     profile_index: usize,
     time_table: &[&ResourceProfile<Var>],
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     capacity: i32,
 ) -> usize {
@@ -508,7 +508,7 @@ fn find_index_last_profile_which_propagates_upper_bound<Var: IntegerVariable + '
 /// Note: It is assumed that task.resource_usage + height > capacity (i.e. the task has the
 /// potential to overflow the capacity in combination with the profile)
 fn lower_bound_can_be_propagated_by_profile<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     profile: &ResourceProfile<Var>,
     capacity: i32,
@@ -528,7 +528,7 @@ fn lower_bound_can_be_propagated_by_profile<Var: IntegerVariable + 'static>(
 ///     * ub(s) <= end, i.e. the latest start time is before the end of the [`ResourceProfile`]
 /// Note: It is assumed that the task is known to overflow the [`ResourceProfile`]
 fn upper_bound_can_be_propagated_by_profile<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     profile: &ResourceProfile<Var>,
     capacity: i32,
@@ -548,7 +548,7 @@ fn upper_bound_can_be_propagated_by_profile<Var: IntegerVariable + 'static>(
 /// If the first condition is true, the second false and the third true then this method returns
 /// true (otherwise it returns false)
 fn can_be_updated_by_profile<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     task: &Rc<Task<Var>>,
     profile: &ResourceProfile<Var>,
     capacity: i32,
@@ -577,7 +577,7 @@ fn find_possible_updates<Var: IntegerVariable + 'static>(
     profile: &ResourceProfile<Var>,
     parameters: &CumulativeParameters<Var>,
 ) -> Vec<CanUpdate> {
-    if !can_be_updated_by_profile(&context.as_readonly(), task, profile, parameters.capacity) {
+    if !can_be_updated_by_profile(context.as_readonly(), task, profile, parameters.capacity) {
         // If the task cannot be updated by the profile then we simply return the empty list
         vec![]
     } else {
@@ -585,7 +585,7 @@ fn find_possible_updates<Var: IntegerVariable + 'static>(
         let mut result = vec![];
 
         if lower_bound_can_be_propagated_by_profile(
-            &context.as_readonly(),
+            context.as_readonly(),
             task,
             profile,
             parameters.capacity,
@@ -594,7 +594,7 @@ fn find_possible_updates<Var: IntegerVariable + 'static>(
             result.push(CanUpdate::LowerBound)
         }
         if upper_bound_can_be_propagated_by_profile(
-            &context.as_readonly(),
+            context.as_readonly(),
             task,
             profile,
             parameters.capacity,
@@ -622,7 +622,7 @@ pub(crate) fn insert_update<Var: IntegerVariable + 'static>(
 }
 
 pub(crate) fn backtrack_update<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     dynamic_structures: &mut UpdatableStructures<Var>,
     updated_task: &Rc<Task<Var>>,
 ) {

--- a/pumpkin-solver/src/propagators/cumulative/utils/structs/updatable_structures.rs
+++ b/pumpkin-solver/src/propagators/cumulative/utils/structs/updatable_structures.rs
@@ -106,9 +106,9 @@ impl<Var: IntegerVariable + 'static> UpdatableStructures<Var> {
 
     /// Resets all of the bounds to the current values in the context and removes all of the fixed
     /// tasks from the internal structure(s).
-    pub(crate) fn reset_all_bounds_and_remove_fixed<Context: ReadDomains>(
+    pub(crate) fn reset_all_bounds_and_remove_fixed(
         &mut self,
-        context: &Context,
+        context: PropagationContext,
         parameters: &CumulativeParameters<Var>,
     ) {
         for task in parameters.tasks.iter() {
@@ -156,9 +156,9 @@ impl<Var: IntegerVariable + 'static> UpdatableStructures<Var> {
     }
 
     // Initialises all stored bounds to their current values and removes any tasks which are fixed
-    pub(crate) fn initialise_bounds_and_remove_fixed<Context: ReadDomains>(
+    pub(crate) fn initialise_bounds_and_remove_fixed(
         &mut self,
-        context: &Context,
+        context: PropagationContext,
         parameters: &CumulativeParameters<Var>,
     ) {
         for task in parameters.tasks.iter() {
@@ -228,7 +228,7 @@ impl<Var: IntegerVariable + 'static> UpdatableStructures<Var> {
     /// Used for creating the dynamic structures from the provided context
     pub(crate) fn recreate_from_context(
         &self,
-        context: &PropagationContext,
+        context: PropagationContext,
         parameters: &CumulativeParameters<Var>,
     ) -> Self {
         let mut other = self.clone();

--- a/pumpkin-solver/src/propagators/cumulative/utils/util.rs
+++ b/pumpkin-solver/src/propagators/cumulative/utils/util.rs
@@ -78,7 +78,7 @@ pub(crate) fn register_tasks<Var: IntegerVariable + 'static>(
 /// Updates the bounds of the provided [`Task`] to those stored in
 /// `context`.
 pub(crate) fn update_bounds_task<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     bounds: &mut [(i32, i32)],
     task: &Rc<Task<Var>>,
 ) {
@@ -90,7 +90,7 @@ pub(crate) fn update_bounds_task<Var: IntegerVariable + 'static>(
 
 /// Determines whether the stored bounds are equal when propagation occurs
 pub(crate) fn check_bounds_equal_at_propagation<Var: IntegerVariable + 'static>(
-    context: &PropagationContext,
+    context: PropagationContext,
     tasks: &[Rc<Task<Var>>],
     bounds: &[(i32, i32)],
 ) -> bool {

--- a/pumpkin-solver/src/propagators/element.rs
+++ b/pumpkin-solver/src/propagators/element.rs
@@ -140,7 +140,7 @@ impl<VX: IntegerVariable + 'static, VI: IntegerVariable, VE: IntegerVariable> Pr
                         ))
                     }));
                     let x_i = (*x_i).clone();
-                    context.remove(&self.index, i, move |_context: &PropagationContext| {
+                    context.remove(&self.index, i, move |_context: PropagationContext| {
                         let mut reason = reason_info.0.clone();
                         reason_info
                             .1
@@ -166,7 +166,7 @@ impl<VX: IntegerVariable + 'static, VI: IntegerVariable, VE: IntegerVariable> Pr
                         ))
                     }));
                     let array = Rc::clone(&self.array);
-                    context.remove(&self.rhs, e, move |_context: &PropagationContext| {
+                    context.remove(&self.rhs, e, move |_context: PropagationContext| {
                         let mut reason = reason_info.0.clone();
                         reason_info
                             .1

--- a/pumpkin-solver/src/propagators/reified_propagator.rs
+++ b/pumpkin-solver/src/propagators/reified_propagator.rs
@@ -65,7 +65,7 @@ impl<WrappedPropagator: Propagator> Propagator for ReifiedPropagator<WrappedProp
 
     fn notify_backtrack(
         &mut self,
-        context: &PropagationContext,
+        context: PropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) {
@@ -116,7 +116,7 @@ impl<WrappedPropagator: Propagator> Propagator for ReifiedPropagator<WrappedProp
         self.propagator.priority()
     }
 
-    fn synchronise(&mut self, context: &PropagationContext) {
+    fn synchronise(&mut self, context: PropagationContext) {
         // We remove the inconsistency upon backtracking since it might be invalid now
         self.inconsistency = None;
 


### PR DESCRIPTION
Since `PropagationContext` implements `Copy`, functions should never take a parameter borrowing `PropagationContext`. It should always be taken with ownership.