### PR TITLE
fix: cumulative sequence generation found less profiles than it should + fixing issues with debug propagation

### DIFF
--- a/pumpkin-solver/src/basic_types/propositional_conjunction.rs
+++ b/pumpkin-solver/src/basic_types/propositional_conjunction.rs
@@ -16,6 +16,10 @@ impl PropositionalConjunction {
         }
     }
 
+    pub fn contains(&self, predicate: Predicate) -> bool {
+        self.predicates_in_conjunction.contains(&predicate)
+    }
+
     pub fn num_predicates(&self) -> u32 {
         self.predicates_in_conjunction.len() as u32
     }

--- a/pumpkin-solver/src/engine/debug_helper.rs
+++ b/pumpkin-solver/src/engine/debug_helper.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::iter::once;
 
 use log::debug;
 use log::warn;
@@ -236,7 +237,9 @@ impl DebugHelper {
         // Also note that the reason could contain the integer variable whose domain is propagated
         // itself
 
-        // Check
+        // Two checks are done
+        //
+        // Check #1
         // Does setting the predicates from the reason indeed lead to the propagation?
         {
             let mut assignments_integer_clone = assignments_integer.debug_create_empty_clone();
@@ -278,7 +281,7 @@ impl DebugHelper {
                     // or
                     //
                     // The conflict explanation should be a subset of the reason literals for the
-                    // proagation
+                    // propagation
                     assert!(
                         (matches!(conflict, Inconsistency::EmptyDomain)
                             && (propagated_predicate.is_integer_predicate()
@@ -341,6 +344,86 @@ impl DebugHelper {
             }
         }
 
+        // Check #2
+        // Does setting the predicates from reason while having the negated propagated predicate
+        // lead to failure?
+        //
+        // This idea is by Graeme Gange in the context of debugging lazy explanations and is closely
+        // related to reverse unit propagation
+        {
+            let mut assignments_integer_clone = assignments_integer.debug_create_empty_clone();
+
+            let mut assignments_propositional_clone =
+                assignments_propositional.debug_create_empty_clone();
+
+            let failing_predicates: Vec<Predicate> = once(!propagated_predicate)
+                .chain(reason.iter().copied())
+                .collect();
+
+            let adding_predicates_was_successful =
+                DebugHelper::debug_add_predicates_to_assignment_integers(
+                    &mut assignments_integer_clone,
+                    &failing_predicates,
+                );
+
+            let adding_propositional_predicates_was_successful =
+                DebugHelper::debug_add_predicates_to_assignment_propositional(
+                    &assignments_integer_clone,
+                    &mut assignments_propositional_clone,
+                    variable_literal_mappings,
+                    &failing_predicates,
+                );
+
+            if adding_predicates_was_successful && adding_propositional_predicates_was_successful {
+                //  now propagate using the debug propagation method
+                let mut reason_store = Default::default();
+
+                // Note that it might take multiple iterations before the conflict is reached due
+                // to the assumption that some propagators make on that they are not idempotent!
+                //
+                // This happened in the cumulative where setting the reason led to a new mandatory
+                // part being created which meant that the same propagation was not performed (i.e.
+                // it did not immediately lead to a conflict) but this new mandatory part would
+                // have led to a new mandatory part in the next call to the propagator
+                loop {
+                    let num_predicates_before = assignments_integer_clone.num_trail_entries();
+
+                    let context = PropagationContextMut::new(
+                        &mut assignments_integer_clone,
+                        &mut reason_store,
+                        &mut assignments_propositional_clone,
+                        propagator_id,
+                    );
+                    let debug_propagation_status_cp =
+                        propagator.debug_propagate_from_scratch(context);
+
+                    // We break if an error was found or if there were no more propagations (i.e.
+                    // fixpoint was reached)
+                    if debug_propagation_status_cp.is_err()
+                        || num_predicates_before == assignments_integer_clone.num_trail_entries()
+                    {
+                        assert!(
+                            debug_propagation_status_cp.is_err(),
+                            "Debug propagation could not obtain a failure by setting the reason and negating the propagated predicate.\n
+                             Propagator: '{}'\n
+                             Propagator id: '{propagator_id}'.\n
+                             The reported reason: {reason}\n
+                             Reported propagated predicate: {propagated_predicate}",
+                            propagator.name()
+                        );
+
+                        break;
+                    }
+                }
+            } else {
+                // Adding the predicates of the reason to the assignments led to failure
+                panic!(
+                    "Bug detected for '{}' propagator with id '{propagator_id}'
+                     after a reason was given by the propagator. This could indicate that the reason contained conflicting predicates.",
+                    propagator.name(),
+                );
+            }
+        }
         true
     }
 

--- a/pumpkin-solver/src/propagators/cumulative/time_table/propagation_handler.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/propagation_handler.rs
@@ -15,6 +15,7 @@ use super::explanations::pointwise::create_pointwise_conflict_explanation;
 use super::explanations::pointwise::create_pointwise_propagation_explanation;
 use super::CumulativeExplanationType;
 use crate::engine::cp::propagation::propagation_context::ReadDomains;
+use crate::engine::propagation::propagation_context::HasAssignments;
 use crate::engine::propagation::PropagationContext;
 use crate::engine::propagation::PropagationContextMut;
 use crate::engine::EmptyDomain;
@@ -23,6 +24,7 @@ use crate::propagators::cumulative::time_table::explanations::pointwise;
 use crate::propagators::ResourceProfile;
 use crate::propagators::Task;
 use crate::pumpkin_assert_advanced;
+use crate::pumpkin_assert_extreme;
 use crate::pumpkin_assert_simple;
 use crate::variables::IntegerVariable;
 
@@ -34,6 +36,16 @@ pub(crate) struct CumulativePropagationHandler {
     /// explanation and re-use it. Note that this will only be used for
     /// [`CumulativeExplanationType::Naive`] and [`CumulativeExplanationType::BigStep`].
     stored_profile_explanation: OnceCell<Rc<PropositionalConjunction>>,
+}
+
+fn check_explanation(explanation: &PropositionalConjunction, context: PropagationContext) -> bool {
+    explanation.iter().all(|&predicate| {
+        let integer_predicate = predicate.try_into().unwrap();
+
+        context
+            .assignments_integer()
+            .does_integer_predicate_hold(integer_predicate)
+    })
 }
 
 impl CumulativePropagationHandler {
@@ -86,6 +98,10 @@ impl CumulativePropagationHandler {
                     None,
                 );
 
+                pumpkin_assert_extreme!(check_explanation(
+                    &full_explanation,
+                    context.as_readonly()
+                ));
                 context.set_lower_bound(
                     &propagating_task.start_variable,
                     profiles[profiles.len() - 1].end + 1,
@@ -144,6 +160,10 @@ impl CumulativePropagationHandler {
                     profiles[profiles.len() - 1],
                     None,
                 );
+                pumpkin_assert_extreme!(check_explanation(
+                    &full_explanation,
+                    context.as_readonly()
+                ));
                 context.set_upper_bound(
                     &propagating_task.start_variable,
                     profiles[0].start - propagating_task.processing_time,
@@ -189,6 +209,7 @@ impl CumulativePropagationHandler {
                         profile,
                         None,
                     );
+                pumpkin_assert_extreme!(check_explanation(&explanation, context.as_readonly()));
                 context.set_lower_bound(
                     &propagating_task.start_variable,
                     profile.end + 1,
@@ -239,6 +260,7 @@ impl CumulativePropagationHandler {
                         profile,
                         None,
                     );
+                pumpkin_assert_extreme!(check_explanation(&explanation, context.as_readonly()));
                 context.set_upper_bound(
                     &propagating_task.start_variable,
                     profile.start - propagating_task.processing_time,
@@ -306,6 +328,7 @@ impl CumulativePropagationHandler {
                     // that `get_stored_profile_explanation_or_init` uses the
                     // explanation type to create the explanations.
                     let explanation = self.get_stored_profile_explanation_or_init(context, profile);
+                    pumpkin_assert_extreme!(check_explanation(&explanation, context.as_readonly()));
                     context.remove(
                         &propagating_task.start_variable,
                         time_point,
@@ -337,6 +360,7 @@ impl CumulativePropagationHandler {
                         corresponding_profile_explanation_point,
                         profile,
                     );
+                    pumpkin_assert_extreme!(check_explanation(&explanation, context.as_readonly()));
                     context.remove(&propagating_task.start_variable, time_point, explanation)?;
                 }
             }

--- a/pumpkin-solver/src/propagators/cumulative/utils/structs/resource_profile.rs
+++ b/pumpkin-solver/src/propagators/cumulative/utils/structs/resource_profile.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::rc::Rc;
 
 use super::Task;
@@ -6,7 +7,7 @@ use crate::variables::IntegerVariable;
 /// Structures used for storing the data related to resource profiles;
 /// A [`ResourceProfile`] represents a rectangle where the height is the cumulative mandatory
 /// resource usage of the [`profile tasks`][ResourceProfile::profile_tasks]
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct ResourceProfile<Var> {
     /// The start time of the [`ResourceProfile`] (inclusive)
     pub(crate) start: i32,
@@ -17,6 +18,16 @@ pub(crate) struct ResourceProfile<Var> {
     /// The amount of cumulative resource usage of all [`profile
     /// tasks`][ResourceProfile::profile_tasks] (i.e. the height of the rectangle)
     pub(crate) height: i32,
+}
+
+impl<Var> Debug for ResourceProfile<Var> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResourceProfile")
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .field("height", &self.height)
+            .finish()
+    }
 }
 
 impl<Var: IntegerVariable + 'static> ResourceProfile<Var> {

--- a/pumpkin-solver/src/propagators/cumulative/utils/structs/task.rs
+++ b/pumpkin-solver/src/propagators/cumulative/utils/structs/task.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::rc::Rc;
 
@@ -6,7 +7,6 @@ use crate::variables::IntegerVariable;
 
 /// Structure which stores the variables related to a task; for now, only the start times are
 /// assumed to be variable
-#[derive(Debug)]
 pub(crate) struct Task<Var> {
     /// The variable representing the start time of a task
     pub(crate) start_variable: Var,
@@ -16,6 +16,16 @@ pub(crate) struct Task<Var> {
     pub(crate) resource_usage: i32,
     /// The [`LocalId`] of the task
     pub(crate) id: LocalId,
+}
+
+impl<Var> Debug for Task<Var> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Task")
+            .field("processing_time", &self.processing_time)
+            .field("resource_usage", &self.resource_usage)
+            .field("local_id", &self.id)
+            .finish()
+    }
 }
 
 impl<Var: IntegerVariable + 'static> Task<Var> {

--- a/pumpkin-solver/src/pumpkin_asserts.rs
+++ b/pumpkin-solver/src/pumpkin_asserts.rs
@@ -1,5 +1,5 @@
 #[cfg(all(not(test), not(feature = "debug-checks")))]
-pub const PUMPKIN_ASSERT_LEVEL_DEFINITION: u8 = PUMPKIN_ASSERT_EXTREME;
+pub const PUMPKIN_ASSERT_LEVEL_DEFINITION: u8 = PUMPKIN_ASSERT_SIMPLE;
 
 #[cfg(any(test, feature = "debug-checks"))]
 pub const PUMPKIN_ASSERT_LEVEL_DEFINITION: u8 = PUMPKIN_ASSERT_EXTREME;

--- a/pumpkin-solver/src/pumpkin_asserts.rs
+++ b/pumpkin-solver/src/pumpkin_asserts.rs
@@ -1,5 +1,5 @@
 #[cfg(all(not(test), not(feature = "debug-checks")))]
-pub const PUMPKIN_ASSERT_LEVEL_DEFINITION: u8 = PUMPKIN_ASSERT_SIMPLE;
+pub const PUMPKIN_ASSERT_LEVEL_DEFINITION: u8 = PUMPKIN_ASSERT_EXTREME;
 
 #[cfg(any(test, feature = "debug-checks"))]
 pub const PUMPKIN_ASSERT_LEVEL_DEFINITION: u8 = PUMPKIN_ASSERT_EXTREME;


### PR DESCRIPTION
The aims of this PR is two-fold:
- To fix the issues with the debug propagation
    - The debug propagation did not take into account that a conflict could be directly reported when the reason for a propagation is set; in this case, it should be the case that the conflict explanation is a superset of the reported explanation
    - There was a `!=` which should have been a `==` in one of the loops which caused incorrect assertions
    
- The cumulative sequence generation was not finding the correct profiles when generating a sequence due to the fact that it checked whether a profile could cause a "full" propagation rather than checking whether a profile could cause a propagtion _after_ the previous profile in the sequence was propagated.