### PR TITLE
refactor: Change the nogood inference label to print 'nogood'

### DIFF
--- a/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-solver/src/engine/constraint_satisfaction_solver.rs
@@ -1580,7 +1580,7 @@ impl CSPSolverState {
     }
 }
 
-declare_inference_label!(NogoodLabel);
+declare_inference_label!(NogoodLabel, "nogood");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Previously it printed 'nogood_label', which is the snake_case version of the label type name. In this case it makes sense that the type name and the actual string differ, since the name 'Nogood' for the inference label would be confusing, whereas with 'NogoodLabel' it is clear what the type represents.