### PR TITLE
fix: Use synchronise instead of notify backtrack for binary equals

### DIFF
--- a/pumpkin-crates/core/src/engine/notifications/domain_event_notification/domain_events.rs
+++ b/pumpkin-crates/core/src/engine/notifications/domain_event_notification/domain_events.rs
@@ -22,8 +22,6 @@ impl DomainEvents {
             | DomainEvent::UpperBound
             | DomainEvent::Removal
     ));
-    pub(crate) const REMOVAL: DomainEvents =
-        DomainEvents::create_with_int_events(enum_set!(DomainEvent::Removal));
     /// DomainEvents with only lower bound tightening.
     pub(crate) const LOWER_BOUND: DomainEvents =
         DomainEvents::create_with_int_events(enum_set!(DomainEvent::LowerBound));

--- a/pumpkin-crates/core/src/propagators/arithmetic/binary/binary_equals.rs
+++ b/pumpkin-crates/core/src/propagators/arithmetic/binary/binary_equals.rs
@@ -48,10 +48,6 @@ where
         context.register(a.clone(), DomainEvents::ANY_INT, LocalId::from(0));
         context.register(b.clone(), DomainEvents::ANY_INT, LocalId::from(1));
 
-        // If we backtrack then we need to update the removable values
-        context.register_for_backtrack_events(a.clone(), DomainEvents::REMOVAL, LocalId::from(0));
-        context.register_for_backtrack_events(b.clone(), DomainEvents::REMOVAL, LocalId::from(1));
-
         BinaryEqualsPropagator {
             a,
             b,
@@ -159,12 +155,7 @@ where
         EnqueueDecision::Enqueue
     }
 
-    fn notify_backtrack(
-        &mut self,
-        _context: PropagationContext,
-        _local_id: LocalId,
-        _event: OpaqueDomainEvent,
-    ) {
+    fn synchronise(&mut self, _context: PropagationContext) {
         // Recall that we need to ensure that the stored removed values could now be inaccurate
         self.has_backtracked = true;
     }


### PR DESCRIPTION
The `backtrack_notify` method does not always notify you of your own changes (since it might also not `notify` you of them if they caused an empty domain/conflict).

For the binary equals propagator this meant that it was not always correctly checking the removed values upon backtracking.