### PR TITLE
fix: cumulative holes in domain incorrectly used cached profile

### DIFF
--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_util.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_util.rs
@@ -364,6 +364,8 @@ fn propagate_sequence_of_profiles<'a, Var: IntegerVariable + 'static>(
                 continue;
             }
 
+            propagation_handler.next_profile();
+
             // Keep track of the next profile index to use after we generate the sequence of
             // profiles
             let mut new_profile_index = profile_index;


### PR DESCRIPTION
When allowing holes in the domain for the cumulative constraint, the explanation was attempting to use the cached profiles even when it should not.

This PR addresses this by dropping the cached explanations whenever we move to the next profile.