### PR TITLE
refactor: Discharge unit-domain terms from the linear inequalities and disequalities

### DIFF
--- a/pumpkin-crates/core/src/propagators/arithmetic/linear_less_or_equal.rs
+++ b/pumpkin-crates/core/src/propagators/arithmetic/linear_less_or_equal.rs
@@ -1,6 +1,3 @@
-use itertools::Itertools;
-use log::warn;
-
 use crate::basic_types::PropagationStatusCP;
 use crate::basic_types::PropagatorConflict;
 use crate::basic_types::PropositionalConjunction;

--- a/pumpkin-crates/core/src/propagators/arithmetic/linear_not_equal.rs
+++ b/pumpkin-crates/core/src/propagators/arithmetic/linear_not_equal.rs
@@ -2,8 +2,10 @@ use std::rc::Rc;
 
 use enumset::enum_set;
 
+use crate::basic_types::PropagationStatusCP;
 use crate::basic_types::PropagatorConflict;
 use crate::basic_types::PropositionalConjunction;
+use crate::conjunction;
 use crate::declare_inference_label;
 use crate::engine::cp::propagation::ReadDomains;
 use crate::engine::notifications::DomainEvent;
@@ -24,7 +26,6 @@ use crate::proof::InferenceCode;
 use crate::pumpkin_assert_extreme;
 use crate::pumpkin_assert_moderate;
 use crate::pumpkin_assert_simple;
-use crate::{basic_types::PropagationStatusCP, conjunction};
 
 declare_inference_label!(LinearNotEquals);
 


### PR DESCRIPTION
This PR simplifies the linear constraint propagators during their creation by:
- removing all terms with singleton domains,
- and subtracting the sum of all involved (constant) values from the right-hand side.

⚠️ **Not ready for merging,** as I do not understand the logic behind the test `propagators::arithmetic::linear_less_or_equal::tests::overflow_leads_to_conflict`.