### PR TITLE
fix: post process new domain

### DIFF
--- a/pumpkin-solver/src/engine/conflict_analysis/minimisers/semantic_minimiser.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/minimisers/semantic_minimiser.rs
@@ -118,12 +118,18 @@ impl SemanticMinimiser {
     }
 
     fn grow(&mut self, lower_bound: i32, upper_bound: i32, holes: Vec<i32>) {
-        let initial_domain = SimpleIntegerDomain {
+        let mut initial_domain = SimpleIntegerDomain {
             lower_bound,
             upper_bound,
             holes: HashSet::from_iter(holes.iter().cloned()),
             inconsistent: false,
         };
+
+        initial_domain.propagate_holes_on_lower_bound();
+        initial_domain.propagate_holes_on_upper_bound();
+        initial_domain.remove_redundant_holes();
+        initial_domain.update_consistency();
+
         let _ = self.original_domains.push(initial_domain.clone());
         let _ = self.domains.push(initial_domain);
     }


### PR DESCRIPTION
When creating a new domain, it could be that the lb/ub is a hole, or that there are holes outside of the bounds. This is currently not post processed before creating the domain, so this happens after minimisation for the first time. This can cause the number of literals after minimisation to be higher than before, causing an overflow:
https://github.com/ConSol-Lab/Pumpkin/blob/d66ecb6e541b9d15562dc7db223b8a86b3bade13/pumpkin-solver/src/engine/conflict_analysis/minimisers/recursive_minimiser.rs#L65

Post-processing the new domain fixes this problem.