### PR TITLE
fix: also log the inference that led to an empty domain

### DIFF
--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -1146,15 +1146,12 @@ impl ConstraintSatisfactionSolver {
             Some(entry.predicate),
         );
 
-        empty_domain_reason
-            .into_iter()
-            // The empty domain reason at this point only contains the reason for the last
-            // propagated predicate. The following also ensures the opposite is present.
-            .chain([
-                predicate!(conflict_domain >= entry.old_lower_bound),
-                predicate!(conflict_domain <= entry.old_upper_bound),
-            ])
-            .collect()
+        empty_domain_reason.extend([
+            predicate!(conflict_domain >= entry.old_lower_bound),
+            predicate!(conflict_domain <= entry.old_upper_bound),
+        ]);
+
+        empty_domain_reason.into()
     }
 
     /// Main propagation loop.


### PR DESCRIPTION
When we compute the starting point of the conflict analysis, we ignore the very last propagation in the proof log. This meant the proof would be missing a proof step.