### PR TITLE
feat: improve element propagator

### DIFF
--- a/pumpkin-solver/src/engine/cp/propagation/explanation_context.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/explanation_context.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 use crate::basic_types::PredicateId;
 use crate::basic_types::PredicateIdGenerator;
 use crate::containers::KeyValueHeap;
+use crate::engine::propagation::propagation_context::HasAssignments;
 use crate::engine::Assignments;
 use crate::predicates::Predicate;
 
@@ -45,6 +46,12 @@ impl<'a> ExplanationContext<'a> {
     #[allow(unused, reason = "it will be part of the public API at some point")]
     pub(crate) fn working_nogood(&self) -> impl Iterator<Item = Predicate> + '_ {
         self.current_nogood.iter()
+    }
+}
+
+impl HasAssignments for ExplanationContext<'_> {
+    fn assignments(&self) -> &Assignments {
+        self.assignments
     }
 }
 


### PR DESCRIPTION
Re-opening https://github.com/ConSol-Lab/Pumpkin/pull/130 due to a change in my repository. 

The `element` propagator improves the bounds of the RHS based on the items in the array. For this, it takes the full array into account. However, it could be that some of these items are not possible anymore due to a (partial) assignment of the `index`. The propagator doesn't currently take this into account, and I believe this can be improved.

