### PR TITLE
feat: implement predicate and assumption solving in python wrapper

### DIFF
--- a/pumpkin-py/src/lib.rs
+++ b/pumpkin-py/src/lib.rs
@@ -28,9 +28,11 @@ macro_rules! submodule {
 fn pumpkin_py(python: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<variables::IntExpression>()?;
     m.add_class::<variables::BoolExpression>()?;
-    m.add_class::<model::Comparator>()?;
+    m.add_class::<variables::Comparator>()?;
+    m.add_class::<variables::Predicate>()?;
     m.add_class::<model::Model>()?;
     m.add_class::<result::SatisfactionResult>()?;
+    m.add_class::<result::SatisfactionUnderAssumptionsResult>()?;
     m.add_class::<result::Solution>()?;
 
     submodule!(constraints, python, m);

--- a/pumpkin-py/src/result.rs
+++ b/pumpkin-py/src/result.rs
@@ -3,12 +3,22 @@ use pyo3::prelude::*;
 
 use crate::variables::BoolExpression;
 use crate::variables::IntExpression;
+use crate::variables::Predicate;
 use crate::variables::VariableMap;
 
 #[pyclass]
 #[allow(clippy::large_enum_variant)]
 pub enum SatisfactionResult {
     Satisfiable(Solution),
+    Unsatisfiable(),
+    Unknown(),
+}
+
+#[pyclass]
+#[allow(clippy::large_enum_variant)]
+pub enum SatisfactionUnderAssumptionsResult {
+    Satisfiable(Solution),
+    UnsatisfiableUnderAssumptions(Vec<Predicate>),
     Unsatisfiable(),
     Unknown(),
 }
@@ -32,3 +42,7 @@ impl Solution {
             .get_literal_value(variable.to_literal(&self.variable_map))
     }
 }
+
+#[pyclass]
+#[derive(Clone)]
+pub struct CoreExtractor {}

--- a/pumpkin-py/tests/test_assumptions.py
+++ b/pumpkin-py/tests/test_assumptions.py
@@ -1,0 +1,36 @@
+from pumpkin_py import Comparator, Model, Predicate, SatisfactionUnderAssumptionsResult
+from pumpkin_py.constraints import LessThanOrEquals
+
+
+def test_assumptions_are_respected():
+    model = Model()
+
+    x = model.new_integer_variable(1, 5, name="x")
+
+    assumption = Predicate(x, Comparator.LessThanOrEqual, 3)
+
+    result = model.satisfy_under_assumptions([assumption])
+    assert isinstance(result, SatisfactionUnderAssumptionsResult.Satisfiable)
+
+    solution = result._0
+    x_value = solution.int_value(x)
+    assert x_value <= 3
+
+
+def test_core_extraction():
+    model = Model()
+
+    x = model.new_integer_variable(1, 5, name="x")
+    y = model.new_integer_variable(1, 5, name="x")
+
+    x_ge_3 = Predicate(x, Comparator.GreaterThanOrEqual, 3)
+    y_ge_3 = Predicate(y, Comparator.GreaterThanOrEqual, 3)
+
+    model.add_constraint(LessThanOrEquals([x, y], 5))
+
+    result = model.satisfy_under_assumptions([x_ge_3, y_ge_3])
+    assert isinstance(result, SatisfactionUnderAssumptionsResult.UnsatisfiableUnderAssumptions)
+
+    core = set(result._0)
+    assert set([x_ge_3, y_ge_3]) == core
+


### PR DESCRIPTION
Assumption solving in the Rust layer currently performs semantic minimisation of the core. E.g. if the assumptions contain `[y <= 1]` and `[y != 0]`, and the domain of `y` starts at 0, then the core may contain `[y == 1]` rather than the original predicates in the assumptions.