### PR TITLE
feat: Propagator for `int_ne` and `int_eq`

### DIFF
--- a/pumpkin-solver/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-solver/src/constraints/arithmetic/equality.rs
@@ -55,9 +55,9 @@ pub fn not_equals<Var: IntegerVariable + Clone + 'static>(
 /// Creates the [`NegatableConstraint`] `lhs != rhs`.
 ///
 /// Its negation is [`binary_equals`].
-pub fn binary_not_equals<Var: IntegerVariable + 'static>(
-    lhs: Var,
-    rhs: Var,
+pub fn binary_not_equals<AVar: IntegerVariable + 'static, BVar: IntegerVariable + 'static>(
+    lhs: AVar,
+    rhs: BVar,
     constraint_tag: ConstraintTag,
 ) -> impl NegatableConstraint {
     BinaryNotEqualsConstraint {

--- a/pumpkin-solver/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-solver/src/constraints/arithmetic/equality.rs
@@ -29,9 +29,9 @@ pub fn equals<Var: IntegerVariable + Clone + 'static>(
 /// Creates the [`NegatableConstraint`] `lhs = rhs`.
 ///
 /// Its negation is [`binary_not_equals`].
-pub fn binary_equals<Var: IntegerVariable + 'static>(
-    lhs: Var,
-    rhs: Var,
+pub fn binary_equals<AVar: IntegerVariable + 'static, BVar: IntegerVariable + 'static>(
+    lhs: AVar,
+    rhs: BVar,
     constraint_tag: ConstraintTag,
 ) -> impl NegatableConstraint {
     BinaryEqualConstraint {
@@ -67,15 +67,16 @@ pub fn binary_not_equals<Var: IntegerVariable + 'static>(
     }
 }
 
-struct BinaryEqualConstraint<Var> {
-    a: Var,
-    b: Var,
+struct BinaryEqualConstraint<AVar, BVar> {
+    a: AVar,
+    b: BVar,
     constraint_tag: ConstraintTag,
 }
 
-impl<Var> Constraint for BinaryEqualConstraint<Var>
+impl<AVar, BVar> Constraint for BinaryEqualConstraint<AVar, BVar>
 where
-    Var: IntegerVariable + 'static,
+    AVar: IntegerVariable + 'static,
+    BVar: IntegerVariable + 'static,
 {
     fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
         solver.add_propagator(BinaryEqualsPropagatorArgs {
@@ -101,11 +102,12 @@ where
     }
 }
 
-impl<Var> NegatableConstraint for BinaryEqualConstraint<Var>
+impl<AVar, BVar> NegatableConstraint for BinaryEqualConstraint<AVar, BVar>
 where
-    Var: IntegerVariable + 'static,
+    AVar: IntegerVariable + 'static,
+    BVar: IntegerVariable + 'static,
 {
-    type NegatedConstraint = BinaryNotEqualsConstraint<Var>;
+    type NegatedConstraint = BinaryNotEqualsConstraint<AVar, BVar>;
 
     fn negation(&self) -> Self::NegatedConstraint {
         BinaryNotEqualsConstraint {
@@ -116,15 +118,16 @@ where
     }
 }
 
-struct BinaryNotEqualsConstraint<Var> {
-    a: Var,
-    b: Var,
+struct BinaryNotEqualsConstraint<AVar, BVar> {
+    a: AVar,
+    b: BVar,
     constraint_tag: ConstraintTag,
 }
 
-impl<Var> Constraint for BinaryNotEqualsConstraint<Var>
+impl<AVar, BVar> Constraint for BinaryNotEqualsConstraint<AVar, BVar>
 where
-    Var: IntegerVariable + 'static,
+    AVar: IntegerVariable + 'static,
+    BVar: IntegerVariable + 'static,
 {
     fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
         solver.add_propagator(BinaryNotEqualsPropagatorArgs {
@@ -150,11 +153,12 @@ where
     }
 }
 
-impl<Var> NegatableConstraint for BinaryNotEqualsConstraint<Var>
+impl<AVar, BVar> NegatableConstraint for BinaryNotEqualsConstraint<AVar, BVar>
 where
-    Var: IntegerVariable + 'static,
+    AVar: IntegerVariable + 'static,
+    BVar: IntegerVariable + 'static,
 {
-    type NegatedConstraint = BinaryEqualConstraint<Var>;
+    type NegatedConstraint = BinaryEqualConstraint<AVar, BVar>;
 
     fn negation(&self) -> Self::NegatedConstraint {
         BinaryEqualConstraint {

--- a/pumpkin-solver/src/engine/cp/assignments.rs
+++ b/pumpkin-solver/src/engine/cp/assignments.rs
@@ -63,6 +63,10 @@ impl Assignments {
         self.domains[domain_id].get_holes_from_current_decision_level(self.get_decision_level())
     }
 
+    pub(crate) fn get_holes(&self, domain_id: DomainId) -> impl Iterator<Item = i32> + '_ {
+        self.domains[domain_id].get_holes()
+    }
+
     pub(crate) fn increase_decision_level(&mut self) {
         self.trail.increase_decision_level()
     }
@@ -1314,6 +1318,10 @@ impl IntegerDomain {
             .rev()
             .take_while(move |entry| entry.decision_level == current_decision_level)
             .map(|entry| entry.removed_value)
+    }
+
+    pub(crate) fn get_holes(&self) -> impl Iterator<Item = i32> + '_ {
+        self.holes.keys().copied()
     }
 }
 

--- a/pumpkin-solver/src/engine/cp/assignments.rs
+++ b/pumpkin-solver/src/engine/cp/assignments.rs
@@ -1299,6 +1299,7 @@ impl IntegerDomain {
         }
     }
 
+    /// Returns the holes which were created on the provided decision level.
     pub(crate) fn get_holes_from_decision_level(
         &self,
         decision_level: usize,
@@ -1309,6 +1310,7 @@ impl IntegerDomain {
             .map(|entry| entry.removed_value)
     }
 
+    /// Returns the holes which were created on the current decision level.
     pub(crate) fn get_holes_from_current_decision_level(
         &self,
         current_decision_level: usize,
@@ -1320,6 +1322,8 @@ impl IntegerDomain {
             .map(|entry| entry.removed_value)
     }
 
+    /// Returns all of the holes (currently) in the domain of `var` (including ones which were
+    /// created at previous decision levels).
     pub(crate) fn get_holes(&self) -> impl Iterator<Item = i32> + '_ {
         self.holes.keys().copied()
     }

--- a/pumpkin-solver/src/engine/cp/assignments.rs
+++ b/pumpkin-solver/src/engine/cp/assignments.rs
@@ -56,6 +56,13 @@ impl Assignments {
         self.domains[domain_id].get_holes_from_decision_level(decision_level)
     }
 
+    pub(crate) fn get_holes_on_current_decision_level(
+        &self,
+        domain_id: DomainId,
+    ) -> impl Iterator<Item = i32> + '_ {
+        self.domains[domain_id].get_holes_from_current_decision_level(self.get_decision_level())
+    }
+
     pub(crate) fn increase_decision_level(&mut self) {
         self.trail.increase_decision_level()
     }
@@ -1295,6 +1302,17 @@ impl IntegerDomain {
         self.hole_updates
             .iter()
             .filter(move |entry| entry.decision_level == decision_level)
+            .map(|entry| entry.removed_value)
+    }
+
+    pub(crate) fn get_holes_from_current_decision_level(
+        &self,
+        current_decision_level: usize,
+    ) -> impl Iterator<Item = i32> + '_ {
+        self.hole_updates
+            .iter()
+            .rev()
+            .take_while(move |entry| entry.decision_level == current_decision_level)
             .map(|entry| entry.removed_value)
     }
 }

--- a/pumpkin-solver/src/engine/cp/assignments.rs
+++ b/pumpkin-solver/src/engine/cp/assignments.rs
@@ -48,6 +48,7 @@ impl Default for Assignments {
 pub(crate) struct EmptyDomain;
 
 impl Assignments {
+    /// Returns all of the holes in the domain which were created at the provided decision level
     pub(crate) fn get_holes_on_decision_level(
         &self,
         domain_id: DomainId,
@@ -56,6 +57,7 @@ impl Assignments {
         self.domains[domain_id].get_holes_from_decision_level(decision_level)
     }
 
+    /// Returns all of the holes in the domain which were created at the current decision level
     pub(crate) fn get_holes_on_current_decision_level(
         &self,
         domain_id: DomainId,
@@ -63,6 +65,8 @@ impl Assignments {
         self.domains[domain_id].get_holes_from_current_decision_level(self.get_decision_level())
     }
 
+    /// Returns all of the holes (currently) in the domain of `var` (including ones which were
+    /// created at previous decision levels).
     pub(crate) fn get_holes(&self, domain_id: DomainId) -> impl Iterator<Item = i32> + '_ {
         self.domains[domain_id].get_holes()
     }

--- a/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
@@ -255,6 +255,10 @@ pub(crate) trait ReadDomains: HasAssignments {
         var.get_holes_on_current_decision_level(self.assignments())
     }
 
+    fn get_holes<Var: IntegerVariable>(&self, var: &Var) -> impl Iterator<Item = i32> {
+        var.get_holes(self.assignments())
+    }
+
     /// Returns `true` if the domain of the given variable is singleton.
     fn is_fixed<Var: IntegerVariable>(&self, var: &Var) -> bool {
         self.lower_bound(var) == self.upper_bound(var)

--- a/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
@@ -248,6 +248,13 @@ pub(crate) trait ReadDomains: HasAssignments {
         self.is_fixed(literal)
     }
 
+    fn get_holes_on_current_decision_level<Var: IntegerVariable>(
+        &self,
+        var: &Var,
+    ) -> impl Iterator<Item = i32> {
+        var.get_holes_on_current_decision_level(self.assignments())
+    }
+
     /// Returns `true` if the domain of the given variable is singleton.
     fn is_fixed<Var: IntegerVariable>(&self, var: &Var) -> bool {
         self.lower_bound(var) == self.upper_bound(var)

--- a/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
+++ b/pumpkin-solver/src/engine/cp/propagation/contexts/propagation_context.rs
@@ -248,6 +248,7 @@ pub(crate) trait ReadDomains: HasAssignments {
         self.is_fixed(literal)
     }
 
+    /// Returns the holes which were created on the current decision level.
     fn get_holes_on_current_decision_level<Var: IntegerVariable>(
         &self,
         var: &Var,
@@ -255,6 +256,8 @@ pub(crate) trait ReadDomains: HasAssignments {
         var.get_holes_on_current_decision_level(self.assignments())
     }
 
+    /// Returns all of the holes (currently) in the domain of `var` (including ones which were
+    /// created at previous decision levels).
     fn get_holes<Var: IntegerVariable>(&self, var: &Var) -> impl Iterator<Item = i32> {
         var.get_holes(self.assignments())
     }

--- a/pumpkin-solver/src/engine/notifications/domain_event_notification/domain_events.rs
+++ b/pumpkin-solver/src/engine/notifications/domain_event_notification/domain_events.rs
@@ -34,8 +34,6 @@ impl DomainEvents {
     /// DomainEvents with only assigning to a single value.
     pub(crate) const ASSIGN: DomainEvents =
         DomainEvents::create_with_int_events(enum_set!(DomainEvent::Assign));
-    pub(crate) const ASSIGN_AND_REMOVAL: DomainEvents =
-        DomainEvents::create_with_int_events(enum_set!(DomainEvent::Assign | DomainEvent::Removal));
 }
 
 impl DomainEvents {

--- a/pumpkin-solver/src/engine/notifications/domain_event_notification/domain_events.rs
+++ b/pumpkin-solver/src/engine/notifications/domain_event_notification/domain_events.rs
@@ -22,6 +22,8 @@ impl DomainEvents {
             | DomainEvent::UpperBound
             | DomainEvent::Removal
     ));
+    pub(crate) const REMOVAL: DomainEvents =
+        DomainEvents::create_with_int_events(enum_set!(DomainEvent::Removal));
     /// DomainEvents with only lower bound tightening.
     pub(crate) const LOWER_BOUND: DomainEvents =
         DomainEvents::create_with_int_events(enum_set!(DomainEvent::LowerBound));

--- a/pumpkin-solver/src/engine/notifications/domain_event_notification/domain_events.rs
+++ b/pumpkin-solver/src/engine/notifications/domain_event_notification/domain_events.rs
@@ -34,6 +34,8 @@ impl DomainEvents {
     /// DomainEvents with only assigning to a single value.
     pub(crate) const ASSIGN: DomainEvents =
         DomainEvents::create_with_int_events(enum_set!(DomainEvent::Assign));
+    pub(crate) const ASSIGN_AND_REMOVAL: DomainEvents =
+        DomainEvents::create_with_int_events(enum_set!(DomainEvent::Assign | DomainEvent::Removal));
 }
 
 impl DomainEvents {

--- a/pumpkin-solver/src/engine/variables/affine_view.rs
+++ b/pumpkin-solver/src/engine/variables/affine_view.rs
@@ -173,6 +173,12 @@ where
             .get_holes_on_current_decision_level(assignments)
             .map(|value| self.map(value))
     }
+
+    fn get_holes(&self, assignments: &Assignments) -> impl Iterator<Item = i32> {
+        self.inner
+            .get_holes(assignments)
+            .map(|value| self.map(value))
+    }
 }
 
 impl<View> TransformableVariable<AffineView<View>> for AffineView<View>

--- a/pumpkin-solver/src/engine/variables/affine_view.rs
+++ b/pumpkin-solver/src/engine/variables/affine_view.rs
@@ -164,6 +164,15 @@ where
             self.inner.unpack_event(event)
         }
     }
+
+    fn get_holes_on_current_decision_level(
+        &self,
+        assignments: &Assignments,
+    ) -> impl Iterator<Item = i32> {
+        self.inner
+            .get_holes_on_current_decision_level(assignments)
+            .map(|value| self.map(value))
+    }
 }
 
 impl<View> TransformableVariable<AffineView<View>> for AffineView<View>

--- a/pumpkin-solver/src/engine/variables/domain_id.rs
+++ b/pumpkin-solver/src/engine/variables/domain_id.rs
@@ -90,6 +90,10 @@ impl IntegerVariable for DomainId {
     ) -> impl Iterator<Item = i32> {
         assignments.get_holes_on_current_decision_level(*self)
     }
+
+    fn get_holes(&self, assignments: &Assignments) -> impl Iterator<Item = i32> {
+        assignments.get_holes(*self)
+    }
 }
 
 impl TransformableVariable<AffineView<DomainId>> for DomainId {

--- a/pumpkin-solver/src/engine/variables/domain_id.rs
+++ b/pumpkin-solver/src/engine/variables/domain_id.rs
@@ -83,6 +83,13 @@ impl IntegerVariable for DomainId {
     fn unpack_event(&self, event: OpaqueDomainEvent) -> DomainEvent {
         event.unwrap()
     }
+
+    fn get_holes_on_current_decision_level(
+        &self,
+        assignments: &Assignments,
+    ) -> impl Iterator<Item = i32> {
+        assignments.get_holes_on_current_decision_level(*self)
+    }
 }
 
 impl TransformableVariable<AffineView<DomainId>> for DomainId {

--- a/pumpkin-solver/src/engine/variables/integer_variable.rs
+++ b/pumpkin-solver/src/engine/variables/integer_variable.rs
@@ -49,4 +49,9 @@ pub trait IntegerVariable:
 
     /// Decode a domain event for this variable.
     fn unpack_event(&self, event: OpaqueDomainEvent) -> DomainEvent;
+
+    fn get_holes_on_current_decision_level(
+        &self,
+        assignments: &Assignments,
+    ) -> impl Iterator<Item = i32>;
 }

--- a/pumpkin-solver/src/engine/variables/integer_variable.rs
+++ b/pumpkin-solver/src/engine/variables/integer_variable.rs
@@ -50,8 +50,12 @@ pub trait IntegerVariable:
     /// Decode a domain event for this variable.
     fn unpack_event(&self, event: OpaqueDomainEvent) -> DomainEvent;
 
+    /// Returns all of the holes in the domain which were created at the current decision level
     fn get_holes_on_current_decision_level(
         &self,
         assignments: &Assignments,
     ) -> impl Iterator<Item = i32>;
+
+    /// Returns all of the holes in the domain
+    fn get_holes(&self, assignments: &Assignments) -> impl Iterator<Item = i32>;
 }

--- a/pumpkin-solver/src/engine/variables/literal.rs
+++ b/pumpkin-solver/src/engine/variables/literal.rs
@@ -134,6 +134,10 @@ impl IntegerVariable for Literal {
         self.integer_variable
             .get_holes_on_current_decision_level(assignments)
     }
+
+    fn get_holes(&self, assignments: &Assignments) -> impl Iterator<Item = i32> {
+        self.integer_variable.get_holes(assignments)
+    }
 }
 
 impl PredicateConstructor for Literal {

--- a/pumpkin-solver/src/engine/variables/literal.rs
+++ b/pumpkin-solver/src/engine/variables/literal.rs
@@ -126,6 +126,14 @@ impl IntegerVariable for Literal {
     fn watch_all_backtrack(&self, watchers: &mut Watchers<'_>, events: EnumSet<DomainEvent>) {
         self.integer_variable.watch_all_backtrack(watchers, events)
     }
+
+    fn get_holes_on_current_decision_level(
+        &self,
+        assignments: &Assignments,
+    ) -> impl Iterator<Item = i32> {
+        self.integer_variable
+            .get_holes_on_current_decision_level(assignments)
+    }
 }
 
 impl PredicateConstructor for Literal {

--- a/pumpkin-solver/src/propagators/arithmetic/binary/binary_equals.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/binary/binary_equals.rs
@@ -1,0 +1,282 @@
+use crate::basic_types::HashSet;
+use crate::basic_types::PropagationStatusCP;
+use crate::basic_types::PropagatorConflict;
+use crate::conjunction;
+use crate::declare_inference_label;
+use crate::engine::cp::propagation::ReadDomains;
+use crate::engine::notifications::DomainEvent;
+use crate::engine::notifications::OpaqueDomainEvent;
+use crate::engine::propagation::constructor::PropagatorConstructor;
+use crate::engine::propagation::constructor::PropagatorConstructorContext;
+use crate::engine::propagation::contexts::PropagationContextWithTrailedValues;
+use crate::engine::propagation::EnqueueDecision;
+use crate::engine::propagation::LocalId;
+use crate::engine::propagation::PropagationContext;
+use crate::engine::propagation::PropagationContextMut;
+use crate::engine::propagation::Propagator;
+use crate::engine::variables::IntegerVariable;
+use crate::engine::DomainEvents;
+use crate::predicate;
+use crate::proof::ConstraintTag;
+use crate::proof::InferenceCode;
+use crate::pumpkin_assert_advanced;
+
+declare_inference_label!(BinaryEquals);
+
+/// The [`PropagatorConstructor`] for the [`LinearLessOrEqualPropagator`].
+#[derive(Clone, Debug)]
+pub(crate) struct BinaryEqualsPropagatorArgs<AVar, BVar> {
+    pub(crate) a: AVar,
+    pub(crate) b: BVar,
+    pub(crate) constraint_tag: ConstraintTag,
+}
+
+impl<AVar, BVar> PropagatorConstructor for BinaryEqualsPropagatorArgs<AVar, BVar>
+where
+    AVar: IntegerVariable + 'static,
+    BVar: IntegerVariable + 'static,
+{
+    type PropagatorImpl = BinaryEqualsPropagator<AVar, BVar>;
+
+    fn create(self, mut context: PropagatorConstructorContext) -> Self::PropagatorImpl {
+        let BinaryEqualsPropagatorArgs {
+            a,
+            b,
+            constraint_tag,
+        } = self;
+
+        context.register(a.clone(), DomainEvents::ANY_INT, LocalId::from(0));
+        context.register(b.clone(), DomainEvents::ANY_INT, LocalId::from(1));
+
+        context.register_for_backtrack_events(a.clone(), DomainEvents::REMOVAL, LocalId::from(0));
+        context.register_for_backtrack_events(b.clone(), DomainEvents::REMOVAL, LocalId::from(1));
+
+        BinaryEqualsPropagator {
+            a,
+            b,
+
+            a_removed_values: HashSet::default(),
+            b_removed_values: HashSet::default(),
+
+            inference_code: context.create_inference_code(constraint_tag, BinaryEquals),
+
+            has_backtracked: false,
+            first_propagation_loop: true,
+        }
+    }
+}
+
+/// Propagator for the constraint `\sum x_i <= c`.
+#[derive(Clone, Debug)]
+pub(crate) struct BinaryEqualsPropagator<AVar, BVar> {
+    a: AVar,
+    b: BVar,
+
+    a_removed_values: HashSet<i32>,
+    b_removed_values: HashSet<i32>,
+
+    has_backtracked: bool,
+    first_propagation_loop: bool,
+
+    inference_code: InferenceCode,
+}
+
+impl<AVar, BVar> Propagator for BinaryEqualsPropagator<AVar, BVar>
+where
+    AVar: IntegerVariable + 'static,
+    BVar: IntegerVariable + 'static,
+{
+    fn detect_inconsistency(
+        &self,
+        context: PropagationContextWithTrailedValues,
+    ) -> Option<PropagatorConflict> {
+        let a_lb = context.lower_bound(&self.a);
+        let a_ub = context.upper_bound(&self.a);
+
+        let b_lb = context.lower_bound(&self.b);
+        let b_ub = context.upper_bound(&self.b);
+
+        if a_ub < b_lb {
+            Some(PropagatorConflict {
+                conjunction: conjunction!([self.a <= b_lb - 1] & [self.b >= b_lb]),
+                inference_code: self.inference_code,
+            })
+        } else if b_ub < a_lb {
+            Some(PropagatorConflict {
+                conjunction: conjunction!([self.b <= a_lb - 1] & [self.a >= a_lb]),
+                inference_code: self.inference_code,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn notify(
+        &mut self,
+        context: PropagationContextWithTrailedValues,
+        local_id: LocalId,
+        event: OpaqueDomainEvent,
+    ) -> EnqueueDecision {
+        match local_id.unpack() {
+            0 => {
+                if matches!(self.a.unpack_event(event), DomainEvent::Removal) {
+                    self.a_removed_values
+                        .extend(context.get_holes_on_current_decision_level(&self.a));
+                }
+            }
+            1 => {
+                if matches!(self.b.unpack_event(event), DomainEvent::Removal) {
+                    self.b_removed_values
+                        .extend(context.get_holes_on_current_decision_level(&self.b));
+                }
+            }
+            _ => panic!("Unexpected local id {local_id:?}"),
+        }
+
+        EnqueueDecision::Enqueue
+    }
+
+    fn notify_backtrack(
+        &mut self,
+        _context: PropagationContext,
+        _local_id: LocalId,
+        _event: OpaqueDomainEvent,
+    ) {
+        self.has_backtracked = true;
+    }
+
+    fn priority(&self) -> u32 {
+        0
+    }
+
+    fn name(&self) -> &str {
+        "BinaryEq"
+    }
+
+    fn propagate(&mut self, mut context: PropagationContextMut) -> PropagationStatusCP {
+        if self.first_propagation_loop {
+            self.first_propagation_loop = false;
+            return self.debug_propagate_from_scratch(context);
+        }
+
+        if let Some(conflict) = self.detect_inconsistency(context.as_trailed_readonly()) {
+            return Err(conflict.into());
+        }
+
+        let a_lb = context.lower_bound(&self.a);
+        let a_ub = context.upper_bound(&self.a);
+
+        let b_lb = context.lower_bound(&self.b);
+        let b_ub = context.upper_bound(&self.b);
+
+        context.post(
+            predicate!(self.a >= b_lb),
+            conjunction!([self.b >= b_lb]),
+            self.inference_code,
+        )?;
+        context.post(
+            predicate!(self.a <= b_ub),
+            conjunction!([self.b <= b_ub]),
+            self.inference_code,
+        )?;
+        context.post(
+            predicate!(self.b >= a_lb),
+            conjunction!([self.a >= a_lb]),
+            self.inference_code,
+        )?;
+        context.post(
+            predicate!(self.b <= a_ub),
+            conjunction!([self.a <= a_ub]),
+            self.inference_code,
+        )?;
+
+        if self.has_backtracked {
+            self.has_backtracked = false;
+            self.a_removed_values
+                .retain(|element| context.is_predicate_satisfied(predicate!(self.a != *element)));
+            self.b_removed_values
+                .retain(|element| context.is_predicate_satisfied(predicate!(self.b != *element)));
+        }
+
+        for removed_value_a in self.a_removed_values.drain() {
+            pumpkin_assert_advanced!(
+                context.is_predicate_satisfied(predicate!(self.a != removed_value_a))
+            );
+            context.post(
+                predicate!(self.b != removed_value_a),
+                conjunction!([self.a != removed_value_a]),
+                self.inference_code,
+            )?;
+        }
+        for removed_value_b in self.b_removed_values.drain() {
+            pumpkin_assert_advanced!(
+                context.is_predicate_satisfied(predicate!(self.b != removed_value_b))
+            );
+            context.post(
+                predicate!(self.a != removed_value_b),
+                conjunction!([self.b != removed_value_b]),
+                self.inference_code,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn debug_propagate_from_scratch(
+        &self,
+        mut context: PropagationContextMut,
+    ) -> PropagationStatusCP {
+        if let Some(conflict) = self.detect_inconsistency(context.as_trailed_readonly()) {
+            return Err(conflict.into());
+        }
+
+        let a_lb = context.lower_bound(&self.a);
+        let a_ub = context.upper_bound(&self.a);
+
+        let b_lb = context.lower_bound(&self.b);
+        let b_ub = context.upper_bound(&self.b);
+
+        context.post(
+            predicate!(self.a >= b_lb),
+            conjunction!([self.b >= b_lb]),
+            self.inference_code,
+        )?;
+        context.post(
+            predicate!(self.a <= b_ub),
+            conjunction!([self.b <= b_ub]),
+            self.inference_code,
+        )?;
+        context.post(
+            predicate!(self.b >= a_lb),
+            conjunction!([self.a >= a_lb]),
+            self.inference_code,
+        )?;
+        context.post(
+            predicate!(self.b <= a_ub),
+            conjunction!([self.a <= a_ub]),
+            self.inference_code,
+        )?;
+
+        for value_a in context.lower_bound(&self.a)..context.upper_bound(&self.a) {
+            if !context.contains(&self.a, value_a) {
+                context.post(
+                    predicate!(self.b != value_a),
+                    conjunction!([self.a != value_a]),
+                    self.inference_code,
+                )?;
+            }
+        }
+
+        for value_b in context.lower_bound(&self.b)..context.upper_bound(&self.b) {
+            if !context.contains(&self.b, value_b) {
+                context.post(
+                    predicate!(self.a != value_b),
+                    conjunction!([self.b != value_b]),
+                    self.inference_code,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/pumpkin-solver/src/propagators/arithmetic/binary/binary_equals.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/binary/binary_equals.rs
@@ -257,10 +257,6 @@ where
         &self,
         mut context: PropagationContextMut,
     ) -> PropagationStatusCP {
-        if let Some(conflict) = self.detect_inconsistency(context.as_trailed_readonly()) {
-            return Err(conflict.into());
-        }
-
         let a_lb = context.lower_bound(&self.a);
         let a_ub = context.upper_bound(&self.a);
 

--- a/pumpkin-solver/src/propagators/arithmetic/binary/binary_not_equals.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/binary/binary_not_equals.rs
@@ -1,0 +1,228 @@
+use crate::basic_types::PropagationStatusCP;
+use crate::basic_types::PropagatorConflict;
+use crate::conjunction;
+use crate::declare_inference_label;
+use crate::engine::cp::propagation::ReadDomains;
+use crate::engine::notifications::OpaqueDomainEvent;
+use crate::engine::propagation::constructor::PropagatorConstructor;
+use crate::engine::propagation::constructor::PropagatorConstructorContext;
+use crate::engine::propagation::contexts::PropagationContextWithTrailedValues;
+use crate::engine::propagation::EnqueueDecision;
+use crate::engine::propagation::LocalId;
+use crate::engine::propagation::PropagationContext;
+use crate::engine::propagation::PropagationContextMut;
+use crate::engine::propagation::Propagator;
+use crate::engine::variables::IntegerVariable;
+use crate::engine::DomainEvents;
+use crate::predicate;
+use crate::proof::ConstraintTag;
+use crate::proof::InferenceCode;
+
+declare_inference_label!(BinaryNotEquals);
+
+/// The [`PropagatorConstructor`] for the [`BinaryNotEqualsPropagator`].
+#[derive(Clone, Debug)]
+pub(crate) struct BinaryNotEqualsPropagatorArgs<AVar, BVar> {
+    pub(crate) a: AVar,
+    pub(crate) b: BVar,
+    pub(crate) constraint_tag: ConstraintTag,
+}
+
+impl<AVar, BVar> PropagatorConstructor for BinaryNotEqualsPropagatorArgs<AVar, BVar>
+where
+    AVar: IntegerVariable + 'static,
+    BVar: IntegerVariable + 'static,
+{
+    type PropagatorImpl = BinaryNotEqualsPropagator<AVar, BVar>;
+
+    fn create(self, mut context: PropagatorConstructorContext) -> Self::PropagatorImpl {
+        let BinaryNotEqualsPropagatorArgs {
+            a,
+            b,
+            constraint_tag,
+        } = self;
+
+        // We only care about the case where one of the two is assigned
+        context.register(a.clone(), DomainEvents::ASSIGN, LocalId::from(0));
+        context.register(b.clone(), DomainEvents::ASSIGN, LocalId::from(1));
+
+        // We also need to ensure that we know when propagation can take place; note that we might
+        // need to re-do a removal after backtracking
+        context.register_for_backtrack_events(
+            a.clone(),
+            DomainEvents::ASSIGN_AND_REMOVAL,
+            LocalId::from(0),
+        );
+        context.register_for_backtrack_events(
+            b.clone(),
+            DomainEvents::ASSIGN_AND_REMOVAL,
+            LocalId::from(1),
+        );
+
+        BinaryNotEqualsPropagator {
+            a,
+            b,
+
+            inference_code: context.create_inference_code(constraint_tag, BinaryNotEquals),
+
+            is_satisfied: false,
+        }
+    }
+}
+
+/// Propagator for the constraint `a != b`.
+#[derive(Clone, Debug)]
+pub(crate) struct BinaryNotEqualsPropagator<AVar, BVar> {
+    a: AVar,
+    b: BVar,
+
+    inference_code: InferenceCode,
+
+    /// Keeps track of whether the constraint is currently satisfied
+    is_satisfied: bool,
+}
+
+impl<AVar, BVar> Propagator for BinaryNotEqualsPropagator<AVar, BVar>
+where
+    AVar: IntegerVariable + 'static,
+    BVar: IntegerVariable + 'static,
+{
+    fn detect_inconsistency(
+        &self,
+        context: PropagationContextWithTrailedValues,
+    ) -> Option<PropagatorConflict> {
+        // We first check whether they are both fixed
+        if context.is_fixed(&self.a) && context.is_fixed(&self.b) {
+            let lb_a = context.lower_bound(&self.a);
+            let lb_b = context.lower_bound(&self.b);
+
+            // If they are, then we check whether they are assigned to the same value
+            if lb_a == lb_b {
+                // If this is the case then we have detected a conflict
+                Some(PropagatorConflict {
+                    conjunction: conjunction!([self.a == lb_a] & [self.b == lb_a]),
+                    inference_code: self.inference_code,
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    fn notify(
+        &mut self,
+        _context: PropagationContextWithTrailedValues,
+        _local_id: LocalId,
+        _event: OpaqueDomainEvent,
+    ) -> EnqueueDecision {
+        if self.is_satisfied {
+            // If it is already satisfied then we simply skip
+            EnqueueDecision::Skip
+        } else {
+            EnqueueDecision::Enqueue
+        }
+    }
+
+    fn notify_backtrack(
+        &mut self,
+        _context: PropagationContext,
+        _local_id: LocalId,
+        _event: OpaqueDomainEvent,
+    ) {
+        // Either one of the variables has become unassigned or one of the removals could have
+        // become undone
+        self.is_satisfied = false;
+    }
+
+    fn priority(&self) -> u32 {
+        0
+    }
+
+    fn name(&self) -> &str {
+        "BinaryNotEq"
+    }
+
+    fn propagate(&mut self, mut context: PropagationContextMut) -> PropagationStatusCP {
+        if self.is_satisfied {
+            // If it is already satisfied then we simply skip
+            return Ok(());
+        }
+
+        if let Some(conflict) = self.detect_inconsistency(context.as_trailed_readonly()) {
+            return Err(conflict.into());
+        }
+
+        let a_lb = context.lower_bound(&self.a);
+        let a_ub = context.upper_bound(&self.a);
+
+        let b_lb = context.lower_bound(&self.b);
+        let b_ub = context.upper_bound(&self.b);
+
+        if a_ub < b_lb || b_ub < a_lb {
+            // The domains are non-overlapping
+            self.is_satisfied = true;
+            return Ok(());
+        }
+
+        // If `a` is fixed then we can propagate
+        if a_lb == a_ub {
+            self.is_satisfied = true;
+            context.post(
+                predicate!(self.b != a_lb),
+                conjunction!([self.a == a_lb]),
+                self.inference_code,
+            )?;
+        }
+
+        // If `b` is fixed then we can propagate
+        if b_lb == b_ub {
+            self.is_satisfied = true;
+            context.post(
+                predicate!(self.a != b_lb),
+                conjunction!([self.b == b_lb]),
+                self.inference_code,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn debug_propagate_from_scratch(
+        &self,
+        mut context: PropagationContextMut,
+    ) -> PropagationStatusCP {
+        if let Some(conflict) = self.detect_inconsistency(context.as_trailed_readonly()) {
+            return Err(conflict.into());
+        }
+
+        let a_lb = context.lower_bound(&self.a);
+        let a_ub = context.upper_bound(&self.a);
+
+        let b_lb = context.lower_bound(&self.b);
+        let b_ub = context.upper_bound(&self.b);
+
+        if a_ub < b_lb || b_ub < a_lb {
+            return Ok(());
+        }
+
+        if a_lb == a_ub {
+            context.post(
+                predicate!(self.b != a_lb),
+                conjunction!([self.a == a_lb]),
+                self.inference_code,
+            )?;
+        }
+
+        if b_lb == b_ub {
+            context.post(
+                predicate!(self.a != b_lb),
+                conjunction!([self.b == b_lb]),
+                self.inference_code,
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/pumpkin-solver/src/propagators/arithmetic/binary/binary_not_equals.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/binary/binary_not_equals.rs
@@ -46,19 +46,6 @@ where
         context.register(a.clone(), DomainEvents::ASSIGN, LocalId::from(0));
         context.register(b.clone(), DomainEvents::ASSIGN, LocalId::from(1));
 
-        // We also need to ensure that we know when propagation can take place; note that we might
-        // need to re-do a removal after backtracking
-        context.register_for_backtrack_events(
-            a.clone(),
-            DomainEvents::ASSIGN_AND_REMOVAL,
-            LocalId::from(0),
-        );
-        context.register_for_backtrack_events(
-            b.clone(),
-            DomainEvents::ASSIGN_AND_REMOVAL,
-            LocalId::from(1),
-        );
-
         BinaryNotEqualsPropagator {
             a,
             b,
@@ -125,12 +112,7 @@ where
         }
     }
 
-    fn notify_backtrack(
-        &mut self,
-        _context: PropagationContext,
-        _local_id: LocalId,
-        _event: OpaqueDomainEvent,
-    ) {
+    fn synchronise(&mut self, _context: PropagationContext) {
         // Either one of the variables has become unassigned or one of the removals could have
         // become undone
         self.is_satisfied = false;

--- a/pumpkin-solver/src/propagators/arithmetic/binary/mod.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/binary/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod binary_equals;
+
+pub(crate) use binary_equals::*;

--- a/pumpkin-solver/src/propagators/arithmetic/binary/mod.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/binary/mod.rs
@@ -1,3 +1,5 @@
 pub(crate) mod binary_equals;
+pub(crate) mod binary_not_equals;
 
 pub(crate) use binary_equals::*;
+pub(crate) use binary_not_equals::*;

--- a/pumpkin-solver/src/propagators/arithmetic/mod.rs
+++ b/pumpkin-solver/src/propagators/arithmetic/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod absolute_value;
+pub(crate) mod binary;
 pub(crate) mod division;
 pub(crate) mod integer_multiplication;
 pub(crate) mod linear_less_or_equal;


### PR DESCRIPTION
Currently, we decompose `int_eq` and `int_ne` in terms of two linear inequalities, and a general not equal propagator, respectively.

This PR aims to implement a dedicated propagator for these two cases, this allows the following benefits:
- For `int_eq`: the decomposition only allows bounds consistency while now we can be domain consistent
- For `int_ne`: earlier experiment showed that implementing `detect_inconsistency` for `int_lin_ne` was not performant, however, it can be easily done for the binary case.

- [x] Check performance difference across benchmarks

MiniZinc Score: 
- With Update: 179.72
- Without Update: 176.28

Average Primal Integral:
- With Update: 37.44
- Without Update: 57.98