### PR TITLE
fix: wrong profile found for over-interval conflict explanation

### DIFF
--- a/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/debug.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/debug.rs
@@ -176,7 +176,7 @@ pub(crate) fn merge_profiles<Var: IntegerVariable + 'static>(
 /// time-table created from scratch.
 ///
 /// It is assumed that the profile tasks of both profiles do not contain duplicates
-fn are_mergeable<Var: IntegerVariable + 'static>(
+pub(crate) fn are_mergeable<Var: IntegerVariable + 'static>(
     first_profile: &ResourceProfile<Var>,
     second_profile: &ResourceProfile<Var>,
 ) -> bool {

--- a/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/synchronisation.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/synchronisation.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use super::debug::are_mergeable;
 use super::debug::merge_profiles;
 use crate::basic_types::ConflictInfo;
 use crate::basic_types::Inconsistency;
@@ -11,7 +12,43 @@ use crate::propagators::cumulative::time_table::propagation_handler::create_conf
 use crate::propagators::CumulativeParameters;
 use crate::propagators::OverIntervalTimeTableType;
 use crate::propagators::ResourceProfile;
+#[cfg(doc)]
+use crate::propagators::TimeTableOverIntervalPropagator;
 use crate::variables::IntegerVariable;
+
+/// Finds the conflicting profile which would have been found by the
+/// [`TimeTableOverIntervalPropagator`]; this is the first conflicting profile in terms of start
+/// time, however, the returned profile should be merged with adjacent profiles to create the
+/// returned conflict profile.
+pub(crate) fn find_synchronised_conflict<Var: IntegerVariable + 'static>(
+    time_table: &mut OverIntervalTimeTableType<Var>,
+    parameters: &CumulativeParameters<Var>,
+) -> Option<ResourceProfile<Var>> {
+    if time_table.is_empty() {
+        return None;
+    }
+
+    let first_conflict_profile_index = time_table
+        .iter()
+        .position(|profile| profile.height > parameters.capacity);
+    if let Some(mut first_conflict_profile_index) = first_conflict_profile_index {
+        let mut new_profile = time_table[first_conflict_profile_index].clone();
+
+        while first_conflict_profile_index < time_table.len() - 1 {
+            if are_mergeable(
+                &time_table[first_conflict_profile_index],
+                &time_table[first_conflict_profile_index + 1],
+            ) {
+                new_profile.end = time_table[first_conflict_profile_index + 1].end;
+                first_conflict_profile_index += 1;
+            } else {
+                break;
+            }
+        }
+        return Some(new_profile);
+    }
+    None
+}
 
 /// Returns whether the synchronised conflict explanation created by
 /// [`TimeTableOverIntervalIncrementalPropgator`] is the same as that created by

--- a/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
@@ -271,6 +271,7 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
                         ),
                         "The conflict explanation was not the same as the conflict explanation from scratch!"
                     );
+                    self.found_previous_conflict = true;
                     return synchronised_conflict_explanation;
                 }
                 // Otherwise we mark that we have not found the previous conflict and continue

--- a/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
@@ -19,6 +19,7 @@ use crate::propagators::create_time_table_over_interval_from_scratch;
 use crate::propagators::cumulative::time_table::over_interval_incremental_propagator::debug;
 use crate::propagators::cumulative::time_table::over_interval_incremental_propagator::synchronisation::check_synchronisation_conflict_explanation_over_interval;
 use crate::propagators::cumulative::time_table::over_interval_incremental_propagator::synchronisation::create_synchronised_conflict_explanation;
+use crate::propagators::cumulative::time_table::over_interval_incremental_propagator::synchronisation::find_synchronised_conflict;
 use crate::propagators::cumulative::time_table::over_interval_incremental_propagator::synchronisation::synchronise_time_table;
 use crate::propagators::cumulative::time_table::propagation_handler::create_conflict_explanation;
 use crate::propagators::cumulative::time_table::time_table_util::backtrack_update;
@@ -248,39 +249,18 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
         // After all the updates have been processed, we need to check whether there is still a
         // conflict in the time-table (if any calls have reported an overflow)
         if found_conflict || self.found_previous_conflict {
-            // We linearly scan the profiles and find the first one which exceeds the capacity
-            let conflicting_profile = self
-                .time_table
-                .iter_mut()
-                .find(|profile| profile.height > self.parameters.capacity);
-
-            // If we have found such a conflict then we return it
-            if let Some(conflicting_profile) = conflicting_profile {
-                pumpkin_assert_extreme!(
-                    create_time_table_over_interval_from_scratch(
-                        context.as_readonly(),
-                        &self.parameters
-                    )
-                    .is_err(),
-                    "Time-table from scratch could not find conflict"
-                );
-                // We have found the previous conflict
-                self.found_previous_conflict = true;
-
-                if SYNCHRONISE {
-                    // If we are synchronising then we need to find the conflict which would have
-                    // been found by the non-incremental propagator
-                    //
-                    // Luckily, the non-incremental propagator would have found the earliest
-                    // time-point at which a conflict would have occured which is exactly what is
-                    // stored in `conflict_profile`
-                    //
-                    // Now we just need to find the same explanation as would have been found by
-                    // the non-incremental propagator
+            if SYNCHRONISE {
+                // If we are synchronising then we need to search for the conflict which would have
+                // been found by the non-incremental propagator
+                let conflicting_profile =
+                    find_synchronised_conflict(&mut self.time_table, &self.parameters);
+                // Now we need to find the same explanation as would have been found by
+                // the non-incremental propagator
+                if let Some(mut conflicting_profile) = conflicting_profile {
                     let synchronised_conflict_explanation =
                         create_synchronised_conflict_explanation(
                             context.as_readonly(),
-                            conflicting_profile,
+                            &mut conflicting_profile,
                             &self.parameters,
                         );
                     pumpkin_assert_extreme!(
@@ -293,17 +273,38 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
                     );
                     return synchronised_conflict_explanation;
                 }
+                // Otherwise we mark that we have not found the previous conflict and continue
+                self.found_previous_conflict = false;
+            } else {
+                // We linearly scan the profiles and find the first one which exceeds the capacity
+                let conflicting_profile = self
+                    .time_table
+                    .iter_mut()
+                    .find(|profile| profile.height > self.parameters.capacity);
 
-                return Err(create_conflict_explanation(
-                    context.as_readonly(),
-                    conflicting_profile,
-                    self.parameters.options.explanation_type,
-                )
-                .into());
+                // If we have found such a conflict then we return it
+                if let Some(conflicting_profile) = conflicting_profile {
+                    pumpkin_assert_extreme!(
+                        create_time_table_over_interval_from_scratch(
+                            context.as_readonly(),
+                            &self.parameters
+                        )
+                        .is_err(),
+                        "Time-table from scratch could not find conflict"
+                    );
+                    // We have found the previous conflict
+                    self.found_previous_conflict = true;
+
+                    return Err(create_conflict_explanation(
+                        context.as_readonly(),
+                        conflicting_profile,
+                        self.parameters.options.explanation_type,
+                    )
+                    .into());
+                }
+                // Otherwise we mark that we have not found the previous conflict and continue
+                self.found_previous_conflict = false;
             }
-
-            // Otherwise we mark that we have not found the previous conflict and continue
-            self.found_previous_conflict = false;
         }
 
         if SYNCHRONISE {


### PR DESCRIPTION
Currently, the synchronised conflict explanation simply uses the first conflicting profile as its explanation. While this is correct in the sense that the start point of this profile is the same as the start point of the profile which would have been found by the non-incremental propagator, it suffers from the issue that the first conflicting profile does not necessarily span all of the adjacent profiles which have not been merged.

This PR aims to address this issue by finding the first profile which is conflicting **and** then creating a profile with all subsequent profiles which could be merged.