### PR TITLE
feat: Reduce size of Predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ The solver currently supports integer variables and a number of (global) constra
 
 We are actively developing Pumpkin and would be happy to hear from you should you have any questions or feature requests!
 
-
+# Citing
+Please cite pumpkin using the following citation:
+```
+@misc{
+    Pumpkin,
+    title={Pumpkin: A Lazy Clause Generation constraint solver in Rust},
+    url={https://github.com/ConSol-Lab/Pumpkin},
+    author={Demirović, Emir and Flippo, Maarten and Marijnissen, Imko and Sidorov, Konstantin and Smits Jeff},
+    year={2024}
+    organization={ConSol Lab - Delft University of Technology}
+} 
+```
 
 # Usage
 

--- a/pumpkin-solver/src/api/mod.rs
+++ b/pumpkin-solver/src/api/mod.rs
@@ -97,10 +97,10 @@ pub mod predicates {
     //! Contains structures which represent certain [predicates](https://en.wikipedia.org/wiki/Predicate_(mathematical_logic)).
     //!
     //! The solver only utilizes the following types of predicates:
-    //! - A [`Predicate::LowerBound`] of the form `[x >= v]`
-    //! - A [`Predicate::UpperBound`] of the form `[x <= v]`
-    //! - A [`Predicate::Equal`] of the form `[x = v]`
-    //! - A [`Predicate::NotEqual`] of the form `[x != v]`
+    //! - A predicate of the form `[x >= v]`
+    //! - A predicate of the form `[x <= v]`
+    //! - A predicate of the form `[x = v]`
+    //! - A predicate of the form `[x != v]`
     //!
     //! In general, these [`Predicate`]s are used to represent propagations, explanations or
     //! decisions.

--- a/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -10,6 +10,7 @@ use crate::containers::StorageKey;
 use crate::engine::constraint_satisfaction_solver::CSPSolverState;
 use crate::engine::notifications::NotificationEngine;
 use crate::engine::predicates::predicate::Predicate;
+use crate::engine::predicates::predicate::PredicateType;
 use crate::engine::propagation::store::PropagatorStore;
 use crate::engine::propagation::CurrentNogood;
 use crate::engine::propagation::ExplanationContext;
@@ -242,17 +243,14 @@ impl ConflictAnalysisContext<'_> {
             // The reason for propagation depends on:
             // 1) The predicate on the trail at the moment the input predicate became true, and
             // 2) The input predicate.
-            match (trail_entry.predicate, predicate) {
-                (
-                    Predicate::LowerBound {
-                        domain_id: _,
-                        lower_bound: trail_lower_bound,
-                    },
-                    Predicate::LowerBound {
-                        domain_id,
-                        lower_bound: input_lower_bound,
-                    },
-                ) => {
+            match (
+                trail_entry.predicate.get_predicate_type(),
+                predicate.get_predicate_type(),
+            ) {
+                (PredicateType::LowerBound, PredicateType::LowerBound) => {
+                    let trail_lower_bound = trail_entry.predicate.get_right_hand_side();
+                    let domain_id = predicate.get_domain();
+                    let input_lower_bound = predicate.get_right_hand_side();
                     // Both the input predicate and the trail predicate are lower bound
                     // literals. Two cases to consider:
                     // 1) The trail predicate has a greater right-hand side, meaning
@@ -283,29 +281,17 @@ impl ConflictAnalysisContext<'_> {
                         // only look for reasons for predicates from the current decision
                         // level, and we never look for reasons at the root level.
 
-                        let one_less_bound_predicate = Predicate::LowerBound {
-                            domain_id,
-                            lower_bound: input_lower_bound - 1,
-                        };
+                        let one_less_bound_predicate =
+                            predicate!(domain_id >= input_lower_bound - 1);
 
-                        let not_equals_predicate = Predicate::NotEqual {
-                            domain_id,
-                            not_equal_constant: input_lower_bound - 1,
-                        };
+                        let not_equals_predicate = predicate!(domain_id != input_lower_bound - 1);
                         reason_buffer.extend(std::iter::once(one_less_bound_predicate));
                         reason_buffer.extend(std::iter::once(not_equals_predicate));
                     }
                 }
-                (
-                    Predicate::LowerBound {
-                        domain_id: _,
-                        lower_bound: trail_lower_bound,
-                    },
-                    Predicate::NotEqual {
-                        domain_id: _,
-                        not_equal_constant,
-                    },
-                ) => {
+                (PredicateType::LowerBound, PredicateType::NotEqual) => {
+                    let trail_lower_bound = trail_entry.predicate.get_right_hand_side();
+                    let not_equal_constant = predicate.get_right_hand_side();
                     // The trail entry is a lower bound literal,
                     // and the input predicate is a not equals.
                     // Only one case to consider:
@@ -315,16 +301,9 @@ impl ConflictAnalysisContext<'_> {
                     pumpkin_assert_simple!(trail_lower_bound > not_equal_constant);
                     reason_buffer.extend(std::iter::once(trail_entry.predicate));
                 }
-                (
-                    Predicate::LowerBound {
-                        domain_id: _,
-                        lower_bound: _,
-                    },
-                    Predicate::Equal {
-                        domain_id,
-                        equality_constant,
-                    },
-                ) => {
+                (PredicateType::LowerBound, PredicateType::Equal) => {
+                    let domain_id = predicate.get_domain();
+                    let equality_constant = predicate.get_right_hand_side();
                     // The input predicate is an equality predicate, and the trail predicate
                     // is a lower bound predicate. This means that the time of posting the
                     // trail predicate is when the input predicate became true.
@@ -337,27 +316,15 @@ impl ConflictAnalysisContext<'_> {
                     // For example, {1, 2, 3, 10}, then posting [x >= 5] will raise the
                     // lower bound to x >= 10.
 
-                    let predicate_lb = Predicate::LowerBound {
-                        domain_id,
-                        lower_bound: equality_constant,
-                    };
-                    let predicate_ub = Predicate::UpperBound {
-                        domain_id,
-                        upper_bound: equality_constant,
-                    };
+                    let predicate_lb = predicate!(domain_id >= equality_constant);
+                    let predicate_ub = predicate!(domain_id <= equality_constant);
                     reason_buffer.extend(std::iter::once(predicate_lb));
                     reason_buffer.extend(std::iter::once(predicate_ub));
                 }
-                (
-                    Predicate::UpperBound {
-                        domain_id: _,
-                        upper_bound: trail_upper_bound,
-                    },
-                    Predicate::UpperBound {
-                        domain_id,
-                        upper_bound: input_upper_bound,
-                    },
-                ) => {
+                (PredicateType::UpperBound, PredicateType::UpperBound) => {
+                    let trail_upper_bound = trail_entry.predicate.get_right_hand_side();
+                    let domain_id = predicate.get_domain();
+                    let input_upper_bound = predicate.get_right_hand_side();
                     // Both the input and trail predicates are upper bound predicates.
                     // There are two scenarios to consider:
                     // 1) The input upper bound is greater than the trail upper bound, meaning that
@@ -379,28 +346,15 @@ impl ConflictAnalysisContext<'_> {
                         // The reason of the input predicate [x <= a] is computed recursively as
                         // the reason for [x <= a + 1] & [x != a + 1].
 
-                        let new_ub_predicate = Predicate::UpperBound {
-                            domain_id,
-                            upper_bound: input_upper_bound + 1,
-                        };
-                        let not_equal_predicate = Predicate::NotEqual {
-                            domain_id,
-                            not_equal_constant: input_upper_bound + 1,
-                        };
+                        let new_ub_predicate = predicate!(domain_id <= input_upper_bound + 1);
+                        let not_equal_predicate = predicate!(domain_id != input_upper_bound + 1);
                         reason_buffer.extend(std::iter::once(new_ub_predicate));
                         reason_buffer.extend(std::iter::once(not_equal_predicate));
                     }
                 }
-                (
-                    Predicate::UpperBound {
-                        domain_id: _,
-                        upper_bound: trail_upper_bound,
-                    },
-                    Predicate::NotEqual {
-                        domain_id: _,
-                        not_equal_constant,
-                    },
-                ) => {
+                (PredicateType::UpperBound, PredicateType::NotEqual) => {
+                    let trail_upper_bound = trail_entry.predicate.get_right_hand_side();
+                    let not_equal_constant = predicate.get_right_hand_side();
                     // The input predicate is a not equal predicate, and the trail predicate is
                     // an upper bound predicate. This is only possible when the upper bound was
                     // pushed below the not equals value. Otherwise the hole would have been
@@ -411,16 +365,9 @@ impl ConflictAnalysisContext<'_> {
                     // reason. todo: can do lifting here.
                     reason_buffer.extend(std::iter::once(trail_entry.predicate));
                 }
-                (
-                    Predicate::UpperBound {
-                        domain_id: _,
-                        upper_bound: _,
-                    },
-                    Predicate::Equal {
-                        domain_id,
-                        equality_constant,
-                    },
-                ) => {
+                (PredicateType::UpperBound, PredicateType::Equal) => {
+                    let domain_id = predicate.get_domain();
+                    let equality_constant = predicate.get_right_hand_side();
                     // The input predicate is an equality predicate, and the trail predicate
                     // is an upper bound predicate. This means that the time of posting the
                     // trail predicate is when the input predicate became true.
@@ -436,27 +383,15 @@ impl ConflictAnalysisContext<'_> {
                     // Note that it could be that one of the two predicates are decision
                     // predicates, so we need to use the substitute functions.
 
-                    let predicate_lb = Predicate::LowerBound {
-                        domain_id,
-                        lower_bound: equality_constant,
-                    };
-                    let predicate_ub = Predicate::UpperBound {
-                        domain_id,
-                        upper_bound: equality_constant,
-                    };
+                    let predicate_lb = predicate!(domain_id >= equality_constant);
+                    let predicate_ub = predicate!(domain_id <= equality_constant);
                     reason_buffer.extend(std::iter::once(predicate_lb));
                     reason_buffer.extend(std::iter::once(predicate_ub));
                 }
-                (
-                    Predicate::NotEqual {
-                        domain_id: _,
-                        not_equal_constant,
-                    },
-                    Predicate::LowerBound {
-                        domain_id,
-                        lower_bound: input_lower_bound,
-                    },
-                ) => {
+                (PredicateType::NotEqual, PredicateType::LowerBound) => {
+                    let not_equal_constant = trail_entry.predicate.get_right_hand_side();
+                    let domain_id = predicate.get_domain();
+                    let input_lower_bound = predicate.get_right_hand_side();
                     // The trail predicate is not equals, but the input predicate is a lower
                     // bound predicate. This means that creating the hole in the domain resulted
                     // in raising the lower bound.
@@ -470,28 +405,16 @@ impl ConflictAnalysisContext<'_> {
 
                     // The reason for the input predicate [x >= a] is computed recursively as
                     // the reason for [x >= a - 1] & [x != a - 1].
-                    let new_lb_predicate = Predicate::LowerBound {
-                        domain_id,
-                        lower_bound: input_lower_bound - 1,
-                    };
-                    let new_not_equals_predicate = Predicate::NotEqual {
-                        domain_id,
-                        not_equal_constant: input_lower_bound - 1,
-                    };
+                    let new_lb_predicate = predicate!(domain_id >= input_lower_bound - 1);
+                    let new_not_equals_predicate = predicate!(domain_id != input_lower_bound - 1);
 
                     reason_buffer.extend(std::iter::once(new_lb_predicate));
                     reason_buffer.extend(std::iter::once(new_not_equals_predicate));
                 }
-                (
-                    Predicate::NotEqual {
-                        domain_id: _,
-                        not_equal_constant,
-                    },
-                    Predicate::UpperBound {
-                        domain_id,
-                        upper_bound: input_upper_bound,
-                    },
-                ) => {
+                (PredicateType::NotEqual, PredicateType::UpperBound) => {
+                    let not_equal_constant = trail_entry.predicate.get_right_hand_side();
+                    let domain_id = predicate.get_domain();
+                    let input_upper_bound = predicate.get_right_hand_side();
                     // The trail predicate is not equals, but the input predicate is an upper
                     // bound predicate. This means that creating the hole in the domain resulted
                     // in lower the upper bound.
@@ -505,28 +428,15 @@ impl ConflictAnalysisContext<'_> {
 
                     // The reason for the input predicate [x <= a] is computed recursively as
                     // the reason for [x <= a + 1] & [x != a + 1].
-                    let new_ub_predicate = Predicate::UpperBound {
-                        domain_id,
-                        upper_bound: input_upper_bound + 1,
-                    };
-                    let new_not_equals_predicate = Predicate::NotEqual {
-                        domain_id,
-                        not_equal_constant: input_upper_bound + 1,
-                    };
+                    let new_ub_predicate = predicate!(domain_id <= input_upper_bound + 1);
+                    let new_not_equals_predicate = predicate!(domain_id != input_upper_bound + 1);
 
                     reason_buffer.extend(std::iter::once(new_ub_predicate));
                     reason_buffer.extend(std::iter::once(new_not_equals_predicate));
                 }
-                (
-                    Predicate::NotEqual {
-                        domain_id: _,
-                        not_equal_constant: _,
-                    },
-                    Predicate::Equal {
-                        domain_id,
-                        equality_constant,
-                    },
-                ) => {
+                (PredicateType::NotEqual, PredicateType::Equal) => {
+                    let domain_id = predicate.get_domain();
+                    let equality_constant = predicate.get_right_hand_side();
                     // The trail predicate is not equals, but the input predicate is
                     // equals. The only time this could is when the not equals forces the
                     // lower/upper bounds to meet. So we simply look for the reasons for those
@@ -535,14 +445,8 @@ impl ConflictAnalysisContext<'_> {
                     // Note that it could be that one of the two predicates are decision
                     // predicates, so we need to use the substitute functions.
 
-                    let predicate_lb = Predicate::LowerBound {
-                        domain_id,
-                        lower_bound: equality_constant,
-                    };
-                    let predicate_ub = Predicate::UpperBound {
-                        domain_id,
-                        upper_bound: equality_constant,
-                    };
+                    let predicate_lb = predicate!(domain_id >= equality_constant);
+                    let predicate_ub = predicate!(domain_id <= equality_constant);
 
                     reason_buffer.extend(std::iter::once(predicate_lb));
                     reason_buffer.extend(std::iter::once(predicate_ub));

--- a/pumpkin-solver/src/engine/conflict_analysis/minimisers/semantic_minimiser.rs
+++ b/pumpkin-solver/src/engine/conflict_analysis/minimisers/semantic_minimiser.rs
@@ -3,6 +3,7 @@ use std::cmp;
 use crate::basic_types::HashSet;
 use crate::containers::KeyedVec;
 use crate::containers::SparseSet;
+use crate::engine::predicates::predicate::PredicateType;
 use crate::engine::Assignments;
 use crate::predicate;
 use crate::predicates::Predicate;
@@ -68,30 +69,21 @@ impl SemanticMinimiser {
         for predicate in nogood {
             self.present_ids.insert(predicate.get_domain());
 
-            match *predicate {
-                Predicate::LowerBound {
-                    domain_id,
-                    lower_bound,
-                } => {
-                    self.domains[domain_id].tighten_lower_bound(lower_bound);
+            let domain_id = predicate.get_domain();
+            let value = predicate.get_right_hand_side();
+
+            match predicate.get_predicate_type() {
+                PredicateType::LowerBound => {
+                    self.domains[domain_id].tighten_lower_bound(value);
                 }
-                Predicate::UpperBound {
-                    domain_id,
-                    upper_bound,
-                } => {
-                    self.domains[domain_id].tighten_upper_bound(upper_bound);
+                PredicateType::UpperBound => {
+                    self.domains[domain_id].tighten_upper_bound(value);
                 }
-                Predicate::NotEqual {
-                    domain_id,
-                    not_equal_constant,
-                } => {
-                    self.domains[domain_id].add_hole(not_equal_constant);
+                PredicateType::NotEqual => {
+                    self.domains[domain_id].add_hole(value);
                 }
-                Predicate::Equal {
-                    domain_id,
-                    equality_constant,
-                } => {
-                    self.domains[domain_id].assign(equality_constant);
+                PredicateType::Equal => {
+                    self.domains[domain_id].assign(value);
                 }
             }
         }

--- a/pumpkin-solver/src/engine/cp/assignments.rs
+++ b/pumpkin-solver/src/engine/cp/assignments.rs
@@ -4,6 +4,7 @@ use crate::containers::KeyedVec;
 use crate::engine::cp::reason::ReasonRef;
 use crate::engine::notifications::NotificationEngine;
 use crate::engine::predicates::predicate::Predicate;
+use crate::engine::predicates::predicate::PredicateType;
 use crate::engine::variables::DomainGeneratorIterator;
 use crate::engine::variables::DomainId;
 use crate::predicate;
@@ -213,29 +214,20 @@ impl Assignments {
     }
 
     pub(crate) fn is_initial_bound(&self, predicate: Predicate) -> bool {
-        match predicate {
-            Predicate::LowerBound {
-                domain_id,
-                lower_bound,
-            } => lower_bound <= self.domains[domain_id].initial_lower_bound(),
-            Predicate::UpperBound {
-                domain_id,
-                upper_bound,
-            } => upper_bound >= self.domains[domain_id].initial_upper_bound(),
-            Predicate::NotEqual {
-                domain_id,
-                not_equal_constant: _,
-            } => {
+        let domain_id = predicate.get_domain();
+        let value = predicate.get_right_hand_side();
+
+        match predicate.get_predicate_type() {
+            PredicateType::LowerBound => value <= self.domains[domain_id].initial_lower_bound(),
+            PredicateType::UpperBound => value >= self.domains[domain_id].initial_upper_bound(),
+            PredicateType::NotEqual => {
                 self.get_trail_position(&predicate).unwrap_or_else(|| {
                     panic!("Expected to be able to get trail entry of {predicate}")
                 }) <= self.domains[domain_id].initial_bounds_below_trail
             }
-            Predicate::Equal {
-                domain_id,
-                equality_constant,
-            } => {
-                equality_constant == self.domains[domain_id].initial_lower_bound()
-                    && equality_constant == self.domains[domain_id].initial_upper_bound()
+            PredicateType::Equal => {
+                value == self.domains[domain_id].initial_lower_bound()
+                    && value == self.domains[domain_id].initial_upper_bound()
             }
         }
     }
@@ -401,10 +393,7 @@ impl Assignments {
             return self.domains[domain_id].verify_consistency();
         }
 
-        let predicate = Predicate::LowerBound {
-            domain_id,
-            lower_bound: new_lower_bound,
-        };
+        let predicate = predicate!(domain_id >= new_lower_bound);
 
         let old_lower_bound = self.get_lower_bound(domain_id);
         let old_upper_bound = self.get_upper_bound(domain_id);
@@ -443,10 +432,7 @@ impl Assignments {
             return self.domains[domain_id].verify_consistency();
         }
 
-        let predicate = Predicate::UpperBound {
-            domain_id,
-            upper_bound: new_upper_bound,
-        };
+        let predicate = predicate!(domain_id <= new_upper_bound);
 
         let old_lower_bound = self.get_lower_bound(domain_id);
         let old_upper_bound = self.get_upper_bound(domain_id);
@@ -507,10 +493,7 @@ impl Assignments {
             return self.domains[domain_id].verify_consistency();
         }
 
-        let predicate = Predicate::NotEqual {
-            domain_id,
-            not_equal_constant: removed_value_from_domain,
-        };
+        let predicate = predicate!(domain_id != removed_value_from_domain);
 
         let old_lower_bound = self.get_lower_bound(domain_id);
         let old_upper_bound = self.get_upper_bound(domain_id);
@@ -559,27 +542,18 @@ impl Assignments {
         let upper_bound_before = self.domains[predicate.get_domain()].upper_bound();
 
         let mut removal_took_place = false;
-        let update_took_place = match predicate {
-            Predicate::LowerBound {
-                domain_id,
-                lower_bound,
-            } => self.tighten_lower_bound(domain_id, lower_bound, reason)?,
-            Predicate::UpperBound {
-                domain_id,
-                upper_bound,
-            } => self.tighten_upper_bound(domain_id, upper_bound, reason)?,
-            Predicate::NotEqual {
-                domain_id,
-                not_equal_constant,
-            } => {
-                removal_took_place =
-                    self.remove_value_from_domain(domain_id, not_equal_constant, reason)?;
+
+        let domain_id = predicate.get_domain();
+        let value = predicate.get_right_hand_side();
+
+        let update_took_place = match predicate.get_predicate_type() {
+            PredicateType::LowerBound => self.tighten_lower_bound(domain_id, value, reason)?,
+            PredicateType::UpperBound => self.tighten_upper_bound(domain_id, value, reason)?,
+            PredicateType::NotEqual => {
+                removal_took_place = self.remove_value_from_domain(domain_id, value, reason)?;
                 removal_took_place
             }
-            Predicate::Equal {
-                domain_id,
-                equality_constant,
-            } => self.make_assignment(domain_id, equality_constant, reason)?,
+            PredicateType::Equal => self.make_assignment(domain_id, value, reason)?,
         };
 
         if update_took_place {
@@ -600,54 +574,45 @@ impl Assignments {
     /// [`Assignments`]. In case the predicate is not assigned yet (neither true nor false),
     /// returns None.
     pub(crate) fn evaluate_predicate(&self, predicate: Predicate) -> Option<bool> {
-        match predicate {
-            Predicate::LowerBound {
-                domain_id,
-                lower_bound,
-            } => {
-                if self.get_lower_bound(domain_id) >= lower_bound {
+        let domain_id = predicate.get_domain();
+        let value = predicate.get_right_hand_side();
+
+        match predicate.get_predicate_type() {
+            PredicateType::LowerBound => {
+                if self.get_lower_bound(domain_id) >= value {
                     Some(true)
-                } else if self.get_upper_bound(domain_id) < lower_bound {
+                } else if self.get_upper_bound(domain_id) < value {
                     Some(false)
                 } else {
                     None
                 }
             }
-            Predicate::UpperBound {
-                domain_id,
-                upper_bound,
-            } => {
-                if self.get_upper_bound(domain_id) <= upper_bound {
+            PredicateType::UpperBound => {
+                if self.get_upper_bound(domain_id) <= value {
                     Some(true)
-                } else if self.get_lower_bound(domain_id) > upper_bound {
+                } else if self.get_lower_bound(domain_id) > value {
                     Some(false)
                 } else {
                     None
                 }
             }
-            Predicate::NotEqual {
-                domain_id,
-                not_equal_constant,
-            } => {
-                if !self.is_value_in_domain(domain_id, not_equal_constant) {
+            PredicateType::NotEqual => {
+                if !self.is_value_in_domain(domain_id, value) {
                     Some(true)
                 } else if let Some(assigned_value) = self.get_assigned_value(&domain_id) {
                     // Previous branch concluded the value is not in the domain, so if the variable
                     // is assigned, then it is assigned to the not equals value.
-                    pumpkin_assert_simple!(assigned_value == not_equal_constant);
+                    pumpkin_assert_simple!(assigned_value == value);
                     Some(false)
                 } else {
                     None
                 }
             }
-            Predicate::Equal {
-                domain_id,
-                equality_constant,
-            } => {
-                if !self.is_value_in_domain(domain_id, equality_constant) {
+            PredicateType::Equal => {
+                if !self.is_value_in_domain(domain_id, value) {
                     Some(false)
                 } else if let Some(assigned_value) = self.get_assigned_value(&domain_id) {
-                    pumpkin_assert_moderate!(assigned_value == equality_constant);
+                    pumpkin_assert_moderate!(assigned_value == value);
                     Some(true)
                 } else {
                     None
@@ -668,28 +633,17 @@ impl Assignments {
     }
 
     pub(crate) fn is_implied_by_bounds(&self, predicate: Predicate) -> bool {
-        match predicate {
-            Predicate::LowerBound {
-                domain_id,
-                lower_bound,
-            } => self.get_lower_bound(domain_id) >= lower_bound,
-            Predicate::UpperBound {
-                domain_id,
-                upper_bound,
-            } => self.get_upper_bound(domain_id) <= upper_bound,
-            Predicate::NotEqual {
-                domain_id,
-                not_equal_constant,
-            } => {
-                self.get_lower_bound(domain_id) > not_equal_constant
-                    || self.get_upper_bound(domain_id) < not_equal_constant
+        let domain_id = predicate.get_domain();
+        let value = predicate.get_right_hand_side();
+
+        match predicate.get_predicate_type() {
+            PredicateType::LowerBound => self.get_lower_bound(domain_id) >= value,
+            PredicateType::UpperBound => self.get_upper_bound(domain_id) <= value,
+            PredicateType::NotEqual => {
+                self.get_lower_bound(domain_id) > value || self.get_upper_bound(domain_id) < value
             }
-            Predicate::Equal {
-                domain_id,
-                equality_constant,
-            } => {
-                self.get_lower_bound(domain_id) == equality_constant
-                    && equality_constant == self.get_upper_bound(domain_id)
+            PredicateType::Equal => {
+                self.get_lower_bound(domain_id) == value && value == self.get_upper_bound(domain_id)
             }
         }
     }
@@ -729,10 +683,8 @@ impl Assignments {
             let add_on_lower_bound = lower_bound_before.abs_diff(entry.old_lower_bound) as u64;
             self.pruned_values -= add_on_upper_bound + add_on_lower_bound;
 
-            if let Predicate::NotEqual { .. } = entry.predicate {
-                if add_on_lower_bound + add_on_upper_bound == 0 {
-                    self.pruned_values -= 1;
-                }
+            if entry.predicate.is_not_equal_predicate() && add_on_lower_bound + add_on_upper_bound == 0 {
+                self.pruned_values -= 1;
             }
 
             let fixed_before = self.domains[domain_id].lower_bound() == self.domains[domain_id].upper_bound();
@@ -1150,30 +1102,24 @@ impl IntegerDomain {
     }
 
     fn undo_trail_entry(&mut self, entry: &ConstraintProgrammingTrailEntry) {
-        match entry.predicate {
-            Predicate::LowerBound {
-                domain_id,
-                lower_bound: _,
-            } => {
+        let domain_id = entry.predicate.get_domain();
+        match entry.predicate.get_predicate_type() {
+            PredicateType::LowerBound => {
                 pumpkin_assert_moderate!(domain_id == self.id);
 
                 let _ = self.lower_bound_updates.pop();
                 pumpkin_assert_moderate!(!self.lower_bound_updates.is_empty());
             }
-            Predicate::UpperBound {
-                domain_id,
-                upper_bound: _,
-            } => {
+            PredicateType::UpperBound => {
                 pumpkin_assert_moderate!(domain_id == self.id);
 
                 let _ = self.upper_bound_updates.pop();
                 pumpkin_assert_moderate!(!self.upper_bound_updates.is_empty());
             }
-            Predicate::NotEqual {
-                domain_id,
-                not_equal_constant,
-            } => {
+            PredicateType::NotEqual => {
                 pumpkin_assert_moderate!(domain_id == self.id);
+
+                let not_equal_constant = entry.predicate.get_right_hand_side();
 
                 let hole_update = self
                     .hole_updates
@@ -1196,10 +1142,7 @@ impl IntegerDomain {
                     pumpkin_assert_moderate!(!self.upper_bound_updates.is_empty());
                 }
             }
-            Predicate::Equal {
-                domain_id: _,
-                equality_constant: _,
-            } => {
+            PredicateType::Equal => {
                 // I think we never push equality predicates to the trail
                 // in the current version. Equality gets substituted
                 // by a lower and upper bound predicate.
@@ -1219,11 +1162,11 @@ impl IntegerDomain {
         // Perhaps the recursion could be done in a cleaner way,
         // e.g., separate functions dependibng on the type of predicate.
         // For the initial version, the current version is okay.
-        match predicate {
-            Predicate::LowerBound {
-                domain_id: _,
-                lower_bound,
-            } => {
+        let domain_id = predicate.get_domain();
+        let value = predicate.get_right_hand_side();
+
+        match predicate.get_predicate_type() {
+            PredicateType::LowerBound => {
                 // Recall that by the nature of the updates,
                 // the updates are stored in increasing order of the lower bound.
 
@@ -1234,16 +1177,13 @@ impl IntegerDomain {
                 // that is greater than or equal to the input lower bound
                 self.lower_bound_updates
                     .iter()
-                    .find(|u| u.bound >= *lower_bound)
+                    .find(|u| u.bound >= value)
                     .map(|u| PairDecisionLevelTrailPosition {
                         decision_level: u.decision_level,
                         trail_position: u.trail_position,
                     })
             }
-            Predicate::UpperBound {
-                domain_id: _,
-                upper_bound,
-            } => {
+            PredicateType::UpperBound => {
                 // Recall that by the nature of the updates,
                 // the updates are stored in decreasing order of the upper bound.
 
@@ -1254,20 +1194,17 @@ impl IntegerDomain {
                 // that is smaller than or equal to the input upper bound
                 self.upper_bound_updates
                     .iter()
-                    .find(|u| u.bound <= *upper_bound)
+                    .find(|u| u.bound <= value)
                     .map(|u| PairDecisionLevelTrailPosition {
                         decision_level: u.decision_level,
                         trail_position: u.trail_position,
                     })
             }
-            Predicate::NotEqual {
-                domain_id,
-                not_equal_constant,
-            } => {
+            PredicateType::NotEqual => {
                 // Check the explictly stored holes.
                 // If the value has been removed explicitly,
                 // then the stored time is the first time the value was removed.
-                if let Some(hole_info) = self.holes.get(not_equal_constant) {
+                if let Some(hole_info) = self.holes.get(&value) {
                     Some(*hole_info)
                 } else {
                     // Otherwise, check the case when the lower/upper bound surpassed the value.
@@ -1278,50 +1215,39 @@ impl IntegerDomain {
                     // So we can stop as soon as we find one of the two.
 
                     // Check the lower bound first.
-                    if let Some(trail_position) = self.get_update_info(&Predicate::LowerBound {
-                        domain_id: *domain_id,
-                        lower_bound: not_equal_constant + 1,
-                    }) {
+                    if let Some(trail_position) =
+                        self.get_update_info(&predicate!(domain_id >= value + 1))
+                    {
                         // The lower bound removed the value from the domain,
                         // report the trail position of the lower bound.
                         Some(trail_position)
                     } else {
                         // The lower bound did not surpass the value,
                         // now check the upper bound.
-                        self.get_update_info(&Predicate::UpperBound {
-                            domain_id: *domain_id,
-                            upper_bound: not_equal_constant - 1,
-                        })
+                        self.get_update_info(&predicate!(domain_id <= value - 1))
                     }
                 }
             }
-            Predicate::Equal {
-                domain_id,
-                equality_constant,
-            } => {
+            PredicateType::Equal => {
                 // For equality to hold, both the lower and upper bound predicates must hold.
                 // Check lower bound first.
-                if let Some(lb_trail_position) = self.get_update_info(&Predicate::LowerBound {
-                    domain_id: *domain_id,
-                    lower_bound: *equality_constant,
-                }) {
+                if let Some(lb_trail_position) =
+                    self.get_update_info(&predicate!(domain_id >= value))
+                {
                     // The lower bound found,
                     // now the check depends on the upper bound.
 
                     // If both the lower and upper bounds are present,
                     // report the trail position of the bound that was set last.
                     // Otherwise, return that the predicate is not on the trail.
-                    self.get_update_info(&Predicate::UpperBound {
-                        domain_id: *domain_id,
-                        upper_bound: *equality_constant,
-                    })
-                    .map(|ub_trail_position| {
-                        if lb_trail_position.trail_position > ub_trail_position.trail_position {
-                            lb_trail_position
-                        } else {
-                            ub_trail_position
-                        }
-                    })
+                    self.get_update_info(&predicate!(domain_id <= value))
+                        .map(|ub_trail_position| {
+                            if lb_trail_position.trail_position > ub_trail_position.trail_position {
+                                lb_trail_position
+                            } else {
+                                ub_trail_position
+                            }
+                        })
                 }
                 // If the lower bound is never reached,
                 // then surely the equality predicate cannot be true.
@@ -1741,10 +1667,7 @@ mod tests {
 
         assert_eq!(
             domain
-                .get_update_info(&Predicate::LowerBound {
-                    domain_id,
-                    lower_bound: 12,
-                })
+                .get_update_info(&predicate!(domain_id >= 12))
                 .unwrap()
                 .trail_position,
             50
@@ -1757,10 +1680,7 @@ mod tests {
 
         assert_eq!(
             domain
-                .get_update_info(&Predicate::LowerBound {
-                    domain_id,
-                    lower_bound: 50,
-                })
+                .get_update_info(&predicate!(domain_id >= 50))
                 .unwrap()
                 .trail_position,
             70
@@ -1772,10 +1692,7 @@ mod tests {
         let (domain_id, domain) = get_domain1();
 
         assert!(domain
-            .get_update_info(&Predicate::LowerBound {
-                domain_id,
-                lower_bound: 101,
-            })
+            .get_update_info(&predicate!(domain_id >= 101))
             .is_none());
     }
 
@@ -1785,10 +1702,7 @@ mod tests {
 
         assert_eq!(
             domain
-                .get_update_info(&Predicate::LowerBound {
-                    domain_id,
-                    lower_bound: -10,
-                })
+                .get_update_info(&predicate!(domain_id >= -10))
                 .unwrap()
                 .trail_position,
             0
@@ -1804,10 +1718,7 @@ mod tests {
 
         assert_eq!(
             domain
-                .get_update_info(&Predicate::LowerBound {
-                    domain_id,
-                    lower_bound: 52,
-                })
+                .get_update_info(&predicate!(domain_id >= 52))
                 .unwrap()
                 .trail_position,
             77
@@ -1823,10 +1734,7 @@ mod tests {
 
         assert_eq!(
             domain
-                .get_update_info(&Predicate::NotEqual {
-                    domain_id,
-                    not_equal_constant: 50,
-                })
+                .get_update_info(&predicate!(domain_id != 50))
                 .unwrap()
                 .trail_position,
             75
@@ -1843,10 +1751,7 @@ mod tests {
 
         assert_eq!(
             domain
-                .get_update_info(&Predicate::NotEqual {
-                    domain_id,
-                    not_equal_constant: 55,
-                })
+                .get_update_info(&predicate!(domain_id != 55))
                 .unwrap()
                 .trail_position,
             150

--- a/pumpkin-solver/src/engine/notifications/mod.rs
+++ b/pumpkin-solver/src/engine/notifications/mod.rs
@@ -201,13 +201,7 @@ impl NotificationEngine {
                 self.backtrack_events
                     .event_occurred(DomainEvent::UpperBound, predicate.get_domain())
             }
-            if matches!(
-                predicate,
-                Predicate::NotEqual {
-                    domain_id: _,
-                    not_equal_constant: _
-                }
-            ) {
+            if predicate.is_not_equal_predicate() {
                 self.backtrack_events
                     .event_occurred(DomainEvent::Removal, predicate.get_domain())
             }

--- a/pumpkin-solver/src/engine/predicates/predicate.rs
+++ b/pumpkin-solver/src/engine/predicates/predicate.rs
@@ -1,231 +1,127 @@
 use crate::engine::variables::DomainId;
+use crate::predicate;
 
 /// Representation of a domain operation.
 ///
-/// It can either be in the form of atomic constraints over
-/// [`DomainId`]s (in the form of [`Predicate::LowerBound`],
-/// [`Predicate::UpperBound`], [`Predicate::NotEqual`] or [`Predicate::Equal`])
+/// It is provided in the form of an atomic constraint over a [`DomainId`]. See the [`predicate!`]
+/// macro on how to construct a predicate.
+///
+/// The 2 most significant bits of the id stored in the [`Predicate`] contains the type of
+/// predicate.
 #[derive(Clone, PartialEq, Eq, Copy, Hash)]
-pub enum Predicate {
-    LowerBound {
-        domain_id: DomainId,
-        lower_bound: i32,
-    },
-    UpperBound {
-        domain_id: DomainId,
-        upper_bound: i32,
-    },
-    NotEqual {
-        domain_id: DomainId,
-        not_equal_constant: i32,
-    },
-    Equal {
-        domain_id: DomainId,
-        equality_constant: i32,
-    },
+pub struct Predicate {
+    id: u32,
+    value: i32,
+}
+
+impl Predicate {
+    pub(super) fn new(id: u32, value: i32) -> Self {
+        Self { id, value }
+    }
+
+    fn get_type_code(&self) -> u8 {
+        (self.id >> 30) as u8
+    }
+
+    pub fn get_predicate_type(&self) -> PredicateType {
+        (*self).into()
+    }
+}
+
+pub(crate) const LOWER_BOUND_CODE: u8 = 1;
+pub(crate) const UPPER_BOUND_CODE: u8 = 2;
+pub(crate) const EQUALITY_CODE: u8 = 0;
+pub(crate) const NOT_EQUALS_CODE: u8 = 3;
+
+#[derive(Debug, Clone, Eq, PartialEq, Copy, Hash)]
+pub enum PredicateType {
+    LowerBound,
+    UpperBound,
+    NotEqual,
+    Equal,
+}
+
+impl From<Predicate> for PredicateType {
+    fn from(value: Predicate) -> Self {
+        match value.get_type_code() {
+            LOWER_BOUND_CODE => Self::LowerBound,
+            UPPER_BOUND_CODE => Self::UpperBound,
+            EQUALITY_CODE => Self::Equal,
+            NOT_EQUALS_CODE => Self::NotEqual,
+            code => panic!("Unknown type code {code}"),
+        }
+    }
 }
 
 impl Predicate {
     pub(crate) fn is_mutually_exclusive_with(self, other: Predicate) -> bool {
-        match (self, other) {
-            (Predicate::LowerBound { .. }, Predicate::LowerBound { .. })
-            | (Predicate::LowerBound { .. }, Predicate::NotEqual { .. })
-            | (Predicate::UpperBound { .. }, Predicate::UpperBound { .. })
-            | (Predicate::UpperBound { .. }, Predicate::NotEqual { .. })
-            | (Predicate::NotEqual { .. }, Predicate::LowerBound { .. })
-            | (Predicate::NotEqual { .. }, Predicate::UpperBound { .. })
-            | (Predicate::NotEqual { .. }, Predicate::NotEqual { .. }) => false,
-            (
-                Predicate::LowerBound {
-                    domain_id,
-                    lower_bound,
-                },
-                Predicate::UpperBound {
-                    domain_id: domain_id_other,
-                    upper_bound,
-                },
-            )
-            | (
-                Predicate::UpperBound {
-                    domain_id: domain_id_other,
-                    upper_bound,
-                },
-                Predicate::LowerBound {
-                    domain_id,
-                    lower_bound,
-                },
-            ) => domain_id == domain_id_other && lower_bound > upper_bound,
-            (
-                Predicate::LowerBound {
-                    domain_id,
-                    lower_bound,
-                },
-                Predicate::Equal {
-                    domain_id: domain_id_other,
-                    equality_constant,
-                },
-            )
-            | (
-                Predicate::Equal {
-                    domain_id: domain_id_other,
-                    equality_constant,
-                },
-                Predicate::LowerBound {
-                    domain_id,
-                    lower_bound,
-                },
-            ) => domain_id == domain_id_other && lower_bound > equality_constant,
-            (
-                Predicate::UpperBound {
-                    domain_id,
-                    upper_bound,
-                },
-                Predicate::Equal {
-                    domain_id: domain_id_other,
-                    equality_constant,
-                },
-            )
-            | (
-                Predicate::Equal {
-                    domain_id: domain_id_other,
-                    equality_constant,
-                },
-                Predicate::UpperBound {
-                    domain_id,
-                    upper_bound,
-                },
-            ) => domain_id == domain_id_other && upper_bound < equality_constant,
-            (
-                Predicate::NotEqual {
-                    domain_id,
-                    not_equal_constant,
-                },
-                Predicate::Equal {
-                    domain_id: domain_id_other,
-                    equality_constant,
-                },
-            )
-            | (
-                Predicate::Equal {
-                    domain_id: domain_id_other,
-                    equality_constant,
-                },
-                Predicate::NotEqual {
-                    domain_id,
-                    not_equal_constant,
-                },
-            ) => domain_id == domain_id_other && equality_constant == not_equal_constant,
-            (
-                Predicate::Equal {
-                    domain_id,
-                    equality_constant,
-                },
-                Predicate::Equal {
-                    domain_id: domain_id_other,
-                    equality_constant: equality_constant_other,
-                },
-            ) => domain_id == domain_id_other && equality_constant != equality_constant_other,
+        let domain_id = self.get_domain();
+        let rhs = self.get_right_hand_side();
+
+        let domain_id_other = other.get_domain();
+        let rhs_other = other.get_right_hand_side();
+
+        if domain_id != domain_id_other {
+            // Domain Ids do not match
+            return false;
+        }
+
+        match (self.get_predicate_type(), other.get_predicate_type()) {
+            (PredicateType::LowerBound, PredicateType::LowerBound)
+            | (PredicateType::LowerBound, PredicateType::NotEqual)
+            | (PredicateType::UpperBound, PredicateType::UpperBound)
+            | (PredicateType::UpperBound, PredicateType::NotEqual)
+            | (PredicateType::NotEqual, PredicateType::LowerBound)
+            | (PredicateType::NotEqual, PredicateType::UpperBound)
+            | (PredicateType::NotEqual, PredicateType::NotEqual) => false,
+            (PredicateType::LowerBound, PredicateType::UpperBound) => rhs > rhs_other,
+            (PredicateType::UpperBound, PredicateType::LowerBound) => rhs_other > rhs,
+            (PredicateType::LowerBound, PredicateType::Equal) => rhs > rhs_other,
+            (PredicateType::Equal, PredicateType::LowerBound) => rhs_other > rhs,
+            (PredicateType::UpperBound, PredicateType::Equal) => rhs < rhs_other,
+            (PredicateType::Equal, PredicateType::UpperBound) => rhs_other < rhs,
+            (PredicateType::NotEqual, PredicateType::Equal)
+            | (PredicateType::Equal, PredicateType::NotEqual) => rhs == rhs_other,
+            (PredicateType::Equal, PredicateType::Equal) => rhs != rhs_other,
         }
     }
     pub fn is_equality_predicate(&self) -> bool {
-        matches!(
-            *self,
-            Predicate::Equal {
-                domain_id: _,
-                equality_constant: _
-            }
-        )
+        self.get_type_code() == EQUALITY_CODE
     }
 
     pub fn is_lower_bound_predicate(&self) -> bool {
-        matches!(
-            *self,
-            Predicate::LowerBound {
-                domain_id: _,
-                lower_bound: _
-            }
-        )
+        self.get_type_code() == LOWER_BOUND_CODE
     }
 
     pub fn is_upper_bound_predicate(&self) -> bool {
-        matches!(
-            *self,
-            Predicate::UpperBound {
-                domain_id: _,
-                upper_bound: _
-            }
-        )
+        self.get_type_code() == UPPER_BOUND_CODE
     }
 
     pub fn is_not_equal_predicate(&self) -> bool {
-        matches!(
-            *self,
-            Predicate::NotEqual {
-                domain_id: _,
-                not_equal_constant: _
-            }
-        )
+        self.get_type_code() == NOT_EQUALS_CODE
     }
 
     /// Returns the [`DomainId`] of the [`Predicate`]
     pub fn get_domain(&self) -> DomainId {
-        match *self {
-            Predicate::LowerBound {
-                domain_id,
-                lower_bound: _,
-            } => domain_id,
-            Predicate::UpperBound {
-                domain_id,
-                upper_bound: _,
-            } => domain_id,
-            Predicate::NotEqual {
-                domain_id,
-                not_equal_constant: _,
-            } => domain_id,
-            Predicate::Equal {
-                domain_id,
-                equality_constant: _,
-            } => domain_id,
-        }
+        DomainId::new(0b00111111_11111111_11111111_11111111 & self.id)
     }
 
     pub fn get_right_hand_side(&self) -> i32 {
-        match self {
-            Predicate::LowerBound {
-                domain_id: _,
-                lower_bound,
-            } => *lower_bound,
-            Predicate::UpperBound {
-                domain_id: _,
-                upper_bound,
-            } => *upper_bound,
-            Predicate::NotEqual {
-                domain_id: _,
-                not_equal_constant,
-            } => *not_equal_constant,
-            Predicate::Equal {
-                domain_id: _,
-                equality_constant,
-            } => *equality_constant,
-        }
+        self.value
     }
 
     pub fn trivially_true() -> Predicate {
         // By convention, there is a dummy 0-1 variable set to one at root.
         // We use it to denote the trivially true predicate.
-        Predicate::Equal {
-            domain_id: DomainId { id: 0 },
-            equality_constant: 1,
-        }
+        let domain_id = DomainId { id: 0 };
+        predicate!(domain_id == 1)
     }
 
     pub fn trivially_false() -> Predicate {
         // By convention, there is a dummy 0-1 variable set to one at root.
         // We use it to denote the trivially true predicate.
-        Predicate::NotEqual {
-            domain_id: DomainId { id: 0 },
-            not_equal_constant: 1,
-        }
+        let domain_id = DomainId { id: 0 };
+        predicate!(domain_id != 1)
     }
 }
 
@@ -233,35 +129,14 @@ impl std::ops::Not for Predicate {
     type Output = Predicate;
 
     fn not(self) -> Self::Output {
-        match self {
-            Predicate::LowerBound {
-                domain_id,
-                lower_bound,
-            } => Predicate::UpperBound {
-                domain_id,
-                upper_bound: lower_bound - 1,
-            },
-            Predicate::UpperBound {
-                domain_id,
-                upper_bound,
-            } => Predicate::LowerBound {
-                domain_id,
-                lower_bound: upper_bound + 1,
-            },
-            Predicate::NotEqual {
-                domain_id,
-                not_equal_constant,
-            } => Predicate::Equal {
-                domain_id,
-                equality_constant: not_equal_constant,
-            },
-            Predicate::Equal {
-                domain_id,
-                equality_constant,
-            } => Predicate::NotEqual {
-                domain_id,
-                not_equal_constant: equality_constant,
-            },
+        let domain_id = self.get_domain();
+        let value = self.get_right_hand_side();
+
+        match self.get_predicate_type() {
+            PredicateType::LowerBound => predicate!(domain_id <= value - 1),
+            PredicateType::UpperBound => predicate!(domain_id >= value + 1),
+            PredicateType::NotEqual => predicate!(domain_id == value),
+            PredicateType::Equal => predicate!(domain_id != value),
         }
     }
 }
@@ -273,23 +148,14 @@ impl std::fmt::Display for Predicate {
         } else if *self == Predicate::trivially_false() {
             write!(f, "[False]")
         } else {
-            match self {
-                Predicate::LowerBound {
-                    domain_id,
-                    lower_bound,
-                } => write!(f, "[{domain_id} >= {lower_bound}]"),
-                Predicate::UpperBound {
-                    domain_id,
-                    upper_bound,
-                } => write!(f, "[{domain_id} <= {upper_bound}]"),
-                Predicate::NotEqual {
-                    domain_id,
-                    not_equal_constant,
-                } => write!(f, "[{domain_id} != {not_equal_constant}]"),
-                Predicate::Equal {
-                    domain_id,
-                    equality_constant,
-                } => write!(f, "[{domain_id} == {equality_constant}]"),
+            let domain_id = self.get_domain();
+            let rhs = self.get_right_hand_side();
+
+            match self.get_predicate_type() {
+                PredicateType::LowerBound => write!(f, "[{domain_id} >= {rhs}]"),
+                PredicateType::UpperBound => write!(f, "[{domain_id} <= {rhs}]"),
+                PredicateType::NotEqual => write!(f, "[{domain_id} != {rhs}]"),
+                PredicateType::Equal => write!(f, "[{domain_id} == {rhs}]"),
             }
         }
     }

--- a/pumpkin-solver/src/engine/predicates/predicate_constructor.rs
+++ b/pumpkin-solver/src/engine/predicates/predicate_constructor.rs
@@ -120,3 +120,79 @@ macro_rules! predicate {
         $($var).+$([$index])?.disequality_predicate($value)
     }};
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macro_local_identifiers_are_matched() {
+        let x = DomainId { id: 0 };
+
+        assert_eq!(x, predicate![x >= 2].get_domain());
+        assert_eq!(x, predicate![x <= 3].get_domain());
+        assert_eq!(x, predicate![x == 5].get_domain());
+        assert_eq!(x, predicate![x != 5].get_domain());
+
+        assert_eq!(2, predicate![x >= 2].get_right_hand_side());
+        assert_eq!(3, predicate![x <= 3].get_right_hand_side());
+        assert_eq!(5, predicate![x == 5].get_right_hand_side());
+        assert_eq!(5, predicate![x != 5].get_right_hand_side());
+
+        assert!(predicate!(x >= 2).is_lower_bound_predicate());
+        assert!(!predicate!(x >= 2).is_upper_bound_predicate());
+        assert!(!predicate!(x >= 2).is_equality_predicate());
+        assert!(!predicate!(x >= 2).is_not_equal_predicate());
+
+        assert!(predicate!(x <= 3).is_upper_bound_predicate());
+        assert!(!predicate!(x <= 3).is_lower_bound_predicate());
+        assert!(!predicate!(x <= 3).is_equality_predicate());
+        assert!(!predicate!(x <= 3).is_not_equal_predicate());
+
+        assert!(predicate!(x == 5).is_equality_predicate());
+        assert!(!predicate!(x == 5).is_lower_bound_predicate());
+        assert!(!predicate!(x == 5).is_upper_bound_predicate());
+        assert!(!predicate!(x == 5).is_not_equal_predicate());
+
+        assert!(predicate!(x != 5).is_not_equal_predicate());
+        assert!(!predicate!(x != 5).is_lower_bound_predicate());
+        assert!(!predicate!(x != 5).is_upper_bound_predicate());
+        assert!(!predicate!(x != 5).is_equality_predicate());
+    }
+
+    #[test]
+    fn macro_nested_identifiers_are_matched() {
+        struct Wrapper {
+            x: DomainId,
+        }
+
+        let wrapper = Wrapper {
+            x: DomainId { id: 0 },
+        };
+
+        assert_eq!(wrapper.x, predicate![wrapper.x >= 2].get_domain());
+        assert_eq!(wrapper.x, predicate![wrapper.x <= 3].get_domain());
+        assert_eq!(wrapper.x, predicate![wrapper.x == 5].get_domain());
+        assert_eq!(wrapper.x, predicate![wrapper.x != 5].get_domain());
+
+        assert_eq!(2, predicate![wrapper.x >= 2].get_right_hand_side());
+        assert_eq!(3, predicate![wrapper.x <= 3].get_right_hand_side());
+        assert_eq!(5, predicate![wrapper.x == 5].get_right_hand_side());
+        assert_eq!(5, predicate![wrapper.x != 5].get_right_hand_side());
+    }
+
+    #[test]
+    fn macro_index_expressions_are_matched() {
+        let wrapper = [DomainId { id: 0 }];
+
+        assert_eq!(wrapper[0], predicate![wrapper[0] >= 2].get_domain());
+        assert_eq!(wrapper[0], predicate![wrapper[0] <= 3].get_domain());
+        assert_eq!(wrapper[0], predicate![wrapper[0] == 5].get_domain());
+        assert_eq!(wrapper[0], predicate![wrapper[0] != 5].get_domain());
+
+        assert_eq!(2, predicate![wrapper[0] >= 2].get_right_hand_side());
+        assert_eq!(3, predicate![wrapper[0] <= 3].get_right_hand_side());
+        assert_eq!(5, predicate![wrapper[0] == 5].get_right_hand_side());
+        assert_eq!(5, predicate![wrapper[0] != 5].get_right_hand_side());
+    }
+}


### PR DESCRIPTION
Currently, the size of the `Predicate` structure is larger than it needs to be; the information for what is stored in the predicate can be stored in the two upper-most bits of the ID.

This PR makes this change.