### PR TITLE
fix: Reporting conflict if there is a task which uses more resource than capacity

### DIFF
--- a/pumpkin-crates/core/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
+++ b/pumpkin-crates/core/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
@@ -4,7 +4,10 @@ use std::rc::Rc;
 
 use super::insertion;
 use super::removal;
+use crate::basic_types::Inconsistency;
 use crate::basic_types::PropagationStatusCP;
+use crate::basic_types::PropagatorConflict;
+use crate::conjunction;
 use crate::engine::notifications::OpaqueDomainEvent;
 use crate::engine::notifications::DomainEvent;
 use crate::engine::propagation::constructor::PropagatorConstructorContext;
@@ -380,6 +383,13 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool> Propagator
             ),
             "Bounds were not equal when propagating"
         );
+
+        if self.parameters.is_infeasible {
+            return Err(Inconsistency::Conflict(PropagatorConflict {
+                conjunction: conjunction!(),
+                inference_code: self.inference_code.unwrap(),
+            }));
+        }
 
         self.update_time_table(&mut context)?;
 

--- a/pumpkin-crates/core/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
+++ b/pumpkin-crates/core/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::rc::Rc;
 
+use crate::basic_types::Inconsistency;
 use crate::basic_types::PropagationStatusCP;
+use crate::basic_types::PropagatorConflict;
+use crate::conjunction;
 use crate::engine::notifications::DomainEvent;
 use crate::engine::notifications::OpaqueDomainEvent;
 use crate::engine::propagation::constructor::PropagatorConstructor;
@@ -390,6 +393,13 @@ impl<Var: IntegerVariable + 'static + Debug, const SYNCHRONISE: bool> Propagator
             ),
             "Bound were not equal when propagating"
         );
+
+        if self.parameters.is_infeasible {
+            return Err(Inconsistency::Conflict(PropagatorConflict {
+                conjunction: conjunction!(),
+                inference_code: self.inference_code.unwrap(),
+            }));
+        }
 
         // We update the time-table based on the stored updates
         self.update_time_table(&mut context)?;


### PR DESCRIPTION
Currently, we do not proactively look for the case where a task is provided that uses more resource than the capacity; this leads to an issue when this conflict is reported as it could have been reported earlier.

This PR addresses this issue by performing an additional check when initialising. This occurs in [certain models](https://github.com/MiniZinc/mzn-challenge/blob/develop/2024/aircraft-disassembly/aircraft.mzn).