### PR TITLE
fix: ensure drcp-format version is the published one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "drcp-format"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86653dea30ca540993e498ba9b8ad9120c82cf5255dd06b4276a89fef5d62ce1"
+dependencies = [
+ "nom",
+ "thiserror",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,7 +428,7 @@ dependencies = [
  "cc",
  "clap",
  "convert_case",
- "drcp-format",
+ "drcp-format 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "enumset",
  "env_logger",
  "flatzinc",

--- a/pumpkin-solver/Cargo.toml
+++ b/pumpkin-solver/Cargo.toml
@@ -17,7 +17,7 @@ fnv = "1.0.3"
 rand = { version = "0.8.5", features = [ "small_rng" ] }
 signal-hook = "0.3.17"
 once_cell = "1.19.0"
-drcp-format = { version = "0.1.0", path = "../drcp-format" }
+drcp-format = { version = "0.1.0" }
 convert_case = "0.6.0"
 itertools = "0.13.0"
 flatzinc = "0.3.21"

--- a/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -173,7 +173,7 @@ impl ConflictAnalysisContext<'_> {
                 let _ = self.internal_parameters.proof_log.log_inference(
                     self.propagator_store.get_tag(*propagator),
                     explanation_literals.iter().map(|&lit| !lit),
-                    None,
+                    self.assignments_propositional.false_literal,
                 );
 
                 on_analysis_step(AnalysisStep::Propagation {
@@ -227,7 +227,7 @@ impl ConflictAnalysisContext<'_> {
         let _ = self.internal_parameters.proof_log.log_inference(
             self.propagator_store.get_tag(propagator),
             explanation_literals.iter().skip(1).map(|&lit| !lit),
-            Some(propagated_literal),
+            propagated_literal,
         );
 
         on_analysis_step(AnalysisStep::Propagation {

--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -1546,10 +1546,11 @@ impl ConstraintSatisfactionSolver {
 
             // The proof inference for the propagation `R -> l` is `R /\ ~l -> false`.
             let inference_premises = premises.iter().copied().chain(std::iter::once(!propagated));
-            let _ = self
-                .internal_parameters
-                .proof_log
-                .log_inference(tag, inference_premises, None);
+            let _ = self.internal_parameters.proof_log.log_inference(
+                tag,
+                inference_premises,
+                self.get_false_literal(),
+            );
 
             // Since inference steps are only related to the nogood they directly precede,
             // facts derived at the root are also logged as nogoods so they can be used in the

--- a/pumpkin-solver/src/engine/proof/mod.rs
+++ b/pumpkin-solver/src/engine/proof/mod.rs
@@ -70,7 +70,7 @@ impl ProofLog {
         &mut self,
         constraint_tag: Option<NonZero<u32>>,
         premises: impl IntoIterator<Item = Literal>,
-        propagated: Option<Literal>,
+        propagated: Literal,
     ) -> std::io::Result<NonZeroU64> {
         let Some(ProofImpl::CpProof {
             writer,


### PR DESCRIPTION
By linking to the version on the file system, when we update the `drcp-format` version, `pumpkin-solver` no-longer builds as there is no package with the required version on the file system anymore.