### PR TITLE
feat: stateful integer

### DIFF
--- a/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -5,6 +5,7 @@ use drcp_format::steps::StepId;
 use super::minimisers::SemanticMinimiser;
 use crate::basic_types::HashMap;
 use crate::basic_types::StoredConflictInfo;
+use crate::basic_types::Trail;
 use crate::branching::Brancher;
 use crate::engine::constraint_satisfaction_solver::CSPSolverState;
 use crate::engine::predicates::predicate::Predicate;
@@ -18,6 +19,7 @@ use crate::engine::Assignments;
 use crate::engine::ConstraintSatisfactionSolver;
 use crate::engine::IntDomainEvent;
 use crate::engine::PropagatorQueue;
+use crate::engine::StateChange;
 use crate::engine::WatchListCP;
 use crate::predicate;
 use crate::proof::ProofLog;
@@ -48,6 +50,7 @@ pub(crate) struct ConflictAnalysisContext<'a> {
 
     pub(crate) is_completing_proof: bool,
     pub(crate) unit_nogood_step_ids: &'a HashMap<Predicate, StepId>,
+    pub(crate) stateful_trail: &'a mut Trail<StateChange>,
 }
 
 impl Debug for ConflictAnalysisContext<'_> {
@@ -82,6 +85,7 @@ impl<'a> ConflictAnalysisContext<'a> {
             self.backtrack_event_drain,
             backtrack_level,
             self.brancher,
+            self.stateful_trail,
         )
     }
 

--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -16,6 +16,7 @@ use super::conflict_analysis::LearnedNogood;
 use super::conflict_analysis::NoLearningResolver;
 use super::conflict_analysis::SemanticMinimiser;
 use super::nogoods::Lbd;
+use super::propagation::propagation_context::StatefulPropagationContext;
 use super::propagation::store::PropagatorStore;
 use super::propagation::PropagatorId;
 use super::solver_statistics::SolverStatistics;
@@ -23,6 +24,7 @@ use super::termination::TerminationCondition;
 use super::variables::IntegerVariable;
 use super::variables::Literal;
 use super::ResolutionResolver;
+use super::StateChange;
 use crate::basic_types::moving_averages::MovingAverage;
 use crate::basic_types::CSPSolverExecutionFlag;
 use crate::basic_types::ConstraintOperationError;
@@ -32,6 +34,7 @@ use crate::basic_types::PropositionalConjunction;
 use crate::basic_types::Random;
 use crate::basic_types::SolutionReference;
 use crate::basic_types::StoredConflictInfo;
+use crate::basic_types::Trail;
 use crate::branching::Brancher;
 use crate::branching::SelectionContext;
 use crate::engine::conflict_analysis::ConflictResolver as Resolver;
@@ -142,6 +145,8 @@ pub struct ConstraintSatisfactionSolver {
     unit_nogood_step_ids: HashMap<Predicate, StepId>,
     /// The resolver which is used upon a conflict.
     conflict_resolver: Box<dyn Resolver>,
+
+    pub(crate) stateful_trail: Trail<StateChange>,
 }
 
 impl Default for ConstraintSatisfactionSolver {
@@ -250,6 +255,7 @@ impl ConstraintSatisfactionSolver {
         propagators: &mut PropagatorStore,
         propagator_queue: &mut PropagatorQueue,
         assignments: &mut Assignments,
+        stateful_trail: &mut Trail<StateChange>,
     ) {
         pumpkin_assert_moderate!(
             propagators[Self::get_nogood_propagator_id()].name() == "NogoodPropagator"
@@ -266,6 +272,7 @@ impl ConstraintSatisfactionSolver {
             propagators,
             propagator_queue,
             assignments,
+            stateful_trail,
         );
     }
 
@@ -276,8 +283,9 @@ impl ConstraintSatisfactionSolver {
         propagators: &mut PropagatorStore,
         propagator_queue: &mut PropagatorQueue,
         assignments: &mut Assignments,
+        stateful_trail: &mut Trail<StateChange>,
     ) {
-        let context = PropagationContext::new(assignments);
+        let context = StatefulPropagationContext::new(stateful_trail, assignments);
 
         let enqueue_decision = propagators[propagator_id].notify(context, local_id, event.into());
 
@@ -306,6 +314,7 @@ impl ConstraintSatisfactionSolver {
                 &mut self.propagators,
                 &mut self.propagator_queue,
                 &mut self.assignments,
+                &mut self.stateful_trail,
             );
             // Now notify other propagators subscribed to this event.
             for propagator_var in self.watch_list_cp.get_affected_propagators(event, domain) {
@@ -318,6 +327,7 @@ impl ConstraintSatisfactionSolver {
                     &mut self.propagators,
                     &mut self.propagator_queue,
                     &mut self.assignments,
+                    &mut self.stateful_trail,
                 );
             }
         }
@@ -371,6 +381,7 @@ impl ConstraintSatisfactionSolver {
             proof_log: &mut self.internal_parameters.proof_log,
             is_completing_proof: true,
             unit_nogood_step_ids: &self.unit_nogood_step_ids,
+            stateful_trail: &mut self.stateful_trail,
         };
 
         let result = self
@@ -410,6 +421,7 @@ impl ConstraintSatisfactionSolver {
                 ConflictResolver::UIP => Box::new(ResolutionResolver::default()),
             },
             internal_parameters: solver_options,
+            stateful_trail: Trail::default(),
         };
 
         // As a convention, the assignments contain a dummy domain_id=0, which represents a 0-1
@@ -654,6 +666,7 @@ impl ConstraintSatisfactionSolver {
                     proof_log: &mut self.internal_parameters.proof_log,
                     is_completing_proof: false,
                     unit_nogood_step_ids: &self.unit_nogood_step_ids,
+                    stateful_trail: &mut self.stateful_trail,
                 };
 
                 let mut resolver = ResolutionResolver::with_mode(AnalysisMode::AllDecision);
@@ -724,6 +737,7 @@ impl ConstraintSatisfactionSolver {
                 &mut self.backtrack_event_drain,
                 0,
                 brancher,
+                &mut self.stateful_trail,
             );
             self.state.declare_ready();
         }
@@ -860,6 +874,7 @@ impl ConstraintSatisfactionSolver {
 
     pub(crate) fn declare_new_decision_level(&mut self) {
         self.assignments.increase_decision_level();
+        self.stateful_trail.increase_decision_level();
         self.reason_store.increase_decision_level();
     }
 
@@ -895,6 +910,7 @@ impl ConstraintSatisfactionSolver {
             proof_log: &mut self.internal_parameters.proof_log,
             is_completing_proof: false,
             unit_nogood_step_ids: &self.unit_nogood_step_ids,
+            stateful_trail: &mut self.stateful_trail,
         };
 
         let learned_nogood = self
@@ -1030,6 +1046,7 @@ impl ConstraintSatisfactionSolver {
             &mut self.backtrack_event_drain,
             0,
             brancher,
+            &mut self.stateful_trail,
         );
 
         self.restart_strategy.notify_restart();
@@ -1050,6 +1067,7 @@ impl ConstraintSatisfactionSolver {
         backtrack_event_drain: &mut Vec<(IntDomainEvent, DomainId)>,
         backtrack_level: usize,
         brancher: &mut BrancherType,
+        stateful_trail: &mut Trail<StateChange>,
     ) {
         pumpkin_assert_simple!(backtrack_level < assignments.get_decision_level());
 
@@ -1065,6 +1083,10 @@ impl ConstraintSatisfactionSolver {
             .for_each(|(domain_id, previous_value)| {
                 brancher.on_unassign_integer(*domain_id, *previous_value)
             });
+        stateful_trail
+            .synchronise(backtrack_level)
+            .for_each(|change| change.undo());
+
         *last_notified_cp_trail_index = assignments.num_trail_entries();
 
         reason_store.synchronise(backtrack_level);
@@ -1349,8 +1371,9 @@ impl ConstraintSatisfactionSolver {
 
         let mut initialisation_context = PropagatorInitialisationContext::new(
             &mut self.watch_list_cp,
+            &mut self.stateful_trail,
             new_propagator_id,
-            &self.assignments,
+            &mut self.assignments,
         );
 
         let initialisation_status = new_propagator.initialise_at_root(&mut initialisation_context);

--- a/pumpkin-solver/src/engine/cp/assignments.rs
+++ b/pumpkin-solver/src/engine/cp/assignments.rs
@@ -734,23 +734,17 @@ impl Assignments {
                 }
             }
         });
+
         // Drain does not remove the events from the internal data structure. Elements are removed
         // lazily, as the iterator gets executed. For this reason we go through the entire iterator.
         let iter = self.events.drain();
         let _ = iter.count();
-        // println!("ASSIGN AFTER SYNC PRESENT: {:?}", self.events.present);
-        // println!("others: {:?}", self.events.events);
         unfixed_variables
     }
 
     /// todo: This is a temporary hack, not to be used in general.
     pub(crate) fn remove_last_trail_element(&mut self) {
         let entry = self.trail.pop().unwrap();
-        // println!(
-        // "\tHacky remova: {} {}",
-        // entry.predicate,
-        // entry.reason.is_none()
-        // );
         let domain_id = entry.predicate.get_domain();
         self.domains[domain_id].undo_trail_entry(&entry);
     }

--- a/pumpkin-solver/src/engine/cp/mod.rs
+++ b/pumpkin-solver/src/engine/cp/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod opaque_domain_event;
 pub(crate) mod propagation;
 mod propagator_queue;
 pub(crate) mod reason;
+mod stateful;
 pub(crate) mod test_solver;
 mod watch_list_cp;
 
@@ -12,6 +13,7 @@ pub(crate) use assignments::Assignments;
 pub(crate) use assignments::EmptyDomain;
 pub(crate) use event_sink::*;
 pub(crate) use propagator_queue::PropagatorQueue;
+pub(crate) use stateful::*;
 pub(crate) use watch_list_cp::IntDomainEvent;
 pub(crate) use watch_list_cp::WatchListCP;
 pub(crate) use watch_list_cp::Watchers;

--- a/pumpkin-solver/src/engine/cp/propagation/propagation_context.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/propagation_context.rs
@@ -1,4 +1,5 @@
 use super::PropagatorId;
+use crate::basic_types::Trail;
 use crate::engine::conflict_analysis::SemanticMinimiser;
 use crate::engine::predicates::predicate::Predicate;
 use crate::engine::reason::Reason;
@@ -7,7 +8,30 @@ use crate::engine::variables::IntegerVariable;
 use crate::engine::variables::Literal;
 use crate::engine::Assignments;
 use crate::engine::EmptyDomain;
+use crate::engine::StateChange;
 use crate::pumpkin_assert_simple;
+
+pub(crate) struct StatefulPropagationContext<'a> {
+    pub(crate) stateful_trail: &'a mut Trail<StateChange>,
+    pub(crate) assignments: &'a Assignments,
+}
+
+impl<'a> StatefulPropagationContext<'a> {
+    pub(crate) fn new(
+        stateful_trail: &'a mut Trail<StateChange>,
+        assignments: &'a Assignments,
+    ) -> Self {
+        Self {
+            stateful_trail,
+            assignments,
+        }
+    }
+    pub(crate) fn as_readonly(&self) -> PropagationContext<'_> {
+        PropagationContext {
+            assignments: self.assignments,
+        }
+    }
+}
 
 /// [`PropagationContext`] is passed to propagators during propagation.
 /// It may be queried to retrieve information about the current variable domains such as the
@@ -105,6 +129,12 @@ mod private {
     }
 
     impl HasAssignments for PropagationContextMut<'_> {
+        fn assignments(&self) -> &Assignments {
+            self.assignments
+        }
+    }
+
+    impl HasAssignments for StatefulPropagationContext<'_> {
         fn assignments(&self) -> &Assignments {
             self.assignments
         }

--- a/pumpkin-solver/src/engine/cp/propagation/propagator.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/propagator.rs
@@ -2,6 +2,7 @@ use downcast_rs::impl_downcast;
 use downcast_rs::Downcast;
 
 use super::explanation_context::ExplanationContext;
+use super::propagation_context::StatefulPropagationContext;
 use super::propagator_initialisation_context::PropagatorInitialisationContext;
 #[cfg(doc)]
 use crate::basic_types::Inconsistency;
@@ -90,7 +91,7 @@ pub(crate) trait Propagator: Downcast {
     /// [`PropagatorInitialisationContext::register()`].
     fn notify(
         &mut self,
-        _context: PropagationContext,
+        _context: StatefulPropagationContext,
         _local_id: LocalId,
         _event: OpaqueDomainEvent,
     ) -> EnqueueDecision {

--- a/pumpkin-solver/src/engine/cp/propagation/propagator_initialisation_context.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/propagator_initialisation_context.rs
@@ -1,5 +1,6 @@
 use super::PropagationContext;
 use super::ReadDomains;
+use crate::basic_types::Trail;
 use crate::engine::domain_events::DomainEvents;
 use crate::engine::propagation::LocalId;
 #[cfg(doc)]
@@ -8,6 +9,7 @@ use crate::engine::propagation::PropagatorId;
 use crate::engine::propagation::PropagatorVarId;
 use crate::engine::variables::IntegerVariable;
 use crate::engine::Assignments;
+use crate::engine::StateChange;
 use crate::engine::WatchListCP;
 use crate::engine::Watchers;
 
@@ -19,29 +21,32 @@ use crate::engine::Watchers;
 #[derive(Debug)]
 pub(crate) struct PropagatorInitialisationContext<'a> {
     watch_list: &'a mut WatchListCP,
+    pub(crate) stateful_trail: &'a mut Trail<StateChange>,
     propagator_id: PropagatorId,
     next_local_id: LocalId,
 
-    context: PropagationContext<'a>,
+    pub assignments: &'a mut Assignments,
 }
 
 impl PropagatorInitialisationContext<'_> {
     pub(crate) fn new<'a>(
         watch_list: &'a mut WatchListCP,
+        stateful_trail: &'a mut Trail<StateChange>,
         propagator_id: PropagatorId,
-        assignments: &'a Assignments,
+        assignments: &'a mut Assignments,
     ) -> PropagatorInitialisationContext<'a> {
         PropagatorInitialisationContext {
             watch_list,
+            stateful_trail,
             propagator_id,
             next_local_id: LocalId::from(0),
 
-            context: PropagationContext::new(assignments),
+            assignments,
         }
     }
 
     pub(crate) fn as_readonly(&self) -> PropagationContext {
-        self.context
+        PropagationContext::new(self.assignments)
     }
 
     /// Subscribes the propagator to the given [`DomainEvents`].
@@ -61,7 +66,7 @@ impl PropagatorInitialisationContext<'_> {
         domain_events: DomainEvents,
         local_id: LocalId,
     ) -> Var {
-        if self.context.is_fixed(&var) {
+        if PropagationContext::new(self.assignments).is_fixed(&var) {
             return var;
         }
         let propagator_var = PropagatorVarId {
@@ -120,7 +125,7 @@ mod private {
 
     impl HasAssignments for PropagatorInitialisationContext<'_> {
         fn assignments(&self) -> &Assignments {
-            self.context.assignments
+            self.assignments
         }
     }
 }

--- a/pumpkin-solver/src/engine/cp/stateful/mod.rs
+++ b/pumpkin-solver/src/engine/cp/stateful/mod.rs
@@ -1,0 +1,4 @@
+mod state_change;
+mod stateful_int;
+pub(crate) use state_change::*;
+pub(crate) use stateful_int::*;

--- a/pumpkin-solver/src/engine/cp/stateful/state_change.rs
+++ b/pumpkin-solver/src/engine/cp/stateful/state_change.rs
@@ -1,0 +1,13 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug, Clone)]
+pub(crate) struct StateChange {
+    pub(crate) old_value: i64,
+    pub(crate) reference: Rc<RefCell<i64>>,
+}
+impl StateChange {
+    pub(crate) fn undo(self) {
+        *(*self.reference).borrow_mut() = self.old_value;
+    }
+}

--- a/pumpkin-solver/src/engine/cp/stateful/stateful_int.rs
+++ b/pumpkin-solver/src/engine/cp/stateful/stateful_int.rs
@@ -1,0 +1,116 @@
+use std::cell::RefCell;
+use std::ops::Add;
+use std::ops::Sub;
+use std::rc::Rc;
+
+use super::StateChange;
+use crate::basic_types::Trail;
+
+#[derive(Debug, Clone)]
+pub struct StatefulInt {
+    value: Rc<RefCell<i64>>,
+}
+
+impl StatefulInt {
+    /// Constructed a new trailed i64 with an initial value.
+    pub(crate) fn new(value: i64) -> StatefulInt {
+        StatefulInt {
+            value: Rc::new(RefCell::new(value)),
+        }
+    }
+
+    /// Get the current value.
+    pub(crate) fn read(&self) -> i64 {
+        *(*self.value).borrow()
+    }
+
+    /// Update the value in a trail-aware manner.
+    pub(crate) fn write(&mut self, value: i64, trail_writer: &mut Trail<StateChange>) {
+        let entry = StateChange {
+            old_value: self.read(),
+            reference: Rc::clone(&self.value),
+        };
+        trail_writer.push(entry);
+        *self.value.borrow_mut() = value;
+    }
+
+    pub(crate) fn add_assign(&mut self, value: i64, trail_writer: &mut Trail<StateChange>) {
+        self.write(self.read() + value, trail_writer);
+    }
+
+    pub(crate) fn assign(&mut self, value: i64, trail_writer: &mut Trail<StateChange>) {
+        self.write(value, trail_writer)
+    }
+}
+impl Add<StatefulInt> for i64 {
+    type Output = i64;
+    fn add(self, rhs: StatefulInt) -> Self::Output {
+        rhs + self
+    }
+}
+impl Add<i64> for StatefulInt {
+    type Output = i64;
+    fn add(self, rhs: i64) -> Self::Output {
+        self.read() + rhs
+    }
+}
+impl<'a> Sub<&'a StatefulInt> for i64 {
+    type Output = i64;
+    fn sub(self, rhs: &'a StatefulInt) -> Self::Output {
+        self - rhs.read()
+    }
+}
+impl Sub<i64> for StatefulInt {
+    type Output = i64;
+    fn sub(self, rhs: i64) -> Self::Output {
+        self.read() - rhs
+    }
+}
+impl PartialEq<i64> for StatefulInt {
+    fn eq(&self, other: &i64) -> bool {
+        self.read() == *other
+    }
+}
+impl PartialEq<StatefulInt> for i64 {
+    fn eq(&self, other: &StatefulInt) -> bool {
+        *self == other.read()
+    }
+}
+impl PartialOrd<i64> for StatefulInt {
+    fn partial_cmp(&self, other: &i64) -> Option<std::cmp::Ordering> {
+        Some(self.read().cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StatefulInt;
+    use crate::basic_types::Trail;
+
+    #[test]
+    fn test_write_resets() {
+        let mut trail = Trail::default();
+        let mut trailed_int = StatefulInt::new(0);
+
+        assert_eq!(trailed_int.read(), 0);
+
+        trail.increase_decision_level();
+        trailed_int.add_assign(5, &mut trail);
+
+        assert_eq!(trailed_int.read(), 5);
+
+        trailed_int.add_assign(5, &mut trail);
+        assert_eq!(trailed_int.read(), 10);
+
+        trail.increase_decision_level();
+        trailed_int.add_assign(1, &mut trail);
+
+        assert_eq!(trailed_int.read(), 11);
+
+        trail.synchronise(1).for_each(|change| change.undo());
+        assert_eq!(trailed_int.read(), 10);
+
+        trail.synchronise(0).for_each(|change| change.undo());
+        assert_eq!(trailed_int.read(), 0);
+    }
+}

--- a/pumpkin-solver/src/engine/cp/stateful/stateful_int.rs
+++ b/pumpkin-solver/src/engine/cp/stateful/stateful_int.rs
@@ -26,8 +26,12 @@ impl StatefulInt {
 
     /// Update the value in a trail-aware manner.
     pub(crate) fn write(&mut self, value: i64, trail_writer: &mut Trail<StateChange>) {
+        let old_value = self.read();
+        if old_value == value {
+            return;
+        }
         let entry = StateChange {
-            old_value: self.read(),
+            old_value,
             reference: Rc::clone(&self.value),
         };
         trail_writer.push(entry);

--- a/pumpkin-solver/src/propagators/arithmetic/linear_less_or_equal.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/linear_less_or_equal.rs
@@ -1,8 +1,11 @@
+use itertools::Itertools;
+
 use crate::basic_types::PropagationStatusCP;
 use crate::basic_types::PropositionalConjunction;
 use crate::engine::cp::propagation::ReadDomains;
 use crate::engine::domain_events::DomainEvents;
 use crate::engine::opaque_domain_event::OpaqueDomainEvent;
+use crate::engine::propagation::propagation_context::StatefulPropagationContext;
 use crate::engine::propagation::EnqueueDecision;
 use crate::engine::propagation::LocalId;
 use crate::engine::propagation::PropagationContext;
@@ -10,6 +13,7 @@ use crate::engine::propagation::PropagationContextMut;
 use crate::engine::propagation::Propagator;
 use crate::engine::propagation::PropagatorInitialisationContext;
 use crate::engine::variables::IntegerVariable;
+use crate::engine::StatefulInt;
 use crate::predicate;
 use crate::pumpkin_assert_simple;
 
@@ -20,9 +24,9 @@ pub(crate) struct LinearLessOrEqualPropagator<Var> {
     c: i32,
 
     /// The lower bound of the sum of the left-hand side. This is incremental state.
-    lower_bound_left_hand_side: i64,
+    lower_bound_left_hand_side: StatefulInt,
     /// The value at index `i` is the bound for `x[i]`.
-    current_bounds: Box<[i32]>,
+    current_bounds: Box<[StatefulInt]>,
 }
 
 impl<Var> LinearLessOrEqualPropagator<Var>
@@ -30,31 +34,18 @@ where
     Var: IntegerVariable,
 {
     pub(crate) fn new(x: Box<[Var]>, c: i32) -> Self {
-        let current_bounds = vec![0; x.len()].into();
+        let current_bounds = (0..x.len())
+            .map(|_| StatefulInt::new(0))
+            .collect_vec()
+            .into();
 
         // incremental state will be properly initialized in `Propagator::initialise_at_root`.
         LinearLessOrEqualPropagator::<Var> {
             x,
             c,
-            lower_bound_left_hand_side: 0,
+            lower_bound_left_hand_side: StatefulInt::new(0),
             current_bounds,
         }
-    }
-
-    /// Recalculates the incremental state from scratch.
-    fn recalculate_incremental_state(&mut self, context: PropagationContext) {
-        self.lower_bound_left_hand_side = self
-            .x
-            .iter()
-            .map(|var| context.lower_bound(var) as i64)
-            .sum();
-
-        self.current_bounds
-            .iter_mut()
-            .enumerate()
-            .for_each(|(index, bound)| {
-                *bound = context.lower_bound(&self.x[index]);
-            });
     }
 
     fn create_conflict_reason(&self, context: PropagationContext) -> PropositionalConjunction {
@@ -79,9 +70,10 @@ where
                 DomainEvents::LOWER_BOUND,
                 LocalId::from(i as u32),
             );
+            self.lower_bound_left_hand_side
+                .add_assign(context.lower_bound(x_i) as i64, context.stateful_trail);
+            self.current_bounds[i].assign(context.lower_bound(x_i) as i64, context.stateful_trail);
         });
-
-        self.recalculate_incremental_state(context.as_readonly());
 
         if let Some(conjunction) = self.detect_inconsistency(context.as_readonly()) {
             Err(conjunction)
@@ -94,7 +86,7 @@ where
         &self,
         context: PropagationContext,
     ) -> Option<PropositionalConjunction> {
-        if (self.c as i64) < self.lower_bound_left_hand_side {
+        if (self.c as i64) < self.lower_bound_left_hand_side.read() {
             Some(self.create_conflict_reason(context))
         } else {
             None
@@ -103,29 +95,26 @@ where
 
     fn notify(
         &mut self,
-        context: PropagationContext,
+        context: StatefulPropagationContext,
         local_id: LocalId,
         _event: OpaqueDomainEvent,
     ) -> EnqueueDecision {
         let index = local_id.unpack() as usize;
-
         let x_i = &self.x[index];
-        let old_bound = self.current_bounds[index];
-        let new_bound = context.lower_bound(x_i);
+
+        let old_bound = self.current_bounds[index].read();
+        let new_bound = context.lower_bound(x_i) as i64;
 
         pumpkin_assert_simple!(
             old_bound < new_bound,
             "propagator should only be triggered when lower bounds are tightened, old_bound={old_bound}, new_bound={new_bound}"
         );
 
-        self.current_bounds[index] = new_bound;
-        self.lower_bound_left_hand_side += (new_bound - old_bound) as i64;
+        self.lower_bound_left_hand_side
+            .add_assign(new_bound - old_bound, context.stateful_trail);
+        self.current_bounds[index].assign(new_bound, context.stateful_trail);
 
         EnqueueDecision::Enqueue
-    }
-
-    fn synchronise(&mut self, context: PropagationContext) {
-        self.recalculate_incremental_state(context);
     }
 
     fn priority(&self) -> u32 {
@@ -142,9 +131,9 @@ where
         }
 
         let lower_bound_left_hand_side =
-            match TryInto::<i32>::try_into(self.lower_bound_left_hand_side) {
+            match TryInto::<i32>::try_into(self.lower_bound_left_hand_side.read()) {
                 Ok(bound) => bound,
-                Err(_) if self.lower_bound_left_hand_side.is_positive() => {
+                Err(_) if self.lower_bound_left_hand_side.read().is_positive() => {
                     // We cannot fit the `lower_bound_left_hand_side` into an i32 due to an
                     // overflow (hence the check that the lower-bound on the left-hand side is
                     // positive)
@@ -200,7 +189,7 @@ where
         let lower_bound_left_hand_side = match TryInto::<i32>::try_into(lower_bound_left_hand_side)
         {
             Ok(bound) => bound,
-            Err(_) if self.lower_bound_left_hand_side.is_positive() => {
+            Err(_) if self.lower_bound_left_hand_side.read().is_positive() => {
                 // We cannot fit the `lower_bound_left_hand_side` into an i32 due to an
                 // overflow (hence the check that the lower-bound on the left-hand side is
                 // positive)

--- a/pumpkin-solver/src/propagators/arithmetic/linear_not_equal.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/linear_not_equal.rs
@@ -7,6 +7,7 @@ use crate::basic_types::PropositionalConjunction;
 use crate::engine::cp::propagation::ReadDomains;
 use crate::engine::domain_events::DomainEvents;
 use crate::engine::opaque_domain_event::OpaqueDomainEvent;
+use crate::engine::propagation::propagation_context::StatefulPropagationContext;
 use crate::engine::propagation::EnqueueDecision;
 use crate::engine::propagation::LocalId;
 use crate::engine::propagation::PropagationContext;
@@ -72,7 +73,7 @@ where
 
     fn notify(
         &mut self,
-        context: PropagationContext,
+        context: StatefulPropagationContext,
         local_id: LocalId,
         _event: OpaqueDomainEvent,
     ) -> EnqueueDecision {
@@ -250,7 +251,7 @@ where
                     .expect("Expected to be able to fit i64 into i32"),
                 reason,
             )?;
-        } else if num_fixed == self.terms.len() && lhs == self.rhs.into() {
+        } else if num_fixed == self.terms.len() && lhs == self.rhs as i64 {
             let failure_reason: PropositionalConjunction = self
                 .terms
                 .iter()
@@ -318,7 +319,7 @@ impl<Var: IntegerVariable + 'static> LinearNotEqualPropagator<Var> {
         let number_of_fixed_terms_is_correct =
             self.number_of_fixed_terms == expected_number_of_fixed_terms;
 
-        let expected_fixed_lhs = self
+        let expected_fixed_lhs: i32 = self
             .terms
             .iter()
             .filter_map(|x_i| {

--- a/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
@@ -6,6 +6,7 @@ use super::insertion;
 use super::removal;
 use crate::basic_types::PropagationStatusCP;
 use crate::engine::opaque_domain_event::OpaqueDomainEvent;
+use crate::engine::propagation::propagation_context::StatefulPropagationContext;
 use crate::engine::propagation::EnqueueDecision;
 use crate::engine::propagation::LocalId;
 use crate::engine::propagation::PropagationContext;
@@ -363,7 +364,7 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool> Propagator
 
     fn notify(
         &mut self,
-        context: PropagationContext,
+        context: StatefulPropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) -> EnqueueDecision {
@@ -379,7 +380,7 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool> Propagator
             &self.parameters,
             &self.updatable_structures,
             &updated_task,
-            context,
+            context.as_readonly(),
             self.time_table.is_empty(),
         );
 
@@ -388,7 +389,7 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool> Propagator
         insert_update(&updated_task, &mut self.updatable_structures, result.update);
 
         update_bounds_task(
-            context,
+            context.as_readonly(),
             self.updatable_structures.get_stored_bounds_mut(),
             &updated_task,
         );

--- a/pumpkin-solver/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 
 use crate::basic_types::PropagationStatusCP;
 use crate::engine::opaque_domain_event::OpaqueDomainEvent;
+use crate::engine::propagation::propagation_context::StatefulPropagationContext;
 use crate::engine::propagation::EnqueueDecision;
 use crate::engine::propagation::LocalId;
 use crate::engine::propagation::PropagationContext;
@@ -375,7 +376,7 @@ impl<Var: IntegerVariable + 'static + Debug, const SYNCHRONISE: bool> Propagator
 
     fn notify(
         &mut self,
-        context: PropagationContext,
+        context: StatefulPropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) -> EnqueueDecision {
@@ -391,7 +392,7 @@ impl<Var: IntegerVariable + 'static + Debug, const SYNCHRONISE: bool> Propagator
             &self.parameters,
             &self.updatable_structures,
             &updated_task,
-            context,
+            context.as_readonly(),
             self.time_table.is_empty(),
         );
 
@@ -400,7 +401,7 @@ impl<Var: IntegerVariable + 'static + Debug, const SYNCHRONISE: bool> Propagator
         insert_update(&updated_task, &mut self.updatable_structures, result.update);
 
         update_bounds_task(
-            context,
+            context.as_readonly(),
             self.updatable_structures.get_stored_bounds_mut(),
             &updated_task,
         );

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_over_interval.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_over_interval.rs
@@ -4,6 +4,7 @@ use super::time_table_util::propagate_based_on_timetable;
 use super::time_table_util::should_enqueue;
 use crate::basic_types::PropagationStatusCP;
 use crate::engine::opaque_domain_event::OpaqueDomainEvent;
+use crate::engine::propagation::propagation_context::StatefulPropagationContext;
 use crate::engine::propagation::EnqueueDecision;
 use crate::engine::propagation::LocalId;
 use crate::engine::propagation::PropagationContext;
@@ -109,7 +110,7 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTableOverIntervalPropaga
 
     fn notify(
         &mut self,
-        context: PropagationContext,
+        context: StatefulPropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) -> EnqueueDecision {
@@ -123,12 +124,12 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTableOverIntervalPropaga
             &self.parameters,
             &self.updatable_structures,
             &updated_task,
-            context,
+            context.as_readonly(),
             self.is_time_table_empty,
         );
 
         update_bounds_task(
-            context,
+            context.as_readonly(),
             self.updatable_structures.get_stored_bounds_mut(),
             &updated_task,
         );

--- a/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/time_table_per_point.rs
@@ -10,6 +10,7 @@ use super::time_table_util::should_enqueue;
 use crate::basic_types::PropagationStatusCP;
 use crate::engine::cp::propagation::ReadDomains;
 use crate::engine::opaque_domain_event::OpaqueDomainEvent;
+use crate::engine::propagation::propagation_context::StatefulPropagationContext;
 use crate::engine::propagation::EnqueueDecision;
 use crate::engine::propagation::LocalId;
 use crate::engine::propagation::PropagationContext;
@@ -102,7 +103,7 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointPropagator<
 
     fn notify(
         &mut self,
-        context: PropagationContext,
+        context: StatefulPropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) -> EnqueueDecision {
@@ -116,14 +117,14 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointPropagator<
             &self.parameters,
             &self.updatable_structures,
             &updated_task,
-            context,
+            context.as_readonly(),
             self.is_time_table_empty,
         );
 
         // Note that the non-incremental proapgator does not make use of `result.updated` since it
         // propagates from scratch anyways
         update_bounds_task(
-            context,
+            context.as_readonly(),
             self.updatable_structures.get_stored_bounds_mut(),
             &updated_task,
         );

--- a/pumpkin-solver/src/propagators/nogoods/nogood_propagator.rs
+++ b/pumpkin-solver/src/propagators/nogoods/nogood_propagator.rs
@@ -17,6 +17,7 @@ use crate::engine::nogoods::Lbd;
 use crate::engine::opaque_domain_event::OpaqueDomainEvent;
 use crate::engine::predicates::predicate::Predicate;
 use crate::engine::propagation::propagation_context::HasAssignments;
+use crate::engine::propagation::propagation_context::StatefulPropagationContext;
 use crate::engine::propagation::EnqueueDecision;
 use crate::engine::propagation::ExplanationContext;
 use crate::engine::propagation::LocalId;
@@ -778,7 +779,7 @@ impl Propagator for NogoodPropagator {
 
     fn notify(
         &mut self,
-        _context: PropagationContext,
+        _context: StatefulPropagationContext,
         local_id: LocalId,
         event: OpaqueDomainEvent,
     ) -> EnqueueDecision {


### PR DESCRIPTION
A well-known concept in CP is variables which are automatically updated to their previous values by the solver.

This PR (based on [this PR](https://bitbucket.org/EmirD/pumpkin-private/pull-requests/58)) aims to implement these variables by creating a new trail for changes to these stateful variables. Upon backtracking, these changes are undone.

As a potential application area, I have implemented it in the `LinearLeq` propagator such that it does not have to recalculate the incremental state from scratch.