### PR TITLE
fix: Disable recursive minimisation when logging the full proof

### DIFF
--- a/pumpkin-solver/src/bin/pumpkin-solver/main.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/main.rs
@@ -512,7 +512,12 @@ fn run() -> PumpkinResult<()> {
 
     let solver_options = SolverOptions {
         restart_options,
-        learning_clause_minimisation: !args.no_learning_clause_minimisation,
+        learning_clause_minimisation: if args.proof_type == ProofType::Full {
+            warn!("Recursive minimisation is disabled when logging the full proof.");
+            false
+        } else {
+            !args.no_learning_clause_minimisation
+        },
         random_generator: SmallRng::seed_from_u64(args.random_seed),
         proof_log,
         conflict_resolver: args.conflict_resolver,


### PR DESCRIPTION
When performing recursive minimisation, our logging of inferences is completely wrong. We should only log the inferences that are actually used when removing a predicate. For now it is easier to disable it, then we can revisit it later. Issue #214 is the reminder that we do not forget to implement this at some point.