### PR TITLE
feat: debug clone does not synchronise at level 0 + random splitter edge cases

### DIFF
--- a/pumpkin-solver/src/branching/value_selection/random_splitter.rs
+++ b/pumpkin-solver/src/branching/value_selection/random_splitter.rs
@@ -25,7 +25,7 @@ impl ValueSelector<DomainId> for RandomSplitter {
         //
         // 1. If the bound is equal to the lower-bound then we need to assign it to this bound since
         //    [x >= lb] is currently true
-        // 2. If the bound is equal to the upper-bound then we need to assin it to this bound since
+        // 2. If the bound is equal to the upper-bound then we need to assign it to this bound since
         //    [x <= ub] is currentl true
         if bound == context.lower_bound(decision_variable) {
             return predicate!(decision_variable <= bound);

--- a/pumpkin-solver/src/branching/value_selection/random_splitter.rs
+++ b/pumpkin-solver/src/branching/value_selection/random_splitter.rs
@@ -21,6 +21,18 @@ impl ValueSelector<DomainId> for RandomSplitter {
             context.lower_bound(decision_variable)..context.upper_bound(decision_variable) + 1;
         let bound = context.random().generate_i32_in_range(range);
 
+        // We need to handle two special cases:
+        //
+        // 1. If the bound is equal to the lower-bound then we need to assign it to this bound since
+        //    [x >= lb] is currently true
+        // 2. If the bound is equal to the upper-bound then we need to assin it to this bound since
+        //    [x <= ub] is currentl true
+        if bound == context.lower_bound(decision_variable) {
+            return predicate!(decision_variable <= bound);
+        } else if bound == context.upper_bound(decision_variable) {
+            return predicate!(decision_variable >= bound);
+        }
+
         // Then randomly determine how to split the domain
         if context.random().generate_bool(0.5) {
             predicate!(decision_variable >= bound)

--- a/pumpkin-solver/src/engine/cp/trailed/trailed_assignments.rs
+++ b/pumpkin-solver/src/engine/cp/trailed/trailed_assignments.rs
@@ -73,9 +73,11 @@ impl TrailedAssignments {
     pub(crate) fn debug_create_empty_clone(&self) -> Self {
         let mut new_trail = self.trail.clone();
         let mut new_values = self.values.clone();
-        new_trail
-            .synchronise(0)
-            .for_each(|state_change| new_values[state_change.reference] = state_change.old_value);
+        if new_trail.get_decision_level() > 0 {
+            new_trail.synchronise(0).for_each(|state_change| {
+                new_values[state_change.reference] = state_change.old_value
+            });
+        }
         Self {
             trail: new_trail,
             values: new_values,


### PR DESCRIPTION
This PR addresses 2 issues:
- Debug clone was backtracking to level 0 which could throw an exception for `TrailedAssignments`
- The `RandomSplitter` had edge cases related to bounds