### PR TITLE
feat(pumpkin-solver): Don't use binary equals when logging the full proof

### DIFF
--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -132,6 +132,10 @@ impl Solver {
     pub fn get_solution_reference(&self) -> SolutionReference<'_> {
         self.satisfaction_solver.get_solution_reference()
     }
+
+    pub(crate) fn is_logging_full_proof(&self) -> bool {
+        self.satisfaction_solver.is_logging_full_proof()
+    }
 }
 
 /// Methods to retrieve information about variables

--- a/pumpkin-crates/core/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-crates/core/src/constraints/arithmetic/equality.rs
@@ -85,7 +85,7 @@ where
     Var: IntegerVariable + Clone + 'static,
 {
     fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
-        if self.terms.len() == 2 {
+        if self.terms.len() == 2 && !solver.is_logging_full_proof() {
             solver.add_propagator(BinaryEqualsPropagatorArgs {
                 a: self.terms[0].clone(),
                 b: self.terms[1].scaled(-1).offset(self.rhs),

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -271,6 +271,10 @@ impl ConstraintSatisfactionSolver {
 
         finalize_proof(context);
     }
+
+    pub(crate) fn is_logging_full_proof(&self) -> bool {
+        self.internal_parameters.proof_log.is_logging_inferences()
+    }
 }
 
 // methods that offer basic functionality


### PR DESCRIPTION
In the full proof, this rule is not yet supported. So we do not do the rewrite for now.