### PR TITLE
fix: Update outdated documentation from before the v0.2 release

### DIFF
--- a/pumpkin-solver/src/engine/cp/propagation/propagator.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/propagator.rs
@@ -27,8 +27,8 @@ use crate::statistics::statistic_logger::StatisticLogger;
 // does not allow downcasting from the trait definition to its concrete type.
 impl_downcast!(Propagator);
 
-/// All propagators implement the [`Propagator`] trait, with the exception of the
-/// clausal propagator. Structs implementing the trait defines the main propagator logic with
+/// All propagators implement the [`Propagator`] trait.
+/// Structs implementing the trait defines the main propagator logic with
 /// regards to propagation, detecting conflicts, and providing explanations.
 ///
 /// The only required functions are [`Propagator::name`],

--- a/pumpkin-solver/src/engine/cp/propagation/propagator.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/propagator.rs
@@ -27,8 +27,7 @@ use crate::statistics::statistic_logger::StatisticLogger;
 // does not allow downcasting from the trait definition to its concrete type.
 impl_downcast!(Propagator);
 
-/// All propagators implement the [`Propagator`] trait.
-/// Structs implementing the trait defines the main propagator logic with
+/// All propagators implement the [`Propagator`] trait, which defines the main propagator logic with
 /// regards to propagation, detecting conflicts, and providing explanations.
 ///
 /// The only required functions are [`Propagator::name`],

--- a/pumpkin-solver/src/propagators/arithmetic/linear_less_or_equal.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/linear_less_or_equal.rs
@@ -18,7 +18,7 @@ use crate::engine::TrailedInt;
 use crate::predicate;
 use crate::pumpkin_assert_simple;
 
-/// Propagator for the constraint `reif => \sum x_i <= c`.
+/// Propagator for the constraint `\sum x_i <= c`.
 #[derive(Clone, Debug)]
 pub(crate) struct LinearLessOrEqualPropagator<Var> {
     x: Box<[Var]>,

--- a/pumpkin-solver/src/propagators/nogoods/nogood_propagator.rs
+++ b/pumpkin-solver/src/propagators/nogoods/nogood_propagator.rs
@@ -249,7 +249,7 @@ impl Propagator for NogoodPropagator {
                             end_index += 1;
                             current_index += 1;
 
-                            // At this point, nonwatched predicates and nogood[1] are falsified.
+                            // At this point, nonwatched predicates and nogood[1] are true.
                             pumpkin_assert_advanced!(nogood
                                 .iter()
                                 .skip(1)
@@ -385,7 +385,7 @@ impl Propagator for NogoodPropagator {
                             end_index += 1;
                             current_index += 1;
 
-                            // At this point, nonwatched predicates and nogood[1] are falsified.
+                            // At this point, nonwatched predicates and nogood[1] are true.
                             pumpkin_assert_advanced!(nogood
                                 .iter()
                                 .skip(1)
@@ -579,7 +579,7 @@ impl Propagator for NogoodPropagator {
                             end_index += 1;
                             current_index += 1;
 
-                            // At this point, nonwatched predicates and nogood[1] are falsified.
+                            // At this point, nonwatched predicates and nogood[1] are true.
                             pumpkin_assert_advanced!(nogood
                                 .iter()
                                 .skip(1)
@@ -716,7 +716,7 @@ impl Propagator for NogoodPropagator {
                             end_index += 1;
                             current_index += 1;
 
-                            // At this point, nonwatched predicates and nogood[1] are falsified.
+                            // At this point, nonwatched predicates and nogood[1] are true.
                             pumpkin_assert_advanced!(nogood
                                 .iter()
                                 .skip(1)


### PR DESCRIPTION
I made minor changes to the comments, mainly outdated comments that refer to the pre-revamp version.