### PR TITLE
feat!: introduce inference-nogoods in drcp-format

### DIFF
--- a/drcp-format/README.md
+++ b/drcp-format/README.md
@@ -18,7 +18,7 @@ Atomic constraints are used in the following proof steps:
 ### Inference
 An inference step encodes the propagation of an atomic constraint. The inference step has the following format:
 ```
-i <step_id> <premises> 0 <propagated> [c:<constraint tag>] [l:<filtering algorithm>]
+i <step_id> <premises> [0 <propagated>] [c:<constraint tag>] [l:<filtering algorithm>]
 ```
 
 The individual components:
@@ -27,6 +27,9 @@ The individual components:
   - `<propagated>` A single atomic constraint identifier.
   - `c:<constraint tag>`: _Optional_. A hint which constraint triggered the inference.
   - `l:<filtering algorithm>`: _Optional_. A hint which filtering algorithm identified the inference.
+
+  If there is no `<propagated>`, then the inference reads that the premises imply false.
+  I.e., the premises form a nogood which is enforced by a propagator.
 
 ### Nogood
 A nogood step encodes a partial assignment which cannot be extended to a solution.

--- a/drcp-format/src/reader/mod.rs
+++ b/drcp-format/src/reader/mod.rs
@@ -78,7 +78,7 @@ pub type ReadStep<'a, AtomicConstraint> =
 ///     hint_constraint_id: Some(NonZero::new(20).unwrap()),
 ///     hint_label: Some("linear_bound"),
 ///     premises: vec![lit(4), lit(5)],
-///     propagated: lit(-2),
+///     propagated: Some(lit(-2)),
 /// };
 /// assert_eq!(Some(Step::Inference(expected_inference)), inference_step);
 ///
@@ -176,7 +176,7 @@ where
                     .into_iter()
                     .map(|literal| self.atomics.to_atomic(literal))
                     .collect(),
-                propagated: self.atomics.to_atomic(propagated),
+                propagated: propagated.map(|p| self.atomics.to_atomic(p)),
             }),
 
             Step::Nogood(Nogood {
@@ -240,7 +240,7 @@ fn inference_step(input: &str) -> IResult<&str, Inference<'_, Vec<NonZero<i32>>,
             hint_constraint_id,
             hint_label,
             premises,
-            propagated,
+            propagated: Some(propagated),
         },
     )(input)
 }

--- a/drcp-format/src/reader/mod.rs
+++ b/drcp-format/src/reader/mod.rs
@@ -309,6 +309,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn inference_nogood_without_hints() {
+        let source = "i 1 4 5\n";
+        let mut reader = ProofReader::new(source.as_bytes(), std::convert::identity);
+
+        let inference_step = reader.next_step().expect("valid drcp inference step");
+        let expected_inference = Inference {
+            id: NonZero::new(1).unwrap(),
+            hint_constraint_id: None,
+            hint_label: None,
+            premises: vec![NonZero::new(4).unwrap(), NonZero::new(5).unwrap()],
+            propagated: None,
+        };
+        assert_eq!(Some(Step::Inference(expected_inference)), inference_step);
+    }
+
+    #[test]
     fn inference_nogood_with_constraint_tag_and_label() {
         let source = "i 1 4 5 c:20 l:linear_bound\n";
         let mut reader = ProofReader::new(source.as_bytes(), std::convert::identity);

--- a/drcp-format/src/steps.rs
+++ b/drcp-format/src/steps.rs
@@ -40,6 +40,8 @@ pub struct Inference<'label, Premises, Propagated> {
     /// The premises of the inference.
     pub premises: Premises,
     /// The conclusion of the inference.
+    ///
+    /// If absent, the inference implies false.
     pub propagated: Option<Propagated>,
 }
 

--- a/drcp-format/src/steps.rs
+++ b/drcp-format/src/steps.rs
@@ -40,7 +40,7 @@ pub struct Inference<'label, Premises, Propagated> {
     /// The premises of the inference.
     pub premises: Premises,
     /// The conclusion of the inference.
-    pub propagated: Propagated,
+    pub propagated: Option<Propagated>,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/drcp-format/src/writer/mod.rs
+++ b/drcp-format/src/writer/mod.rs
@@ -32,7 +32,7 @@ use crate::steps::StepId;
 ///
 /// let lit = |num: i32| NonZeroI32::new(num).unwrap();
 /// writer
-///     .log_inference(None, Some("linear_bound"), [lit(4), lit(5)], lit(-2))
+///     .log_inference(None, Some("linear_bound"), [lit(4), lit(5)], Some(lit(-2)))
 ///     .unwrap();
 /// let nogood_id = writer
 ///     .log_nogood_clause([lit(1), lit(-3), lit(5)], None::<[StepId; 0]>)
@@ -131,15 +131,18 @@ where
     /// the constraint that implied the inference, and the label of the filtering algorithm which
     /// identified the inference.
     ///
+    /// If there is no conclusion, then the format prescribes that the conclusion is false, so that
+    /// the premises form a nogood.
+    ///
     /// This function wraps an IO operation, which is why it can fail with an IO error.
     pub fn log_inference(
         &mut self,
         hint_constraint_id: Option<NonZero<u32>>,
         hint_label: Option<&str>,
         premises: impl IntoIterator<Item = Literals::Literal>,
-        propagated: Literals::Literal,
+        propagated: Option<Literals::Literal>,
     ) -> std::io::Result<StepId> {
-        let propagated = self.encountered_literals.to_code(propagated);
+        let propagated = propagated.map(|p| self.encountered_literals.to_code(p));
         let id = self.next_step_id();
 
         let inference = Inference {
@@ -254,7 +257,9 @@ where
             write!(sink, " {literal}")?;
         }
 
-        write!(sink, " 0 {}", self.propagated)?;
+        if let Some(propagated) = self.propagated {
+            write!(sink, " 0 {}", propagated)?;
+        }
 
         if let Some(constraint_id) = self.hint_constraint_id {
             write!(sink, " c:{constraint_id}")?;
@@ -300,7 +305,7 @@ mod tests {
                 hint_constraint_id: None,
                 hint_label: None,
                 premises: [lit(2), lit(-3)],
-                propagated: lit(1),
+                propagated: Some(lit(1)),
             },
             "i 1 2 -3 0 1\n",
         );
@@ -314,7 +319,7 @@ mod tests {
                 hint_constraint_id: None,
                 hint_label: Some("inf_label"),
                 premises: [lit(2), lit(-3)],
-                propagated: lit(1),
+                propagated: Some(lit(1)),
             },
             "i 1 2 -3 0 1 l:inf_label\n",
         );
@@ -328,7 +333,7 @@ mod tests {
                 hint_constraint_id: Some(NonZero::new(1).unwrap()),
                 hint_label: None,
                 premises: [lit(2), lit(-3)],
-                propagated: lit(1),
+                propagated: Some(lit(1)),
             },
             "i 1 2 -3 0 1 c:1\n",
         );
@@ -342,9 +347,23 @@ mod tests {
                 hint_constraint_id: Some(NonZero::new(1).unwrap()),
                 hint_label: Some("inf_label"),
                 premises: [lit(2), lit(-3)],
-                propagated: lit(1),
+                propagated: Some(lit(1)),
             },
             "i 1 2 -3 0 1 c:1 l:inf_label\n",
+        );
+    }
+
+    #[test]
+    fn write_inference_without_conclusion() {
+        test_step_serialization(
+            Inference {
+                id: TEST_ID,
+                hint_constraint_id: Some(NonZero::new(1).unwrap()),
+                hint_label: Some("inf_label"),
+                premises: [lit(2), lit(-3)],
+                propagated: None,
+            },
+            "i 1 2 -3 c:1 l:inf_label\n",
         );
     }
 

--- a/drcp-format/src/writer/mod.rs
+++ b/drcp-format/src/writer/mod.rs
@@ -354,7 +354,7 @@ mod tests {
     }
 
     #[test]
-    fn write_inference_without_conclusion() {
+    fn write_inference_without_conclusion_with_hints() {
         test_step_serialization(
             Inference {
                 id: TEST_ID,
@@ -364,6 +364,20 @@ mod tests {
                 propagated: None,
             },
             "i 1 2 -3 c:1 l:inf_label\n",
+        );
+    }
+
+    #[test]
+    fn write_inference_without_conclusion_without_hints() {
+        test_step_serialization(
+            Inference {
+                id: TEST_ID,
+                hint_constraint_id: None,
+                hint_label: None,
+                premises: [lit(2), lit(-3)],
+                propagated: None,
+            },
+            "i 1 2 -3\n",
         );
     }
 

--- a/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -173,7 +173,7 @@ impl ConflictAnalysisContext<'_> {
                 let _ = self.internal_parameters.proof_log.log_inference(
                     self.propagator_store.get_tag(*propagator),
                     explanation_literals.iter().map(|&lit| !lit),
-                    self.assignments_propositional.false_literal,
+                    None,
                 );
 
                 on_analysis_step(AnalysisStep::Propagation {
@@ -227,7 +227,7 @@ impl ConflictAnalysisContext<'_> {
         let _ = self.internal_parameters.proof_log.log_inference(
             self.propagator_store.get_tag(propagator),
             explanation_literals.iter().skip(1).map(|&lit| !lit),
-            propagated_literal,
+            Some(propagated_literal),
         );
 
         on_analysis_step(AnalysisStep::Propagation {

--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -1546,11 +1546,10 @@ impl ConstraintSatisfactionSolver {
 
             // The proof inference for the propagation `R -> l` is `R /\ ~l -> false`.
             let inference_premises = premises.iter().copied().chain(std::iter::once(!propagated));
-            let _ = self.internal_parameters.proof_log.log_inference(
-                tag,
-                inference_premises,
-                self.false_literal,
-            );
+            let _ = self
+                .internal_parameters
+                .proof_log
+                .log_inference(tag, inference_premises, None);
 
             // Since inference steps are only related to the nogood they directly precede,
             // facts derived at the root are also logged as nogoods so they can be used in the

--- a/pumpkin-solver/src/engine/proof/mod.rs
+++ b/pumpkin-solver/src/engine/proof/mod.rs
@@ -70,7 +70,7 @@ impl ProofLog {
         &mut self,
         constraint_tag: Option<NonZero<u32>>,
         premises: impl IntoIterator<Item = Literal>,
-        propagated: Literal,
+        propagated: Option<Literal>,
     ) -> std::io::Result<NonZeroU64> {
         let Some(ProofImpl::CpProof {
             writer,


### PR DESCRIPTION
The DRCP format is extended to support nogoods that are lazily blocked by propagators. When there is a propagation `R -> false`, then it suffices to log `R`. The README describes how this affects the textual format.