### PR TITLE
fix: Log the initial bounds in the full proof as inferences

### DIFF
--- a/pumpkin-solver/src/proof/finalizer.rs
+++ b/pumpkin-solver/src/proof/finalizer.rs
@@ -76,8 +76,11 @@ pub(crate) fn explain_root_assignment(
         return;
     }
 
-    // If the predicate is a root-level assignment, there is nothing to explain.
+    // If the predicate is a root-level assignment, add the appropriate inference to the proof.
     if context.assignments.is_initial_bound(predicate) {
+        let _ = context
+            .proof_log
+            .log_domain_inference(predicate, context.variable_names);
         return;
     }
 


### PR DESCRIPTION
Also fix the hint for the deduction, to log the id of the inference instead of the id that triggered the inference.