### PR TITLE
docs: Expand documentation of reified propagator

### DIFF
--- a/pumpkin-solver/src/propagators/reified_propagator.rs
+++ b/pumpkin-solver/src/propagators/reified_propagator.rs
@@ -14,24 +14,24 @@ use crate::predicates::PropositionalConjunction;
 use crate::pumpkin_assert_simple;
 use crate::variables::Literal;
 
-/// Propagator for the constraint `r -> p`, where `r` is a Boolean literal and `p` is an arbitrary
-/// propagator.
+/// Propagator for the constraint `r -> p`,
+/// where `r` is a literal and `p` is an arbitrary propagator.
 ///
-/// When a propagator is reified, it will only propagate whenever `r` is set to true. However, if
-/// the propagator implements [`Propagator::detect_inconsistency`], the result of that method may
-/// be used to propagate `r` to false. If that method is not implemented, `r` will never be
-/// propagated to false.
+/// By default, the propagator 'p' only propagates whenever `r` is set to true.
+/// However, if the propagator 'p' implements [`Propagator::detect_inconsistency`], the result of
+/// that method may be used to propagate `r` to false. If that method is not implemented, `r` will
+/// never be propagated to false.
 #[derive(Clone, Debug)]
 pub(crate) struct ReifiedPropagator<WrappedPropagator> {
-    propagator: WrappedPropagator,
     reification_literal: Literal,
+    /// The `LocalId` of the reification literal. Is guaranteed to be a larger ID than any of the
+    /// registered ids of the wrapped propagator.
+    reification_literal_id: LocalId,
+    propagator: WrappedPropagator,
     /// An inconsistency that is identified by `propagator`.
     inconsistency: Option<PropositionalConjunction>,
     /// The formatted name of the propagator.
     name: String,
-    /// The `LocalId` of the reification literal. Is guaranteed to be a larger ID than any of the
-    /// registered ids of the wrapped propagator.
-    reification_literal_id: LocalId,
 }
 
 impl<WrappedPropagator: Propagator> ReifiedPropagator<WrappedPropagator> {


### PR DESCRIPTION
- Expanded the documentation a bit.
- Placed reified literal id right after the reified literal.
- Placed reified literal as the first field and the propagator as the second, to follow r -> p.