### PR TITLE
feat: improve not equals propagator

### DIFF
--- a/pumpkin-solver/src/engine/cp/domain_events.rs
+++ b/pumpkin-solver/src/engine/cp/domain_events.rs
@@ -29,9 +29,6 @@ impl DomainEvents {
     #[allow(unused, reason = "will be part of public API at some point")]
     pub(crate) const UPPER_BOUND: DomainEvents =
         DomainEvents::create_with_int_events(enum_set!(IntDomainEvent::UpperBound));
-    /// DomainEvents with only assigning to a single value.
-    pub(crate) const ASSIGN: DomainEvents =
-        DomainEvents::create_with_int_events(enum_set!(IntDomainEvent::Assign));
 }
 
 impl DomainEvents {


### PR DESCRIPTION
When working with the Minizinc decomposition of not equals, I noticed that they have some smart cases for when you know that the lb / ub is equal to the rhs. In that case, you can propgate not equals as a single linear inequality. This PR shows what this could look like. It is not a full implementation with proper caching etc.