### PR TITLE
feat: no additional variables during constraint construction

### DIFF
--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
@@ -451,12 +451,11 @@ fn compile_bool2int(
     let a = context.resolve_bool_variable(&exprs[0])?;
     let b = context.resolve_integer_variable(&exprs[1])?;
 
-    Ok(constraints::binary_equals(
-        a,
-        context.solver.new_literal_for_predicate(predicate!(b == 1)),
+    Ok(
+        constraints::binary_equals(a.get_integer_variable(), b.scaled(1))
+            .post(context.solver, None)
+            .is_ok(),
     )
-    .post(context.solver, None)
-    .is_ok())
 }
 
 fn compile_bool_or(

--- a/pumpkin-solver/src/engine/variables/literal.rs
+++ b/pumpkin-solver/src/engine/variables/literal.rs
@@ -34,6 +34,10 @@ impl Literal {
         }
     }
 
+    pub fn get_integer_variable(&self) -> AffineView<DomainId> {
+        self.integer_variable
+    }
+
     pub fn get_true_predicate(&self) -> Predicate {
         self.lower_bound_predicate(1)
     }


### PR DESCRIPTION
There are three spots in the flatzinc parser & constraint constructors that I believe to contain unnecessary variable creation:
- `create_domains` for `BooleanLessThanOrEqual`  and `BooleanEqual`
- `compile_bool2int`

It seems like we can directly used the parsed literals instead of creating a new variable and a linking clause. It only requires access to the underlying `integer_variable` of the literal, but I don't see that as a problem. Is there any reason for doing it this way, or is it because of the legacy structure?