### PR TITLE
fix: use propagate for "<=" constraint + using solution reference from solution rather than solver 

### DIFF
--- a/pumpkin-solver/src/api/solver.rs
+++ b/pumpkin-solver/src/api/solver.rs
@@ -613,7 +613,7 @@ impl Solver {
         brancher: &mut impl Brancher,
         objective_value: Option<i64>,
     ) {
-        brancher.on_solution(self.satisfaction_solver.get_solution_reference());
+        brancher.on_solution(solution.as_reference());
 
         (self.solution_callback)(SolutionCallbackArguments::new(
             self,

--- a/pumpkin-solver/src/propagators/cumulative/time_table/propagation/mod.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/propagation/mod.rs
@@ -1,0 +1,179 @@
+mod sequence;
+mod single_profile;
+
+use std::rc::Rc;
+
+use sequence::propagate_sequence_of_profiles;
+use single_profile::propagate_single_profiles;
+
+use super::time_table_util::has_mandatory_part_in_interval;
+use crate::basic_types::PropagationStatusCP;
+use crate::engine::propagation::PropagationContext;
+use crate::engine::propagation::PropagationContextMut;
+use crate::engine::propagation::ReadDomains;
+use crate::propagators::cumulative::time_table::time_table_util::task_has_overlap_with_interval;
+use crate::propagators::CumulativeParameters;
+use crate::propagators::ResourceProfileInterface;
+use crate::propagators::Task;
+use crate::propagators::UpdatableStructures;
+use crate::pumpkin_assert_extreme;
+use crate::pumpkin_assert_moderate;
+use crate::variables::IntegerVariable;
+
+/// Checks whether propagations should occur based on the current state of the time-table.
+///
+/// It goes over all profiles and all tasks and determines which ones should be propagated;
+/// Note that this method is not idempotent and that it assumes that the [`ResourceProfile`]s are
+/// sorted in increasing order in terms of [`ResourceProfile::start`] and that the
+/// [`ResourceProfile`] is maximal (i.e. the [`ResourceProfile::start`] and [`ResourceProfile::end`]
+/// cannot be increased or decreased, respectively).
+pub(crate) fn propagate_based_on_timetable<'a, Var: IntegerVariable + 'static>(
+    context: &mut PropagationContextMut,
+    time_table: impl Iterator<Item = &'a mut (impl ResourceProfileInterface<Var> + 'a)>,
+    parameters: &CumulativeParameters<Var>,
+    updatable_structures: &mut UpdatableStructures<Var>,
+) -> PropagationStatusCP {
+    pumpkin_assert_extreme!(
+        updatable_structures
+            .get_unfixed_tasks()
+            .all(|unfixed_task| !context.is_fixed(&unfixed_task.start_variable)),
+        "All of the unfixed tasks should not be fixed at this point"
+    );
+    pumpkin_assert_extreme!(
+        updatable_structures
+            .get_fixed_tasks()
+            .all(|fixed_task| context.is_fixed(&fixed_task.start_variable)),
+        "All of the fixed tasks should be fixed at this point"
+    );
+
+    if parameters.options.generate_sequence {
+        propagate_sequence_of_profiles(context, time_table, updatable_structures, parameters)?;
+    } else {
+        propagate_single_profiles(context, time_table, updatable_structures, parameters)?;
+    }
+
+    Ok(())
+}
+
+/// Determines whether the lower bound of a task can be propagated by a [`ResourceProfile`] with the
+/// provided start time and end time; This method checks the following conditions:
+///     * lb(s) + p > start, i.e. the earliest completion time of the task is after the start of the
+///       [`ResourceProfile`]
+///     * lb(s) <= end, i.e. the earliest start time is before the end of the [`ResourceProfile`]
+///
+/// Note: It is assumed that task.resource_usage + height > capacity (i.e. the task has the
+/// potential to overflow the capacity in combination with the profile)
+fn lower_bound_can_be_propagated_by_profile<
+    Var: IntegerVariable + 'static,
+    ResourceProfileType: ResourceProfileInterface<Var>,
+>(
+    context: PropagationContext,
+    task: &Rc<Task<Var>>,
+    profile: &ResourceProfileType,
+    capacity: i32,
+) -> bool {
+    pumpkin_assert_moderate!(
+        profile.get_height() + task.resource_usage > capacity
+            && task_has_overlap_with_interval(context, task, profile.get_start(), profile.get_end())
+    , "It is checked whether a task can be propagated while the invariants do not hold - The task should overflow the capacity with the profile");
+    (context.lower_bound(&task.start_variable) + task.processing_time) > profile.get_start()
+        && context.lower_bound(&task.start_variable) <= profile.get_end()
+}
+
+/// Determines whether the upper bound of a task can be propagated by a [`ResourceProfile`] with the
+/// provided start time and end time This method checks the following conditions:
+///     * ub(s) + p > start, i.e. the latest completion time is after the start of the
+///       [`ResourceProfile`]
+///     * ub(s) <= end, i.e. the latest start time is before the end of the [`ResourceProfile`]
+/// Note: It is assumed that the task is known to overflow the [`ResourceProfile`]
+fn upper_bound_can_be_propagated_by_profile<
+    Var: IntegerVariable + 'static,
+    ResourceProfileType: ResourceProfileInterface<Var>,
+>(
+    context: PropagationContext,
+    task: &Rc<Task<Var>>,
+    profile: &ResourceProfileType,
+    capacity: i32,
+) -> bool {
+    pumpkin_assert_moderate!(
+        profile.get_height()+ task.resource_usage > capacity
+    , "It is checked whether a task can be propagated while the invariants do not hold - The task should overflow the capacity with the profile");
+    (context.upper_bound(&task.start_variable) + task.processing_time) > profile.get_start()
+        && context.upper_bound(&task.start_variable) <= profile.get_end()
+}
+
+/// Returns whether the provided `task` can be updated by the profile by checking the following:
+/// 1. Whether the task and the profile together would overflow the resource capacity
+/// 2. Whether the task has a mandatory part in the profile
+/// 3. Whether the bounds of the task overlap with the profile
+///
+/// If the first condition is true, the second false and the third true then this method returns
+/// true (otherwise it returns false)
+fn can_be_updated_by_profile<
+    Var: IntegerVariable + 'static,
+    ResourceProfileType: ResourceProfileInterface<Var>,
+>(
+    context: PropagationContext,
+    task: &Rc<Task<Var>>,
+    profile: &ResourceProfileType,
+    capacity: i32,
+) -> bool {
+    profile.get_height() + task.resource_usage > capacity
+        && !has_mandatory_part_in_interval(context, task, profile.get_start(), profile.get_end())
+        && task_has_overlap_with_interval(context, task, profile.get_start(), profile.get_end())
+}
+
+/// An enum which represents which values can be updated by a profile
+enum CanUpdate {
+    LowerBound,
+    UpperBound,
+    Holes,
+}
+
+/// The method checks whether the current task can be propagated by the provided profile and (if
+/// appropriate) performs the propagation. It then returns whether any of the propagations led to a
+/// conflict or whether all propagations were succesful.
+///
+/// Note that this method can only find [`Inconsistency::EmptyDomain`] conflicts which means that we
+/// handle that error in the parent function
+fn find_possible_updates<
+    Var: IntegerVariable + 'static,
+    ResourceProfileType: ResourceProfileInterface<Var>,
+>(
+    context: &mut PropagationContextMut,
+    task: &Rc<Task<Var>>,
+    profile: &ResourceProfileType,
+    parameters: &CumulativeParameters<Var>,
+) -> Vec<CanUpdate> {
+    if !can_be_updated_by_profile(context.as_readonly(), task, profile, parameters.capacity) {
+        // If the task cannot be updated by the profile then we simply return the empty list
+        vec![]
+    } else {
+        // The task could be updated by the profile!
+        let mut result = vec![];
+
+        if lower_bound_can_be_propagated_by_profile(
+            context.as_readonly(),
+            task,
+            profile,
+            parameters.capacity,
+        ) {
+            // The lower-bound of the task can be updated by the profile
+            result.push(CanUpdate::LowerBound)
+        }
+        if upper_bound_can_be_propagated_by_profile(
+            context.as_readonly(),
+            task,
+            profile,
+            parameters.capacity,
+        ) {
+            // The upper-bound of the task can be updated by the profile
+            result.push(CanUpdate::UpperBound)
+        }
+        if parameters.options.allow_holes_in_domain {
+            // Holes can be created in the domain of the task by the profile
+            result.push(CanUpdate::Holes)
+        }
+        result
+    }
+}

--- a/pumpkin-solver/src/propagators/cumulative/time_table/propagation/sequence.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/propagation/sequence.rs
@@ -1,0 +1,224 @@
+use std::cmp::max;
+use std::rc::Rc;
+
+use super::can_be_updated_by_profile;
+use super::find_possible_updates;
+use super::lower_bound_can_be_propagated_by_profile;
+use super::upper_bound_can_be_propagated_by_profile;
+use crate::basic_types::PropagationStatusCP;
+use crate::engine::cp::propagation::propagation_context::ReadDomains;
+use crate::engine::propagation::PropagationContext;
+use crate::engine::propagation::PropagationContextMut;
+use crate::propagators::cumulative::time_table::propagation_handler::CumulativePropagationHandler;
+use crate::propagators::CumulativeParameters;
+use crate::propagators::ResourceProfileInterface;
+use crate::propagators::Task;
+use crate::propagators::UpdatableStructures;
+use crate::variables::IntegerVariable;
+
+/// For each task this method goes through the profiles in chronological order to find one which can
+/// update the task's bounds.
+///
+/// If it can find such a profile then it proceeds to generate a sequence of profiles
+/// which can propagate the bound of the task and uses these to explain the propagation rather than
+/// the individual profiles (for propagating individual profiles see [`propagate_single_profiles`]).
+///
+/// Especially in the case of [`CumulativeExplanationType::Pointwise`] this is likely to be
+/// beneficial.
+pub(crate) fn propagate_sequence_of_profiles<'a, Var: IntegerVariable + 'static>(
+    context: &mut PropagationContextMut,
+    time_table: impl Iterator<Item = &'a mut (impl ResourceProfileInterface<Var> + 'a)>,
+    updatable_structures: &UpdatableStructures<Var>,
+    parameters: &CumulativeParameters<Var>,
+) -> PropagationStatusCP {
+    // We create the structure responsible for propagations and explanations
+    let mut propagation_handler =
+        CumulativePropagationHandler::new(parameters.options.explanation_type);
+
+    // We collect the time-table since we will need to index into it
+    let time_table = time_table.collect::<Vec<_>>();
+
+    // Then we go over all the possible tasks
+    for task in updatable_structures.get_unfixed_tasks() {
+        if context.is_fixed(&task.start_variable) {
+            // If the task is fixed then we are not able to propagate it further
+            continue;
+        }
+
+        // Then we go over all the different profiles
+        let mut profile_index = 0;
+        'profile_loop: while profile_index < time_table.len() {
+            let profile = &time_table[profile_index];
+
+            if profile.get_start()
+                > context.upper_bound(&task.start_variable) + task.processing_time
+            {
+                // The profiles are sorted, if we cannot update using this one then we cannot update
+                // using the subsequent profiles, we can break from the loop
+                break 'profile_loop;
+            }
+
+            let possible_upates = find_possible_updates(context, task, *profile, parameters);
+
+            if possible_upates.is_empty() {
+                // The task cannot be propagate by the profile so we move to the next one
+                profile_index += 1;
+                continue;
+            }
+
+            // Keep track of the next profile index to use after we generate the sequence of
+            // profiles
+            let mut new_profile_index = profile_index;
+
+            // Then we check what propagations can be performed
+            if lower_bound_can_be_propagated_by_profile(
+                context.as_readonly(),
+                task,
+                *profile,
+                parameters.capacity,
+            ) {
+                // We find the index (non-inclusive) of the last profile in the chain of lower-bound
+                // propagations
+                let last_index = find_index_last_profile_which_propagates_lower_bound(
+                    profile_index,
+                    time_table.iter().map(|element| &**element),
+                    context.as_readonly(),
+                    task,
+                    parameters.capacity,
+                );
+
+                // Then we provide the propagation handler with the chain of profiles and propagate
+                // all of them
+                propagation_handler.propagate_chain_of_lower_bounds_with_explanations(
+                    context,
+                    time_table[profile_index..last_index]
+                        .iter()
+                        .map(|element| &**element),
+                    task,
+                )?;
+
+                // Then we set the new profile index to the last index, note that this index (since
+                // it is non-inclusive) will always be larger than the current profile index
+                new_profile_index = last_index;
+            }
+
+            if upper_bound_can_be_propagated_by_profile(
+                context.as_readonly(),
+                task,
+                *profile,
+                parameters.capacity,
+            ) {
+                // We find the index (inclusive) of the last profile in the chain of upper-bound
+                // propagations (note that the index of this last profile in the chain is `<=
+                // profile_index`)
+                let first_index = find_index_last_profile_which_propagates_upper_bound(
+                    profile_index,
+                    time_table.iter().map(|element| &**element),
+                    context.as_readonly(),
+                    task,
+                    parameters.capacity,
+                );
+                // Then we provide the propagation handler with the chain of profiles and propagate
+                // all of them
+                propagation_handler.propagate_chain_of_upper_bounds_with_explanations(
+                    context,
+                    time_table[first_index..=profile_index]
+                        .iter()
+                        .map(|element| &**element),
+                    task,
+                )?;
+
+                // Then we set the new profile index to maximum of the previous value of the new
+                // profile index and the next profile index
+                new_profile_index = max(new_profile_index, profile_index + 1);
+            }
+
+            if parameters.options.allow_holes_in_domain {
+                // If we allow the propagation of holes in the domain then we simply let the
+                // propagation handler handle it
+                propagation_handler.propagate_holes_in_domain(context, *profile, task)?;
+
+                // Then we set the new profile index to maximum of the previous value of the new
+                // profile index and the next profile index
+                new_profile_index = max(new_profile_index, profile_index + 1);
+            }
+
+            // Finally, we simply set the profile index to the index of the new profile
+            profile_index = max(new_profile_index, profile_index + 1);
+        }
+    }
+    Ok(())
+}
+
+/// Returns the index of the profile which cannot propagate the lower-bound of the provided task any
+/// further based on the propagation of the upper-bound due to `time_table[profile_index]`.
+fn find_index_last_profile_which_propagates_lower_bound<
+    'a,
+    Var: IntegerVariable + 'static,
+    ResourceProfileType: ResourceProfileInterface<Var> + 'a,
+>(
+    profile_index: usize,
+    time_table: impl Iterator<Item = &'a ResourceProfileType>,
+    context: PropagationContext,
+    task: &Rc<Task<Var>>,
+    capacity: i32,
+) -> usize {
+    let mut time_table = time_table.enumerate().peekable().skip(profile_index);
+
+    let (mut index, mut current_profile) = time_table
+        .next()
+        .expect("Expected the number of profiles to exist to at least be equal to the next");
+    for (next_index, next_profile) in time_table {
+        if next_profile.get_start() - current_profile.get_end() >= task.processing_time
+            || !can_be_updated_by_profile(context, task, next_profile, capacity)
+            || !lower_bound_can_be_propagated_by_profile(context, task, next_profile, capacity)
+        {
+            break;
+        }
+        index = next_index;
+        current_profile = next_profile;
+    }
+    // Note that the index is non-inclusive
+    index + 1
+}
+
+/// Returns the index of the last profile which could propagate the upper-bound of the task based on
+/// the propagation of the upper-bound due to `time_table[profile_index]`.
+fn find_index_last_profile_which_propagates_upper_bound<
+    'a,
+    Var: IntegerVariable + 'static,
+    ResourceProfileType: ResourceProfileInterface<Var> + 'a,
+>(
+    profile_index: usize,
+    time_table: impl DoubleEndedIterator<Item = &'a ResourceProfileType> + ExactSizeIterator,
+    context: PropagationContext,
+    task: &Rc<Task<Var>>,
+    capacity: i32,
+) -> usize {
+    if profile_index == 0 {
+        return 0;
+    }
+    let num_profiles = time_table.len();
+    let mut time_table = time_table
+        .enumerate()
+        .rev()
+        .skip(num_profiles - profile_index - 1);
+
+    let (mut index, mut current_profile) = time_table
+        .next()
+        .expect("Expected element to exists at position {profile_index}");
+    for (previous_index, previous_profile) in time_table {
+        if current_profile.get_start() - previous_profile.get_end() >= task.processing_time
+            || !can_be_updated_by_profile(context, task, previous_profile, capacity)
+            || !upper_bound_can_be_propagated_by_profile(context, task, previous_profile, capacity)
+        {
+            // The index here is already correctly set
+            break;
+        }
+
+        current_profile = previous_profile;
+        index = previous_index;
+    }
+    // Note that the index is inclusive
+    index
+}

--- a/pumpkin-solver/src/propagators/cumulative/time_table/propagation/single_profile.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/propagation/single_profile.rs
@@ -1,0 +1,97 @@
+use super::CanUpdate;
+use crate::basic_types::PropagationStatusCP;
+use crate::engine::cp::propagation::propagation_context::ReadDomains;
+use crate::engine::propagation::PropagationContextMut;
+use crate::propagators::cumulative::time_table::propagation::find_possible_updates;
+use crate::propagators::cumulative::time_table::propagation_handler::CumulativePropagationHandler;
+use crate::propagators::CumulativeParameters;
+use crate::propagators::ResourceProfileInterface;
+use crate::propagators::UpdatableStructures;
+use crate::variables::IntegerVariable;
+
+/// For each profile in chronological order, this method goes through the tasks and checks whether
+/// the profile can propagate the domain of the task.
+///
+/// If it can then it will immediately propagate it even if this propagation would cause subsequent
+/// propagations by the next profile. For a method which propagates based on a sequence of profiles
+/// see [`propagate_sequence_of_profiles`].
+///
+/// This type of propagation is likely to be less beneficial for the explanation
+/// [`CumulativeExplanationType::Pointwise`].
+pub(crate) fn propagate_single_profiles<'a, Var: IntegerVariable + 'static>(
+    context: &mut PropagationContextMut,
+    time_table: impl Iterator<Item = &'a mut (impl ResourceProfileInterface<Var> + 'a)>,
+    updatable_structures: &mut UpdatableStructures<Var>,
+    parameters: &CumulativeParameters<Var>,
+) -> PropagationStatusCP {
+    // We create the structure responsible for propagations and explanations
+    let mut propagation_handler =
+        CumulativePropagationHandler::new(parameters.options.explanation_type);
+
+    // Then we go over all of the profiles in the time-table
+    'profile_loop: for profile in time_table {
+        // We indicate to the propagation handler that we cannot re-use an existing profile
+        // explanation
+        propagation_handler.next_profile();
+
+        // Then we go over all the different tasks
+        let mut task_index = 0;
+        while task_index
+            < if profile.is_updated() {
+                updatable_structures.number_of_unfixed_tasks()
+            } else {
+                updatable_structures.number_of_updated_tasks()
+            }
+        {
+            let task = if profile.is_updated() {
+                updatable_structures.get_unfixed_task_at_index(task_index)
+            } else {
+                updatable_structures.get_updated_task_at_index(task_index)
+            };
+            if context.is_fixed(&task.start_variable)
+                || profile.get_start()
+                    > context.upper_bound(&task.start_variable) + task.processing_time
+            {
+                // The task is currently fixed after propagating
+                //
+                // Note that we fix this task temporarily and then wait for the notification to
+                // come in before properly fixing it - this is to avoid fixing a task without ever
+                // receiving the notification for it (which would result in a task never becoming
+                // unfixed since no backtrack notification would occur)
+                updatable_structures.temporarily_remove_task_from_unfixed(&task);
+                updatable_structures.remove_task_from_updated(&task);
+                if updatable_structures.has_no_unfixed_tasks() {
+                    // There are no tasks left to consider, we can exit the loop
+                    break 'profile_loop;
+                }
+                continue;
+            }
+
+            task_index += 1;
+
+            // We get the updates which are possible (i.e. a lower-bound update, an upper-bound
+            // update or a hole in the domain)
+            let possible_updates = find_possible_updates(context, &task, profile, parameters);
+            for possible_update in possible_updates {
+                // For every possible update we let the propagation handler propagate
+                let result = match possible_update {
+                    CanUpdate::LowerBound => propagation_handler
+                        .propagate_lower_bound_with_explanations(context, profile, &task),
+                    CanUpdate::UpperBound => propagation_handler
+                        .propagate_upper_bound_with_explanations(context, profile, &task),
+                    CanUpdate::Holes => {
+                        propagation_handler.propagate_holes_in_domain(context, profile, &task)
+                    }
+                };
+                if result.is_err() {
+                    updatable_structures.restore_temporarily_removed();
+                    result?;
+                }
+            }
+        }
+
+        profile.mark_processed();
+    }
+    updatable_structures.restore_temporarily_removed();
+    Ok(())
+}


### PR DESCRIPTION
Currently, the "<="  propagator uses incremental state in the `debug_propagate_from_scratch` method which leads to test failures when using extreme asserts.

This PR addresses this by creating a separate `propagate` and `debug_propagate_from_scratch` implementation