### PR TITLE
feat/wasm emscripten target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "drcp-format"
-version = "0.2.1"
+version = "0.2.0"
 dependencies = [
  "nom",
  "thiserror",
@@ -304,8 +310,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -362,6 +370,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -545,6 +563,7 @@ dependencies = [
  "env_logger",
  "flatzinc",
  "fnv",
+ "getrandom",
  "itertools",
  "log",
  "num",
@@ -810,6 +829,63 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi-util"

--- a/pumpkin-solver/Cargo.toml
+++ b/pumpkin-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pumpkin-solver"
-version = "0.2.0"
+version = "0.1.4"
 description = "The Pumpkin combinatorial optimisation solver library."
 readme = "../README.md"
 authors.workspace = true
@@ -15,10 +15,9 @@ bitfield = "0.14.0"
 enumset = "1.1.2"
 fnv = "1.0.3"
 rand = { version = "0.8.5", features = [ "small_rng", "alloc" ] }
-signal-hook = "0.3.17"
 once_cell = "1.19.0"
 downcast-rs = "1.2.1"
-drcp-format = { version = "0.2.1", path = "../drcp-format" }
+drcp-format = { version = "0.2.0", path = "../drcp-format" }
 convert_case = "0.6.0"
 itertools = "0.13.0"
 flatzinc = "0.3.21"
@@ -27,6 +26,12 @@ env_logger = "0.10.0"
 bitfield-struct = "0.9.2"
 num = "0.4.3"
 enum-map = "2.7.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+signal-hook = "0.3.17"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 clap = { version = "4.5.17", features = ["derive"] }

--- a/pumpkin-solver/build.rs
+++ b/pumpkin-solver/build.rs
@@ -71,7 +71,13 @@ fn add_output_file<P: AsRef<Path>>(
     output_stem: &str,
 ) {
     let output_dir = output_dir.as_ref();
-    if is_msvc {
+    let target = std::env::var("TARGET").unwrap();
+    if target.contains("wasm32") {
+        // Output as a .wasm file when targeting WebAssembly.
+        let wasm_filename = format!("{output_stem}.wasm");
+        let output_file = output_dir.join(wasm_filename);
+        let _ = cmd.arg("-o").arg(output_file);
+    } else if is_msvc {
         let exe_name = format!("{output_stem}.exe");
 
         // The path to the object file.

--- a/pumpkin-solver/src/api/mod.rs
+++ b/pumpkin-solver/src/api/mod.rs
@@ -86,6 +86,7 @@ pub mod termination {
     //! the time budget is exceeded.
     pub use crate::engine::termination::combinator::*;
     pub use crate::engine::termination::indefinite::*;
+    #[cfg(not(target_arch = "wasm32"))]
     pub use crate::engine::termination::os_signal::*;
     pub use crate::engine::termination::time_budget::*;
     pub use crate::engine::termination::TerminationCondition;


### PR DESCRIPTION
This is a PR of 1 commit on top of https://github.com/ConSol-Lab/Pumpkin/tree/feat/support-webassembly by @maartenflippo as discussed in https://github.com/ConSol-Lab/Pumpkin/issues/161#issuecomment-2792467275

- **feat: only include OsSignal termination if not in wasm**
- **feat(wasm32): use `wasm32-emscripten` target to provide C headers needed to build WebAssembly**

Please feel free to just extract these files which got changed in the 1 real commit I added:

```
Cargo.lock
pumpkin-solver/Cargo.toml
pumpkin-solver/build.rs
pumpkin-solver/src/api/mod.rs
pumpkin-solver/src/bin/pumpkin-solver/flatzinc/mod.rs
```