### PR TITLE
refactor: Remove default constructor for TrailedInteger

### DIFF
--- a/pumpkin-solver/src/engine/cp/trailed/trailed_integer.rs
+++ b/pumpkin-solver/src/engine/cp/trailed/trailed_integer.rs
@@ -5,12 +5,6 @@ pub(crate) struct TrailedInteger {
     id: u32,
 }
 
-impl Default for TrailedInteger {
-    fn default() -> Self {
-        Self { id: u32::MAX }
-    }
-}
-
 impl StorageKey for TrailedInteger {
     fn index(&self) -> usize {
         self.id as usize


### PR DESCRIPTION
A `TrailedInteger` should only be created via a trail. Having a default constructor breaks that invariant. Consequently, if someone ever uses a `TrailedInteger` that was created with the default constructor, the solver would crash.