### PR TITLE
fix: Update drcp-debugger to new drcp-format version

### DIFF
--- a/drcp-debugger/src/main.rs
+++ b/drcp-debugger/src/main.rs
@@ -1,17 +1,18 @@
 use std::fs::File;
+use std::io::BufReader;
 use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::Context;
 use clap::Parser;
 use drcp_format::reader::ProofReader;
+use drcp_format::Conclusion;
+use drcp_format::Step;
 
 #[derive(Parser)]
 struct Cli {
     /// The input proof.
     input_proof: PathBuf,
-    /// The input literals.
-    input_lits: PathBuf,
     /// The output proof where literals are replaced with atomics.
     output: PathBuf,
 }
@@ -22,62 +23,51 @@ fn main() -> anyhow::Result<()> {
     let input_proof = File::open(&args.input_proof)
         .with_context(|| format!("Failed to open {}", args.input_proof.display()))?;
 
-    let input_lits = File::open(&args.input_lits)
-        .with_context(|| format!("Failed to open {}", args.input_proof.display()))?;
-
-    let literals = LiteralDefinitions::<String>::parse(input_lits).with_context(|| {
-        format!(
-            "Failed to parse literal definitions from {}.",
-            args.input_lits.display()
-        )
-    })?;
-
-    let mut reader = ProofReader::new(input_proof, literals);
+    let mut reader = ProofReader::<_, i32>::new(BufReader::new(input_proof));
     let mut output = File::create(&args.output)
         .with_context(|| format!("Failed to create {}", args.output.display()))?;
 
     while let Some(step) = reader.next_step()? {
         match step {
             Step::Inference(inference) => {
-                write!(output, "i {}", inference.id)?;
+                write!(output, "i {}", inference.constraint_id)?;
 
                 for premise in inference.premises {
                     write!(output, " {}", premise)?;
                 }
 
-                if let Some(propagated) = inference.propagated {
+                if let Some(propagated) = inference.consequent {
                     write!(output, " 0 {}", propagated)?;
                 }
 
-                if let Some(label) = inference.hint_label {
+                if let Some(label) = inference.label {
                     write!(output, " l:{label}")?;
                 }
 
-                if let Some(constraint_id) = inference.hint_constraint_id {
+                if let Some(constraint_id) = inference.generated_by {
                     write!(output, " c:{constraint_id}")?;
                 }
 
                 writeln!(output)?;
             }
-            Step::Nogood(nogood) => {
-                write!(output, "n {}", nogood.id)?;
+            Step::Deduction(deduction) => {
+                write!(output, "n {}", deduction.constraint_id)?;
 
-                for literal in nogood.literals {
-                    write!(output, " {}", literal)?;
+                for premise in deduction.premises {
+                    write!(output, " {}", premise)?;
                 }
 
                 write!(output, " 0")?;
 
-                for hint in nogood.hints.iter().flatten() {
+                for hint in deduction.sequence {
                     write!(output, " {}", hint)?;
                 }
 
                 writeln!(output)?;
             }
-            Step::Delete(step) => writeln!(output, "d {}", step.id)?,
             Step::Conclusion(conclusion) => match conclusion {
-                Conclusion::Unsatisfiable => writeln!(output, "c UNSAT")?,
-                Conclusion::Optimal(bound) => writeln!(output, "c {bound}")?,
+                Conclusion::Unsat => writeln!(output, "c UNSAT")?,
+                Conclusion::DualBound(bound) => writeln!(output, "c {bound}")?,
             },
         }
     }


### PR DESCRIPTION
When we updated the drcp-format crate, we forgot to update the drcp-debugger. Now that the proof format does not span two files, it is already easier to read. However, replacing the literals with atomic constraints is still very useful for debugging apps producing/consuming proofs.