### PR TITLE
feat: implement a tool to combine a proof with its literal mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,9 +112,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -116,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -128,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -140,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -198,6 +204,15 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "drcp-debugger"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "drcp-format 0.2.0",
+]
 
 [[package]]
 name = "drcp-format"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["./pumpkin-solver", "./drcp-format", "./pumpkin-py", "./pumpkin-macros", "drcp-debugger"]
+members = ["./pumpkin-solver", "./drcp-format", "./pumpkin-py", "./pumpkin-macros", "./drcp-debugger"]
 resolver = "2"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["./pumpkin-solver", "./drcp-format", "./pumpkin-py", "./pumpkin-macros"]
+members = ["./pumpkin-solver", "./drcp-format", "./pumpkin-py", "./pumpkin-macros", "drcp-debugger"]
 resolver = "2"
 
 [workspace.package]

--- a/drcp-debugger/Cargo.toml
+++ b/drcp-debugger/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "drcp-debugger"
+version = "0.1.0"
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+anyhow = "1.0.97"
+clap = { version = "4.5.31", features = ["derive"] }
+drcp-format = { path = "../drcp-format" }
+
+[lints]
+workspace = true

--- a/drcp-debugger/src/main.rs
+++ b/drcp-debugger/src/main.rs
@@ -1,0 +1,88 @@
+use std::{fs::File, io::Write, path::PathBuf};
+
+use anyhow::Context;
+use clap::Parser;
+use drcp_format::{
+    reader::ProofReader,
+    steps::{Conclusion, Step},
+    LiteralDefinitions,
+};
+
+#[derive(Parser)]
+struct Cli {
+    /// The input proof.
+    input_proof: PathBuf,
+    /// The input literals.
+    input_lits: PathBuf,
+    /// The output proof where literals are replaced with atomics.
+    output: PathBuf,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Cli::parse();
+
+    let input_proof = File::open(&args.input_proof)
+        .with_context(|| format!("Failed to open {}", args.input_proof.display()))?;
+
+    let input_lits = File::open(&args.input_lits)
+        .with_context(|| format!("Failed to open {}", args.input_proof.display()))?;
+
+    let literals = LiteralDefinitions::<String>::parse(input_lits).with_context(|| {
+        format!(
+            "Failed to parse literal definitions from {}.",
+            args.input_lits.display()
+        )
+    })?;
+
+    let mut reader = ProofReader::new(input_proof, literals);
+    let mut output = File::create(&args.output)
+        .with_context(|| format!("Failed to create {}", args.output.display()))?;
+
+    while let Some(step) = reader.next_step()? {
+        match step {
+            Step::Inference(inference) => {
+                write!(output, "i {}", inference.id)?;
+
+                for premise in inference.premises {
+                    write!(output, " {}", premise)?;
+                }
+
+                if let Some(propagated) = inference.propagated {
+                    write!(output, " 0 {}", propagated)?;
+                }
+
+                if let Some(label) = inference.hint_label {
+                    write!(output, " l:{label}")?;
+                }
+
+                if let Some(constraint_id) = inference.hint_constraint_id {
+                    write!(output, " c:{constraint_id}")?;
+                }
+
+                writeln!(output)?;
+            }
+            Step::Nogood(nogood) => {
+                write!(output, "n {}", nogood.id)?;
+
+                for literal in nogood.literals {
+                    write!(output, " {}", literal)?;
+                }
+
+                write!(output, " 0")?;
+
+                for hint in nogood.hints.iter().flatten() {
+                    write!(output, " {}", hint)?;
+                }
+
+                writeln!(output)?;
+            }
+            Step::Delete(step) => writeln!(output, "d {}", step.id)?,
+            Step::Conclusion(conclusion) => match conclusion {
+                Conclusion::Unsatisfiable => writeln!(output, "c UNSAT")?,
+                Conclusion::Optimal(bound) => writeln!(output, "c {bound}")?,
+            },
+        }
+    }
+
+    Ok(())
+}

--- a/drcp-debugger/src/main.rs
+++ b/drcp-debugger/src/main.rs
@@ -1,12 +1,13 @@
-use std::{fs::File, io::Write, path::PathBuf};
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
 
 use anyhow::Context;
 use clap::Parser;
-use drcp_format::{
-    reader::ProofReader,
-    steps::{Conclusion, Step},
-    LiteralDefinitions,
-};
+use drcp_format::reader::ProofReader;
+use drcp_format::steps::Conclusion;
+use drcp_format::steps::Step;
+use drcp_format::LiteralDefinitions;
 
 #[derive(Parser)]
 struct Cli {

--- a/drcp-format/src/reader/mod.rs
+++ b/drcp-format/src/reader/mod.rs
@@ -250,7 +250,11 @@ fn nogood_step(input: &str) -> IResult<&str, Nogood<Vec<NonZero<i32>>, Vec<StepI
             step_id,
             tag(" "),
             literal_list,
-            opt(preceded(tag(" 0 "), separated_list0(tag(" "), step_id))),
+            opt(preceded(
+                // Hack! If `literal_list` is empty, then the space will be parsed already.
+                alt((tag("0 "), tag(" 0 "))),
+                separated_list0(tag(" "), step_id),
+            )),
         )),
         |(_, id, _, literals, hints)| Nogood {
             id,

--- a/drcp-format/src/reader/mod.rs
+++ b/drcp-format/src/reader/mod.rs
@@ -343,4 +343,22 @@ mod tests {
         };
         assert_eq!(Some(Step::Inference(expected_inference)), inference_step);
     }
+
+    #[test]
+    fn empty_nogood_with_hints() {
+        let source = "n 100 0 1 4 5\n";
+        let mut reader = ProofReader::new(source.as_bytes(), std::convert::identity);
+
+        let nogood_step = reader.next_step().expect("valid drcp nogood step");
+        let expected_nogood = Nogood {
+            id: NonZero::new(100).unwrap(),
+            literals: vec![],
+            hints: Some(vec![
+                NonZero::new(1).unwrap(),
+                NonZero::new(4).unwrap(),
+                NonZero::new(5).unwrap(),
+            ]),
+        };
+        assert_eq!(Some(Step::Nogood(expected_nogood)), nogood_step);
+    }
 }


### PR DESCRIPTION
The tool takes a proof and replaces all the literals with appropriate atomic constraints. This makes for easier reading of the proof by humans.

fix(drcp-format): An empty nogood with hints can now be parsed.