### PR TITLE
Arena Allocation (initial version)

### DIFF
--- a/pumpkin-solver/src/containers/keyed_vec.rs
+++ b/pumpkin-solver/src/containers/keyed_vec.rs
@@ -120,6 +120,15 @@ impl<Key: StorageKey, Value: Clone> KeyedVec<Key, Value> {
         self.elements.resize(new_len, value)
     }
 
+    /// Resizes the vector if the length of the vector is smaller than the provided minimum length.
+    /// Does nothing if the vector is already large enough.
+    /// Convenient when using the vector to implement direct hashing.
+    pub(crate) fn resize_if_smaller(&mut self, minimum_length: usize, value: Value) {
+        if self.elements.len() <= minimum_length {
+            self.elements.resize(minimum_length, value);
+        }
+    }
+
     pub(crate) fn clear(&mut self) {
         self.elements.clear();
     }

--- a/pumpkin-solver/src/propagators/nogoods/mod.rs
+++ b/pumpkin-solver/src/propagators/nogoods/mod.rs
@@ -2,8 +2,10 @@ mod learning_options;
 mod nogood_id;
 mod nogood_info;
 mod nogood_propagator;
+mod predicate_arena;
 
 pub use learning_options::*;
 pub(crate) use nogood_id::*;
 pub(crate) use nogood_info::*;
 pub(crate) use nogood_propagator::*;
+pub(crate) use predicate_arena::PredicateArena;

--- a/pumpkin-solver/src/propagators/nogoods/predicate_arena.rs
+++ b/pumpkin-solver/src/propagators/nogoods/predicate_arena.rs
@@ -1,0 +1,79 @@
+use std::ops::Index;
+use std::ops::IndexMut;
+
+use crate::containers::StorageKey;
+use crate::predicates::Predicate;
+use crate::predicates::PredicateType;
+use crate::propagators::nogoods::NogoodId;
+use crate::variables::DomainId;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PredicateArena {
+    predicates: Vec<Predicate>,
+}
+
+impl PredicateArena {
+    /// Stores the predicates into the arena
+    /// and returns the nogood id associated with these predicates.
+    pub(crate) fn store_predicates(&mut self, mut nogood_predicates: Vec<Predicate>) -> NogoodId {
+        // New nogoods are always stored at the end.
+        let nogood_id = NogoodId::create_from_index(self.predicates.len());
+        // The first predicate stored in the arena is not a real predicate. Instead, the right-hand
+        // side of that predicate stores the length of the nogood. of the nogood.
+        let dummy_domain_id = DomainId::new(0);
+        let predicate_storing_the_length = Predicate::new(
+            dummy_domain_id,
+            PredicateType::Equal,
+            nogood_predicates.len() as i32,
+        );
+        self.predicates.push(predicate_storing_the_length);
+        // The predicates from the nogood are placed after the length-indicating predicate
+        self.predicates.append(&mut nogood_predicates);
+        nogood_id
+    }
+
+    /// Returns the number of predicates in the nogood.
+    fn get_len(&self, nogood_id: NogoodId) -> usize {
+        // Recall that the length of nogood is stored in the right-hand side of the predicate
+        // located at the position given by the nogood id.
+        let size_storing_predicate = self.predicates[nogood_id.index()];
+        size_storing_predicate.get_right_hand_side() as usize
+    }
+}
+
+impl Index<NogoodId> for PredicateArena {
+    type Output = [Predicate];
+
+    fn index(&self, index: NogoodId) -> &Self::Output {
+        let len = self.get_len(index);
+        // Recall that the length of nogood is stored in the right-hand side of the predicate
+        // located at the position given by the nogood id.
+        // This means that the predicates start one position after.
+        let start_index = index.index() + 1;
+        &self.predicates[start_index..start_index + len]
+    }
+}
+
+impl Index<&NogoodId> for PredicateArena {
+    type Output = [Predicate];
+
+    fn index(&self, index: &NogoodId) -> &Self::Output {
+        let len = self.get_len(*index);
+        // Recall that the length of nogood is stored in the right-hand side of the predicate
+        // located at the position given by the nogood id.
+        // This means that the predicates start one position after.
+        let start_index = index.index() + 1;
+        &self.predicates[start_index..start_index + len]
+    }
+}
+
+impl IndexMut<NogoodId> for PredicateArena {
+    fn index_mut(&mut self, index: NogoodId) -> &mut Self::Output {
+        let len = self.get_len(index);
+        // Recall that the length of nogood is stored in the right-hand side of the predicate
+        // located at the position given by the nogood id.
+        // This means that the predicates start one position after.
+        let start_index = index.index() + 1;
+        &mut self.predicates[start_index..start_index + len]
+    }
+}


### PR DESCRIPTION
To help get things going, I added a version of the arena allocation we have been talking about. I implemented the simplest version possible, so currently it does not delete predicates, nor does it preallocate any memory or have any other advanced features (an immeduate improvement would be to align the nogood start position with cache lines).

Can you please have a look to see if there are any issues, and possibly run this version and see if it leads to better performance?

Note that this does not change the trace so it is easier to test.