### PR TITLE
fix: allow reification of lazy reasons

### DIFF
--- a/pumpkin-solver/src/basic_types/propositional_conjunction.rs
+++ b/pumpkin-solver/src/basic_types/propositional_conjunction.rs
@@ -77,6 +77,12 @@ impl PropositionalConjunction {
     }
 }
 
+impl Extend<Predicate> for PropositionalConjunction {
+    fn extend<T: IntoIterator<Item = Predicate>>(&mut self, iter: T) {
+        self.predicates_in_conjunction.extend(iter);
+    }
+}
+
 impl IntoIterator for PropositionalConjunction {
     type Item = Predicate;
 

--- a/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -130,8 +130,10 @@ impl ConflictAnalysisContext<'_> {
         }
     }
 
-    /// Returns the reason for a propagation; if it is implied then the reason will be the decision
-    /// which implied the predicate.
+    /// Compute the reason for `predicate` being true. The reason will be stored in
+    /// `reason_buffer`.
+    ///
+    /// If `predicate` is not true, or it is a decision, then this function will panic.
     #[allow(
         clippy::too_many_arguments,
         reason = "borrow checker complains either here or elsewhere"
@@ -144,7 +146,7 @@ impl ConflictAnalysisContext<'_> {
         propagators: &mut PropagatorStore,
         proof_log: &mut ProofLog,
         unit_nogood_step_ids: &HashMap<Predicate, StepId>,
-        reason_out: &mut (impl Extend<Predicate> + AsRef<[Predicate]>),
+        reason_buffer: &mut (impl Extend<Predicate> + AsRef<[Predicate]>),
     ) {
         // TODO: this function could be put into the reason store
 
@@ -187,13 +189,13 @@ impl ConflictAnalysisContext<'_> {
                 reason_ref,
                 explanation_context,
                 propagators,
-                reason_out,
+                reason_buffer,
             );
 
             assert!(reason_exists, "reason reference should not be stale");
 
             if propagator_id == ConstraintSatisfactionSolver::get_nogood_propagator_id()
-                && reason_out.as_ref().is_empty()
+                && reason_buffer.as_ref().is_empty()
             {
                 // This means that a unit nogood was propagated, we indicate that this nogood step
                 // was used
@@ -217,7 +219,7 @@ impl ConflictAnalysisContext<'_> {
                 // Otherwise we log the inference which was used to derive the nogood
                 let _ = proof_log.log_inference(
                     constraint_tag,
-                    reason_out.as_ref().iter().copied(),
+                    reason_buffer.as_ref().iter().copied(),
                     Some(predicate),
                 );
             }
@@ -248,7 +250,7 @@ impl ConflictAnalysisContext<'_> {
                     //  todo: could consider lifting here, since the trail bound
                     //  might be too strong.
                     if trail_lower_bound > input_lower_bound {
-                        reason_out.extend(std::iter::once(trail_entry.predicate));
+                        reason_buffer.extend(std::iter::once(trail_entry.predicate));
                     }
                     // Otherwise, the input bound is strictly greater than the trailed
                     // bound. This means the reason is due to holes in the domain.
@@ -278,8 +280,8 @@ impl ConflictAnalysisContext<'_> {
                             domain_id,
                             not_equal_constant: input_lower_bound - 1,
                         };
-                        reason_out.extend(std::iter::once(one_less_bound_predicate));
-                        reason_out.extend(std::iter::once(not_equals_predicate));
+                        reason_buffer.extend(std::iter::once(one_less_bound_predicate));
+                        reason_buffer.extend(std::iter::once(not_equals_predicate));
                     }
                 }
                 (
@@ -299,7 +301,7 @@ impl ConflictAnalysisContext<'_> {
                     // so it safe to take the reason from the trail.
                     // todo: lifting could be used here
                     pumpkin_assert_simple!(trail_lower_bound > not_equal_constant);
-                    reason_out.extend(std::iter::once(trail_entry.predicate));
+                    reason_buffer.extend(std::iter::once(trail_entry.predicate));
                 }
                 (
                     Predicate::LowerBound {
@@ -331,8 +333,8 @@ impl ConflictAnalysisContext<'_> {
                         domain_id,
                         upper_bound: equality_constant,
                     };
-                    reason_out.extend(std::iter::once(predicate_lb));
-                    reason_out.extend(std::iter::once(predicate_ub));
+                    reason_buffer.extend(std::iter::once(predicate_lb));
+                    reason_buffer.extend(std::iter::once(predicate_ub));
                 }
                 (
                     Predicate::UpperBound {
@@ -352,7 +354,7 @@ impl ConflictAnalysisContext<'_> {
                     //    reason for the input predicate.
                     // todo: lifting could be applied here.
                     if trail_upper_bound < input_upper_bound {
-                        reason_out.extend(std::iter::once(trail_entry.predicate));
+                        reason_buffer.extend(std::iter::once(trail_entry.predicate));
                     } else {
                         // I think it cannot be that the bounds are equal, since otherwise we
                         // would have found the predicate explicitly on the trail.
@@ -373,8 +375,8 @@ impl ConflictAnalysisContext<'_> {
                             domain_id,
                             not_equal_constant: input_upper_bound + 1,
                         };
-                        reason_out.extend(std::iter::once(new_ub_predicate));
-                        reason_out.extend(std::iter::once(not_equal_predicate));
+                        reason_buffer.extend(std::iter::once(new_ub_predicate));
+                        reason_buffer.extend(std::iter::once(not_equal_predicate));
                     }
                 }
                 (
@@ -395,7 +397,7 @@ impl ConflictAnalysisContext<'_> {
 
                     // The bound was set past the not equals, so we can safely returns the trail
                     // reason. todo: can do lifting here.
-                    reason_out.extend(std::iter::once(trail_entry.predicate));
+                    reason_buffer.extend(std::iter::once(trail_entry.predicate));
                 }
                 (
                     Predicate::UpperBound {
@@ -430,8 +432,8 @@ impl ConflictAnalysisContext<'_> {
                         domain_id,
                         upper_bound: equality_constant,
                     };
-                    reason_out.extend(std::iter::once(predicate_lb));
-                    reason_out.extend(std::iter::once(predicate_ub));
+                    reason_buffer.extend(std::iter::once(predicate_lb));
+                    reason_buffer.extend(std::iter::once(predicate_ub));
                 }
                 (
                     Predicate::NotEqual {
@@ -465,8 +467,8 @@ impl ConflictAnalysisContext<'_> {
                         not_equal_constant: input_lower_bound - 1,
                     };
 
-                    reason_out.extend(std::iter::once(new_lb_predicate));
-                    reason_out.extend(std::iter::once(new_not_equals_predicate));
+                    reason_buffer.extend(std::iter::once(new_lb_predicate));
+                    reason_buffer.extend(std::iter::once(new_not_equals_predicate));
                 }
                 (
                     Predicate::NotEqual {
@@ -500,8 +502,8 @@ impl ConflictAnalysisContext<'_> {
                         not_equal_constant: input_upper_bound + 1,
                     };
 
-                    reason_out.extend(std::iter::once(new_ub_predicate));
-                    reason_out.extend(std::iter::once(new_not_equals_predicate));
+                    reason_buffer.extend(std::iter::once(new_ub_predicate));
+                    reason_buffer.extend(std::iter::once(new_not_equals_predicate));
                 }
                 (
                     Predicate::NotEqual {
@@ -530,8 +532,8 @@ impl ConflictAnalysisContext<'_> {
                         upper_bound: equality_constant,
                     };
 
-                    reason_out.extend(std::iter::once(predicate_lb));
-                    reason_out.extend(std::iter::once(predicate_ub));
+                    reason_buffer.extend(std::iter::once(predicate_lb));
+                    reason_buffer.extend(std::iter::once(predicate_ub));
                 }
                 _ => unreachable!(
                     "Unreachable combination of {} and {}",

--- a/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -58,7 +58,7 @@ impl Debug for ConflictAnalysisContext<'_> {
     }
 }
 
-impl<'a> ConflictAnalysisContext<'a> {
+impl ConflictAnalysisContext<'_> {
     /// Returns the last decision which was made by the solver.
     pub(crate) fn find_last_decision(&mut self) -> Option<Predicate> {
         self.assignments.find_last_decision()
@@ -132,15 +132,20 @@ impl<'a> ConflictAnalysisContext<'a> {
 
     /// Returns the reason for a propagation; if it is implied then the reason will be the decision
     /// which implied the predicate.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "borrow checker complains either here or elsewhere"
+    )]
     pub(crate) fn get_propagation_reason(
         predicate: Predicate,
         assignments: &Assignments,
         current_nogood: CurrentNogood<'_>,
-        reason_store: &'a mut ReasonStore,
-        propagators: &'a mut PropagatorStore,
-        proof_log: &'a mut ProofLog,
+        reason_store: &mut ReasonStore,
+        propagators: &mut PropagatorStore,
+        proof_log: &mut ProofLog,
         unit_nogood_step_ids: &HashMap<Predicate, StepId>,
-    ) -> &'a [Predicate] {
+        reason_out: &mut (impl Extend<Predicate> + AsRef<[Predicate]>),
+    ) {
         // TODO: this function could be put into the reason store
 
         // Note that this function can only be called with propagations, and never decision
@@ -156,9 +161,8 @@ impl<'a> ConflictAnalysisContext<'a> {
         // there would be only one predicate from the current decision level. For this
         // reason, it is safe to assume that in the following, that any input predicate is
         // indeed a propagated predicate.
-        reason_store.helper.clear();
         if assignments.is_initial_bound(predicate) {
-            return reason_store.helper.as_slice();
+            return;
         }
 
         let trail_position = assignments
@@ -179,11 +183,17 @@ impl<'a> ConflictAnalysisContext<'a> {
 
             let explanation_context = ExplanationContext::new(assignments, current_nogood);
 
-            let reason = reason_store
-                .get_or_compute(reason_ref, explanation_context, propagators)
-                .expect("reason reference should not be stale");
+            let reason_exists = reason_store.get_or_compute(
+                reason_ref,
+                explanation_context,
+                propagators,
+                reason_out,
+            );
+
+            assert!(reason_exists, "reason reference should not be stale");
+
             if propagator_id == ConstraintSatisfactionSolver::get_nogood_propagator_id()
-                && reason.is_empty()
+                && reason_out.as_ref().is_empty()
             {
                 // This means that a unit nogood was propagated, we indicate that this nogood step
                 // was used
@@ -207,12 +217,10 @@ impl<'a> ConflictAnalysisContext<'a> {
                 // Otherwise we log the inference which was used to derive the nogood
                 let _ = proof_log.log_inference(
                     constraint_tag,
-                    reason.iter().copied(),
+                    reason_out.as_ref().iter().copied(),
                     Some(predicate),
                 );
             }
-            reason
-        // The predicate is implicitly due as a result of a decision.
         }
         // 2) The predicate is true due to a propagation, and not explicitly on the trail.
         // It is necessary to further analyse what was the reason for setting the predicate true.
@@ -240,7 +248,7 @@ impl<'a> ConflictAnalysisContext<'a> {
                     //  todo: could consider lifting here, since the trail bound
                     //  might be too strong.
                     if trail_lower_bound > input_lower_bound {
-                        reason_store.helper.push(trail_entry.predicate);
+                        reason_out.extend(std::iter::once(trail_entry.predicate));
                     }
                     // Otherwise, the input bound is strictly greater than the trailed
                     // bound. This means the reason is due to holes in the domain.
@@ -270,8 +278,8 @@ impl<'a> ConflictAnalysisContext<'a> {
                             domain_id,
                             not_equal_constant: input_lower_bound - 1,
                         };
-                        reason_store.helper.push(one_less_bound_predicate);
-                        reason_store.helper.push(not_equals_predicate);
+                        reason_out.extend(std::iter::once(one_less_bound_predicate));
+                        reason_out.extend(std::iter::once(not_equals_predicate));
                     }
                 }
                 (
@@ -291,7 +299,7 @@ impl<'a> ConflictAnalysisContext<'a> {
                     // so it safe to take the reason from the trail.
                     // todo: lifting could be used here
                     pumpkin_assert_simple!(trail_lower_bound > not_equal_constant);
-                    reason_store.helper.push(trail_entry.predicate);
+                    reason_out.extend(std::iter::once(trail_entry.predicate));
                 }
                 (
                     Predicate::LowerBound {
@@ -323,8 +331,8 @@ impl<'a> ConflictAnalysisContext<'a> {
                         domain_id,
                         upper_bound: equality_constant,
                     };
-                    reason_store.helper.push(predicate_lb);
-                    reason_store.helper.push(predicate_ub);
+                    reason_out.extend(std::iter::once(predicate_lb));
+                    reason_out.extend(std::iter::once(predicate_ub));
                 }
                 (
                     Predicate::UpperBound {
@@ -344,7 +352,7 @@ impl<'a> ConflictAnalysisContext<'a> {
                     //    reason for the input predicate.
                     // todo: lifting could be applied here.
                     if trail_upper_bound < input_upper_bound {
-                        reason_store.helper.push(trail_entry.predicate);
+                        reason_out.extend(std::iter::once(trail_entry.predicate));
                     } else {
                         // I think it cannot be that the bounds are equal, since otherwise we
                         // would have found the predicate explicitly on the trail.
@@ -365,8 +373,8 @@ impl<'a> ConflictAnalysisContext<'a> {
                             domain_id,
                             not_equal_constant: input_upper_bound + 1,
                         };
-                        reason_store.helper.push(new_ub_predicate);
-                        reason_store.helper.push(not_equal_predicate);
+                        reason_out.extend(std::iter::once(new_ub_predicate));
+                        reason_out.extend(std::iter::once(not_equal_predicate));
                     }
                 }
                 (
@@ -387,7 +395,7 @@ impl<'a> ConflictAnalysisContext<'a> {
 
                     // The bound was set past the not equals, so we can safely returns the trail
                     // reason. todo: can do lifting here.
-                    reason_store.helper.push(trail_entry.predicate);
+                    reason_out.extend(std::iter::once(trail_entry.predicate));
                 }
                 (
                     Predicate::UpperBound {
@@ -422,8 +430,8 @@ impl<'a> ConflictAnalysisContext<'a> {
                         domain_id,
                         upper_bound: equality_constant,
                     };
-                    reason_store.helper.push(predicate_lb);
-                    reason_store.helper.push(predicate_ub);
+                    reason_out.extend(std::iter::once(predicate_lb));
+                    reason_out.extend(std::iter::once(predicate_ub));
                 }
                 (
                     Predicate::NotEqual {
@@ -457,8 +465,8 @@ impl<'a> ConflictAnalysisContext<'a> {
                         not_equal_constant: input_lower_bound - 1,
                     };
 
-                    reason_store.helper.push(new_lb_predicate);
-                    reason_store.helper.push(new_not_equals_predicate);
+                    reason_out.extend(std::iter::once(new_lb_predicate));
+                    reason_out.extend(std::iter::once(new_not_equals_predicate));
                 }
                 (
                     Predicate::NotEqual {
@@ -492,8 +500,8 @@ impl<'a> ConflictAnalysisContext<'a> {
                         not_equal_constant: input_upper_bound + 1,
                     };
 
-                    reason_store.helper.push(new_ub_predicate);
-                    reason_store.helper.push(new_not_equals_predicate);
+                    reason_out.extend(std::iter::once(new_ub_predicate));
+                    reason_out.extend(std::iter::once(new_not_equals_predicate));
                 }
                 (
                     Predicate::NotEqual {
@@ -522,15 +530,14 @@ impl<'a> ConflictAnalysisContext<'a> {
                         upper_bound: equality_constant,
                     };
 
-                    reason_store.helper.push(predicate_lb);
-                    reason_store.helper.push(predicate_ub);
+                    reason_out.extend(std::iter::once(predicate_lb));
+                    reason_out.extend(std::iter::once(predicate_ub));
                 }
                 _ => unreachable!(
                     "Unreachable combination of {} and {}",
                     trail_entry.predicate, predicate
                 ),
             };
-            reason_store.helper.as_slice()
         }
     }
 }

--- a/pumpkin-solver/src/engine/conflict_analysis/minimisers/recursive_minimiser.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/minimisers/recursive_minimiser.rs
@@ -117,7 +117,8 @@ impl RecursiveMinimiser {
 
         // Due to ownership rules, we have to take ownership of the reason.
         // TODO: Reuse the allocation if it becomes a bottleneck.
-        let reason = ConflictAnalysisContext::get_propagation_reason(
+        let mut reason = vec![];
+        ConflictAnalysisContext::get_propagation_reason(
             input_predicate,
             context.assignments,
             CurrentNogood::from(current_nogood),
@@ -125,10 +126,10 @@ impl RecursiveMinimiser {
             context.propagators,
             context.proof_log,
             context.unit_nogood_step_ids,
-        )
-        .to_vec();
+            &mut reason,
+        );
 
-        for antecedent_predicate in reason {
+        for antecedent_predicate in reason.iter().copied() {
             // Root assignments can be safely ignored.
             if context
                 .assignments

--- a/pumpkin-solver/src/engine/conflict_analysis/resolvers/resolution_resolver.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/resolvers/resolution_resolver.rs
@@ -249,20 +249,17 @@ impl ConflictResolver for ResolutionResolver {
                 &mut self.reason_buffer,
             );
 
-            // We do a little swapping of the ownership of the buffer, so we can call
-            // `self.add_predicate_to_conflict_nogood`.
-            let reason = std::mem::take(&mut self.reason_buffer);
-            for predicate in reason.iter().copied() {
+            for i in 0..self.reason_buffer.len() {
                 self.add_predicate_to_conflict_nogood(
-                    predicate,
+                    self.reason_buffer[i],
                     context.assignments,
                     context.brancher,
                     self.mode,
                     context.is_completing_proof,
                 );
             }
-            self.reason_buffer = reason;
         }
+
         Some(self.extract_final_nogood(context))
     }
 

--- a/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
@@ -3,6 +3,7 @@ use crate::engine::predicates::predicate::Predicate;
 use crate::engine::propagation::PropagatorId;
 use crate::engine::reason::Reason;
 use crate::engine::reason::ReasonStore;
+use crate::engine::reason::StoredReason;
 use crate::engine::variables::IntegerVariable;
 use crate::engine::variables::Literal;
 use crate::engine::Assignments;
@@ -91,20 +92,23 @@ impl<'a> PropagationContextMut<'a> {
         self.reification_literal = Some(reification_literal);
     }
 
-    fn build_reason(&self, reason: Reason) -> Reason {
-        if let Some(reification_literal) = self.reification_literal {
-            match reason {
-                Reason::Eager(mut conjunction) => {
-                    conjunction.add(reification_literal.get_true_predicate());
-                    Reason::Eager(conjunction)
-                }
-                Reason::DynamicLazy(code) => Reason::ReifiedLazy(reification_literal, code),
-                Reason::ReifiedLazy(_, _) => {
-                    unimplemented!("cannot reify an already reified reason")
+    fn build_reason(&self, reason: Reason) -> StoredReason {
+        match reason {
+            Reason::Eager(mut conjunction) => {
+                conjunction.extend(
+                    self.reification_literal
+                        .iter()
+                        .map(|lit| lit.get_true_predicate()),
+                );
+                StoredReason::Eager(conjunction)
+            }
+            Reason::DynamicLazy(code) => {
+                if let Some(reification_literal) = self.reification_literal {
+                    StoredReason::ReifiedLazy(reification_literal, code)
+                } else {
+                    StoredReason::DynamicLazy(code)
                 }
             }
-        } else {
-            reason
         }
     }
 
@@ -342,7 +346,8 @@ impl PropagationContextMut<'_> {
                     .is_value_in_domain(domain_id, equality_constant)
                     && !self.assignments.is_domain_assigned(&domain_id)
                 {
-                    let reason = self.reason_store.push(self.propagator_id, reason.into());
+                    let reason = self.build_reason(reason.into());
+                    let reason = self.reason_store.push(self.propagator_id, reason);
                     self.assignments
                         .make_assignment(domain_id, equality_constant, Some(reason))?;
                 }

--- a/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
@@ -98,7 +98,10 @@ impl<'a> PropagationContextMut<'a> {
                     conjunction.add(reification_literal.get_true_predicate());
                     Reason::Eager(conjunction)
                 }
-                Reason::DynamicLazy(_) => todo!(),
+                Reason::DynamicLazy(code) => Reason::ReifiedLazy(reification_literal, code),
+                Reason::ReifiedLazy(_, _) => {
+                    unimplemented!("cannot reify an already reified reason")
+                }
             }
         } else {
             reason

--- a/pumpkin-solver/src/engine/cp/reason.rs
+++ b/pumpkin-solver/src/engine/cp/reason.rs
@@ -110,7 +110,7 @@ pub(crate) enum StoredReason {
     /// propagation the reason is for. The payload should be enough for the propagator to construct
     /// an explanation based on its internal state.
     DynamicLazy(u64),
-    /// A lazy explanation that has reified.
+    /// A lazy explanation that has been reified.
     ReifiedLazy(Literal, u64),
 }
 

--- a/pumpkin-solver/src/engine/cp/reason.rs
+++ b/pumpkin-solver/src/engine/cp/reason.rs
@@ -27,6 +27,8 @@ impl ReasonStore {
         ReasonRef(index as u32)
     }
 
+    /// Evaluate the reason with the given reference, and write the predicates to
+    /// `destination_buffer`.
     pub(crate) fn get_or_compute(
         &self,
         reference: ReasonRef,
@@ -115,6 +117,7 @@ pub(crate) enum StoredReason {
 }
 
 impl StoredReason {
+    /// Evaluate the reason, and write the predicates to the `destination_buffer`.
     pub(crate) fn compute(
         &self,
         context: ExplanationContext<'_>,

--- a/pumpkin-solver/src/engine/cp/reason.rs
+++ b/pumpkin-solver/src/engine/cp/reason.rs
@@ -7,12 +7,12 @@ use crate::basic_types::PropositionalConjunction;
 use crate::basic_types::Trail;
 use crate::predicates::Predicate;
 use crate::pumpkin_assert_simple;
+use crate::variables::Literal;
 
 /// The reason store holds a reason for each change made by a CP propagator on a trail.
 #[derive(Default, Debug)]
 pub(crate) struct ReasonStore {
     trail: Trail<(PropagatorId, Reason)>,
-    pub helper: PropositionalConjunction,
 }
 
 impl ReasonStore {
@@ -27,15 +27,22 @@ impl ReasonStore {
         ReasonRef(index as u32)
     }
 
-    pub(crate) fn get_or_compute<'this>(
-        &'this self,
+    pub(crate) fn get_or_compute(
+        &self,
         reference: ReasonRef,
         context: ExplanationContext<'_>,
-        propagators: &'this mut PropagatorStore,
-    ) -> Option<&'this [Predicate]> {
-        self.trail
-            .get(reference.0 as usize)
-            .map(|reason| reason.1.compute(context, reason.0, propagators))
+        propagators: &mut PropagatorStore,
+        destination_buffer: &mut impl Extend<Predicate>,
+    ) -> bool {
+        let Some(reason) = self.trail.get(reference.0 as usize) else {
+            return false;
+        };
+
+        reason
+            .1
+            .compute(context, reason.0, propagators, destination_buffer);
+
+        true
     }
 
     pub(crate) fn get_lazy_code(&self, reference: ReasonRef) -> Option<&u64> {
@@ -43,6 +50,9 @@ impl ReasonStore {
             Some(reason) => match &reason.1 {
                 Reason::Eager(_) => None,
                 Reason::DynamicLazy(code) => Some(code),
+                Reason::ReifiedLazy(_, _) => {
+                    unimplemented!("Getting the code of a reified lazy reason is unsupported.")
+                }
             },
             None => None,
         }
@@ -84,23 +94,38 @@ pub(crate) enum Reason {
     /// propagation the reason is for. The payload should be enough for the propagator to construct
     /// an explanation based on its internal state.
     DynamicLazy(u64),
+    /// A lazy explanation that has reified.
+    ReifiedLazy(Literal, u64),
 }
 
 impl Reason {
-    pub(crate) fn compute<'a>(
-        &'a self,
+    pub(crate) fn compute(
+        &self,
         context: ExplanationContext<'_>,
         propagator_id: PropagatorId,
-        propagators: &'a mut PropagatorStore,
-    ) -> &'a [Predicate] {
+        propagators: &mut PropagatorStore,
+        destination_buffer: &mut impl Extend<Predicate>,
+    ) {
         match self {
             // We do not replace the reason with an eager explanation for dynamic lazy explanations.
             //
             // Benchmarking will have to show whether this should change or not.
-            Reason::DynamicLazy(code) => {
-                propagators[propagator_id].lazy_explanation(*code, context)
+            Reason::DynamicLazy(code) => destination_buffer.extend(
+                propagators[propagator_id]
+                    .lazy_explanation(*code, context)
+                    .iter()
+                    .copied(),
+            ),
+            Reason::Eager(result) => destination_buffer.extend(result.iter().copied()),
+            Reason::ReifiedLazy(literal, code) => {
+                destination_buffer.extend(
+                    propagators[propagator_id]
+                        .lazy_explanation(*code, context)
+                        .iter()
+                        .copied(),
+                );
+                destination_buffer.extend(std::iter::once(literal.get_true_predicate()));
             }
-            Reason::Eager(result) => result.as_slice(),
         }
     }
 }
@@ -115,8 +140,10 @@ impl From<PropositionalConjunction> for Reason {
 mod tests {
     use super::*;
     use crate::conjunction;
+    use crate::engine::propagation::Propagator;
     use crate::engine::variables::DomainId;
     use crate::engine::Assignments;
+    use crate::predicate;
 
     #[test]
     fn computing_an_eager_reason_returns_a_reference_to_the_conjunction() {
@@ -128,14 +155,15 @@ mod tests {
         let conjunction = conjunction!([x == 1] & [y == 2]);
         let reason = Reason::Eager(conjunction.clone());
 
-        assert_eq!(
-            conjunction.as_slice(),
-            reason.compute(
-                ExplanationContext::from(&integers),
-                PropagatorId(0),
-                &mut PropagatorStore::default()
-            )
+        let mut out_reason = vec![];
+        reason.compute(
+            ExplanationContext::from(&integers),
+            PropagatorId(0),
+            &mut PropagatorStore::default(),
+            &mut out_reason,
         );
+
+        assert_eq!(conjunction.as_slice(), &out_reason);
     }
 
     #[test]
@@ -151,13 +179,68 @@ mod tests {
 
         assert_eq!(ReasonRef(0), reason_ref);
 
-        assert_eq!(
-            Some(conjunction.as_slice()),
-            reason_store.get_or_compute(
-                reason_ref,
-                ExplanationContext::from(&integers),
-                &mut PropagatorStore::default()
-            )
+        let mut out_reason = vec![];
+        let _ = reason_store.get_or_compute(
+            reason_ref,
+            ExplanationContext::from(&integers),
+            &mut PropagatorStore::default(),
+            &mut out_reason,
         );
+
+        assert_eq!(conjunction.as_slice(), &out_reason);
+    }
+
+    #[test]
+    fn reified_lazy_explanation_has_reification_added_after_compute() {
+        let mut reason_store = ReasonStore::default();
+        let mut integers = Assignments::default();
+
+        let x = integers.grow(1, 5);
+        let reif = Literal::new(integers.grow(0, 1));
+
+        struct TestPropagator(Vec<Predicate>);
+
+        impl Propagator for TestPropagator {
+            fn name(&self) -> &str {
+                todo!()
+            }
+
+            fn debug_propagate_from_scratch(
+                &self,
+                _: crate::engine::propagation::PropagationContextMut,
+            ) -> crate::basic_types::PropagationStatusCP {
+                todo!()
+            }
+
+            fn initialise_at_root(
+                &mut self,
+                _: &mut crate::engine::propagation::PropagatorInitialisationContext,
+            ) -> Result<(), PropositionalConjunction> {
+                todo!()
+            }
+
+            fn lazy_explanation(&mut self, code: u64, _: ExplanationContext) -> &[Predicate] {
+                assert_eq!(0, code);
+
+                &self.0
+            }
+        }
+
+        let mut propagator_store = PropagatorStore::default();
+        let propagator_id =
+            propagator_store.alloc(Box::new(TestPropagator(vec![predicate![x >= 2]])), None);
+        let reason_ref = reason_store.push(propagator_id, Reason::ReifiedLazy(reif, 0));
+
+        assert_eq!(ReasonRef(0), reason_ref);
+
+        let mut reason = vec![];
+        let _ = reason_store.get_or_compute(
+            reason_ref,
+            ExplanationContext::from(&integers),
+            &mut propagator_store,
+            &mut reason,
+        );
+
+        assert_eq!(vec![predicate![x >= 2], reif.get_true_predicate()], reason);
     }
 }

--- a/pumpkin-solver/src/engine/cp/test_solver.rs
+++ b/pumpkin-solver/src/engine/cp/test_solver.rs
@@ -244,14 +244,13 @@ impl TestSolver {
         let reason_ref = self
             .assignments
             .get_reason_for_predicate_brute_force(predicate);
-        let predicates = self
-            .reason_store
-            .get_or_compute(
-                reason_ref,
-                ExplanationContext::from(&self.assignments),
-                &mut self.propagator_store,
-            )
-            .expect("reason_ref should not be stale");
+        let mut predicates = vec![];
+        let _ = self.reason_store.get_or_compute(
+            reason_ref,
+            ExplanationContext::from(&self.assignments),
+            &mut self.propagator_store,
+            &mut predicates,
+        );
 
         PropositionalConjunction::from(predicates)
     }

--- a/pumpkin-solver/src/engine/debug_helper.rs
+++ b/pumpkin-solver/src/engine/debug_helper.rs
@@ -162,16 +162,15 @@ impl DebugHelper {
         for trail_index in num_trail_entries_before..assignments.num_trail_entries() {
             let trail_entry = assignments.get_trail_entry(trail_index);
 
-            let reason = reason_store
-                .get_or_compute(
-                    trail_entry
-                        .reason
-                        .expect("Expected checked propagation to have a reason"),
-                    ExplanationContext::from(assignments),
-                    propagators,
-                )
-                .expect("reason should exist for this propagation")
-                .to_vec();
+            let mut reason = vec![];
+            let _ = reason_store.get_or_compute(
+                trail_entry
+                    .reason
+                    .expect("Expected checked propagation to have a reason"),
+                ExplanationContext::from(assignments),
+                propagators,
+                &mut reason,
+            );
 
             result &= Self::debug_propagator_reason(
                 trail_entry.predicate,

--- a/pumpkin-solver/src/propagators/cumulative/time_table/propagation_handler.rs
+++ b/pumpkin-solver/src/propagators/cumulative/time_table/propagation_handler.rs
@@ -714,16 +714,15 @@ pub(crate) mod test_propagation_handler {
                 .assignments
                 .get_reason_for_predicate_brute_force(predicate);
             let mut propagator_store = PropagatorStore::default();
-            let reason = self
-                .reason_store
-                .get_or_compute(
-                    reason_ref,
-                    ExplanationContext::from(&self.assignments),
-                    &mut propagator_store,
-                )
-                .expect("reason_ref should not be stale");
+            let mut reason = vec![];
+            let _ = self.reason_store.get_or_compute(
+                reason_ref,
+                ExplanationContext::from(&self.assignments),
+                &mut propagator_store,
+                &mut reason,
+            );
 
-            reason.iter().copied().collect()
+            reason.into()
         }
     }
 }


### PR DESCRIPTION
Previously, submitting a lazy reason in a reified propagator would crash the solver. Implementing this is non-trivial, as reasons used in conflict analysis were returned as slices. However, we need to insert a reification literal into that slice somehow.

One approach would be to always return some owned buffer like a `Vec` from the reason store, so that it can insert the reification literal there. However, that would entail allocating when we ideally want to avoid that.

Instead, the solution implemented here is to provide the buffer that the reason should be written in to. Then it is up to the caller to either allocate or reuse an existing allocation.