### PR TITLE
fix: Properly explain root-level explanations that are not considered during conflict analysis

### DIFF
--- a/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -21,7 +21,9 @@ use crate::engine::PropagatorQueue;
 use crate::engine::TrailedValues;
 use crate::engine::WatchListCP;
 use crate::predicate;
+use crate::proof::explain_root_assignment;
 use crate::proof::ProofLog;
+use crate::proof::RootExplanationContext;
 use crate::pumpkin_assert_simple;
 use crate::variables::DomainId;
 
@@ -90,7 +92,7 @@ impl ConflictAnalysisContext<'_> {
     /// Returns a nogood which led to the conflict, excluding predicates from the root decision
     /// level.
     pub(crate) fn get_conflict_nogood(&mut self) -> Vec<Predicate> {
-        match self.solver_state.get_conflict_info() {
+        let conflict_nogood = match self.solver_state.get_conflict_info() {
             StoredConflictInfo::Propagator {
                 conflict_nogood,
                 propagator_id,
@@ -100,33 +102,46 @@ impl ConflictAnalysisContext<'_> {
                     conflict_nogood.iter().copied(),
                     None,
                 );
+
                 conflict_nogood
-                    .iter()
-                    .filter(|p| {
-                        // filter out root predicates
-                        self.assignments
-                            .get_decision_level_for_predicate(p)
-                            .is_some_and(|dl| dl > 0)
-                    })
-                    .copied()
-                    .collect()
             }
             StoredConflictInfo::EmptyDomain { conflict_nogood } => {
                 conflict_nogood
-                    .iter()
-                    .filter(|p| {
-                        // filter out root predicates
-                        self.assignments
-                            .get_decision_level_for_predicate(p)
-                            .is_some_and(|dl| dl > 0)
-                    })
-                    .copied()
-                    .collect()
             }
             StoredConflictInfo::RootLevelConflict(_) => {
                 unreachable!("Should never attempt to learn a nogood from a root level conflict")
             }
+        };
+
+        for &predicate in conflict_nogood.iter() {
+            if self
+                .assignments
+                .get_decision_level_for_predicate(&predicate)
+                .unwrap()
+                == 0
+            {
+                explain_root_assignment(
+                    &mut RootExplanationContext {
+                        propagators: self.propagators,
+                        proof_log: self.proof_log,
+                        unit_nogood_step_ids: self.unit_nogood_step_ids,
+                        assignments: self.assignments,
+                        reason_store: self.reason_store,
+                    },
+                    predicate,
+                );
+            }
         }
+
+        conflict_nogood
+            .into_iter()
+            .filter(|p| {
+                self.assignments
+                    .get_decision_level_for_predicate(p)
+                    .unwrap()
+                    > 0
+            })
+            .collect()
     }
 
     /// Compute the reason for `predicate` being true. The reason will be stored in

--- a/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -105,9 +105,7 @@ impl ConflictAnalysisContext<'_> {
 
                 conflict_nogood
             }
-            StoredConflictInfo::EmptyDomain { conflict_nogood } => {
-                conflict_nogood
-            }
+            StoredConflictInfo::EmptyDomain { conflict_nogood } => conflict_nogood,
             StoredConflictInfo::RootLevelConflict(_) => {
                 unreachable!("Should never attempt to learn a nogood from a root level conflict")
             }

--- a/pumpkin-solver/src/engine/cp/assignments.rs
+++ b/pumpkin-solver/src/engine/cp/assignments.rs
@@ -157,6 +157,8 @@ impl Assignments {
             } else {
                 self.remove_value_from_domain(domain_id, value, None)
                     .expect("the domain should not be empty");
+
+                self.domains[domain_id].initial_holes.push(value);
             }
         }
         self.domains[domain_id].initial_bounds_below_trail = self.trail.len() - 1;
@@ -291,12 +293,7 @@ impl Assignments {
     }
 
     pub(crate) fn get_initial_holes(&self, domain_id: DomainId) -> Vec<i32> {
-        self.domains[domain_id]
-            .hole_updates
-            .iter()
-            .take_while(|h| h.decision_level == 0)
-            .map(|h| h.removed_value)
-            .collect()
+        self.domains[domain_id].initial_holes.clone()
     }
 
     pub(crate) fn get_assigned_value<Var: IntegerVariable + 'static>(
@@ -829,6 +826,8 @@ struct IntegerDomain {
     holes: HashMap<i32, PairDecisionLevelTrailPosition>,
     // Records the trail entry at which all of the root bounds are true
     initial_bounds_below_trail: usize,
+    /// The holes that exist in the input problem.
+    initial_holes: Vec<i32>,
 }
 
 impl IntegerDomain {
@@ -854,6 +853,7 @@ impl IntegerDomain {
 
         IntegerDomain {
             id,
+            initial_holes: vec![],
             lower_bound_updates,
             upper_bound_updates,
             hole_updates: vec![],

--- a/pumpkin-solver/src/engine/cp/assignments.rs
+++ b/pumpkin-solver/src/engine/cp/assignments.rs
@@ -801,6 +801,10 @@ struct BoundUpdateInfo {
 struct HoleUpdateInfo {
     removed_value: i32,
 
+    #[allow(
+        dead_code,
+        reason = "Unsure whether the current implementation will pass review. However, if it does, this can be removed."
+    )]
     decision_level: usize,
 
     triggered_lower_bound_update: bool,

--- a/pumpkin-solver/src/engine/cp/assignments.rs
+++ b/pumpkin-solver/src/engine/cp/assignments.rs
@@ -801,12 +801,6 @@ struct BoundUpdateInfo {
 struct HoleUpdateInfo {
     removed_value: i32,
 
-    #[allow(
-        dead_code,
-        reason = "Unsure whether the current implementation will pass review. However, if it does, this can be removed."
-    )]
-    decision_level: usize,
-
     triggered_lower_bound_update: bool,
     triggered_upper_bound_update: bool,
 }
@@ -1001,7 +995,6 @@ impl IntegerDomain {
 
         self.hole_updates.push(HoleUpdateInfo {
             removed_value,
-            decision_level,
             triggered_lower_bound_update: false,
             triggered_upper_bound_update: false,
         });


### PR DESCRIPTION
In the proof log, this difference is crucial. We cannot say that initial holes are those at decision level 0.