### PR TITLE
fix: remove removal of variable + adding restoration of key to heap

### DIFF
--- a/pumpkin-solver/src/basic_types/predicate_id_generator.rs
+++ b/pumpkin-solver/src/basic_types/predicate_id_generator.rs
@@ -73,13 +73,6 @@ impl PredicateIdGenerator {
         self.predicate_to_id.clear();
     }
 
-    /// Returns an iterator over all active predicate ids.
-    /// Note that constructing the iterator is not constant time,
-    /// since the function internally sortes the inactive predicate ids.
-    pub(crate) fn iter(&self) -> PredicateIdIterator {
-        PredicateIdIterator::new(self.next_id, self.deleted_ids.clone())
-    }
-
     pub(crate) fn replace_predicate(&mut self, predicate: Predicate, replacement: Predicate) {
         pumpkin_assert_moderate!(self.has_id_for_predicate(predicate));
         let predicate_id = self.get_id(predicate);
@@ -87,6 +80,7 @@ impl PredicateIdGenerator {
     }
 }
 
+#[cfg(test)]
 #[derive(Debug)]
 pub(crate) struct PredicateIdIterator {
     sorted_deleted_ids: Vec<PredicateId>,
@@ -94,6 +88,7 @@ pub(crate) struct PredicateIdIterator {
     next_deleted: u32,
 }
 
+#[cfg(test)]
 impl PredicateIdIterator {
     fn new(end_id: u32, mut deleted_ids: Vec<PredicateId>) -> PredicateIdIterator {
         deleted_ids.sort();
@@ -136,6 +131,7 @@ impl PredicateIdIterator {
     }
 }
 
+#[cfg(test)]
 impl Iterator for PredicateIdIterator {
     type Item = PredicateId;
 


### PR DESCRIPTION
There were two issues with autonomous search which are addressed by this PR:

1. The removal was too aggressive since it was calculated using `self.increment` which could grow very large
2. When a key is set to be dormant, we remove it from the heap and from `predicate_id_info` (in that order); when a new predicate is then added to the heap, it could be the case that it is now linked to the id which has been removed. This leads the heap to incorrectly believe that the newly added predicate has already been removed