### PR TITLE
feat: implement consistency check interface in linear less than propagator

### DIFF
--- a/pumpkin-solver/src/propagators/arithmetic/linear_less_or_equal.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/linear_less_or_equal.rs
@@ -2,18 +2,27 @@ use crate::basic_types::PropagationStatusCP;
 use crate::basic_types::PropositionalConjunction;
 use crate::engine::cp::propagation::ReadDomains;
 use crate::engine::domain_events::DomainEvents;
+use crate::engine::opaque_domain_event::OpaqueDomainEvent;
+use crate::engine::propagation::EnqueueDecision;
 use crate::engine::propagation::LocalId;
+use crate::engine::propagation::PropagationContext;
 use crate::engine::propagation::PropagationContextMut;
 use crate::engine::propagation::Propagator;
 use crate::engine::propagation::PropagatorInitialisationContext;
 use crate::engine::variables::IntegerVariable;
 use crate::predicate;
+use crate::pumpkin_assert_simple;
 
 /// Propagator for the constraint `reif => \sum x_i <= c`.
 #[derive(Clone, Debug)]
 pub(crate) struct LinearLessOrEqualPropagator<Var> {
     x: Box<[Var]>,
     c: i32,
+
+    /// The lower bound of the sum of the left-hand side. This is incremental state.
+    lower_bound_left_hand_side: i32,
+    /// The value at index `i` is the bound for `x[i]`.
+    current_bounds: Box<[i32]>,
 }
 
 impl<Var> LinearLessOrEqualPropagator<Var>
@@ -21,7 +30,31 @@ where
     Var: IntegerVariable,
 {
     pub(crate) fn new(x: Box<[Var]>, c: i32) -> Self {
-        LinearLessOrEqualPropagator::<Var> { x, c }
+        let current_bounds = vec![0; x.len()].into();
+
+        // incremental state will be properly initialized in `Propagator::initialise_at_root`.
+        LinearLessOrEqualPropagator::<Var> {
+            x,
+            c,
+            lower_bound_left_hand_side: 0,
+            current_bounds,
+        }
+    }
+
+    /// Recalculates the incremental state from scratch.
+    fn recalculate_incremental_state(&mut self, context: PropagationContext) {
+        self.lower_bound_left_hand_side = self
+            .x
+            .iter()
+            .map(|var| context.lower_bound(var))
+            .sum::<i32>();
+
+        self.current_bounds
+            .iter_mut()
+            .enumerate()
+            .for_each(|(index, bound)| {
+                *bound = context.lower_bound(&self.x[index]);
+            });
     }
 }
 
@@ -41,7 +74,56 @@ where
             );
         });
 
-        Ok(())
+        self.recalculate_incremental_state(context.as_readonly());
+
+        if let Some(conjunction) = self.detect_inconsistency(context.as_readonly()) {
+            Err(conjunction)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn detect_inconsistency(
+        &self,
+        context: PropagationContext,
+    ) -> Option<PropositionalConjunction> {
+        if self.c < self.lower_bound_left_hand_side {
+            let reason: PropositionalConjunction = self
+                .x
+                .iter()
+                .map(|var| predicate![var >= context.lower_bound(var)])
+                .collect();
+            Some(reason)
+        } else {
+            None
+        }
+    }
+
+    fn notify(
+        &mut self,
+        context: PropagationContext,
+        local_id: LocalId,
+        _event: OpaqueDomainEvent,
+    ) -> EnqueueDecision {
+        let index = local_id.unpack() as usize;
+
+        let x_i = &self.x[index];
+        let old_bound = self.current_bounds[index];
+        let new_bound = context.lower_bound(x_i);
+
+        pumpkin_assert_simple!(
+            old_bound < new_bound,
+            "propagator should only be triggered when lower bounds are tightened, old_bound={old_bound}, new_bound={new_bound}"
+        );
+
+        self.current_bounds[index] = new_bound;
+        self.lower_bound_left_hand_side += new_bound - old_bound;
+
+        EnqueueDecision::Enqueue
+    }
+
+    fn synchronise(&mut self, context: PropagationContext) {
+        self.recalculate_incremental_state(context);
     }
 
     fn priority(&self) -> u32 {
@@ -52,46 +134,37 @@ where
         "LinearLeq"
     }
 
-    fn debug_propagate_from_scratch(&self, context: PropagationContextMut) -> PropagationStatusCP {
-        perform_propagation(context, &self.x, self.c)
-    }
-}
-
-fn perform_propagation<Var: IntegerVariable>(
-    mut context: PropagationContextMut,
-    x: &[Var],
-    c: i32,
-) -> PropagationStatusCP {
-    let lb_lhs = x.iter().map(|var| context.lower_bound(var)).sum::<i32>();
-    if c < lb_lhs {
-        let reason: PropositionalConjunction = x
-            .iter()
-            .map(|var| predicate![var >= context.lower_bound(var)])
-            .collect();
-        return Err(reason.into());
-    }
-
-    for (i, x_i) in x.iter().enumerate() {
-        let bound = c - (lb_lhs - context.lower_bound(x_i));
-
-        if context.upper_bound(x_i) > bound {
-            let reason: PropositionalConjunction = x
-                .iter()
-                .enumerate()
-                .filter_map(|(j, x_j)| {
-                    if j != i {
-                        Some(predicate![x_j >= context.lower_bound(x_j)])
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            context.set_upper_bound(x_i, bound, reason)?;
+    fn debug_propagate_from_scratch(
+        &self,
+        mut context: PropagationContextMut,
+    ) -> PropagationStatusCP {
+        if let Some(conjunction) = self.detect_inconsistency(context.as_readonly()) {
+            return Err(conjunction.into());
         }
-    }
 
-    Ok(())
+        for (i, x_i) in self.x.iter().enumerate() {
+            let bound = self.c - (self.lower_bound_left_hand_side - context.lower_bound(x_i));
+
+            if context.upper_bound(x_i) > bound {
+                let reason: PropositionalConjunction = self
+                    .x
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(j, x_j)| {
+                        if j != i {
+                            Some(predicate![x_j >= context.lower_bound(x_j)])
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                context.set_upper_bound(x_i, bound, reason)?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The incremental state makes the consistency check cheap. This now improves the propagation strength when the `LinearLessThanEqual` is reified.

On benchmarks without reification this shows no difference compared to the non-incremental linear. Therefore I believe it does not need to be guarded behind an option.