### PR TITLE
feat: Adding logging of brancher statistics on completion

### DIFF
--- a/pumpkin-crates/core/src/api/outputs/mod.rs
+++ b/pumpkin-crates/core/src/api/outputs/mod.rs
@@ -19,10 +19,10 @@ pub enum SatisfactionResult<'solver, 'brancher, B: Brancher> {
     /// result is dropped, the solver will be reset to the root, ready for further use.
     Satisfiable(Satisfiable<'solver, 'brancher, B>),
     /// Indicates that there is no solution to the satisfaction problem.
-    Unsatisfiable(&'solver Solver),
+    Unsatisfiable(&'solver Solver, &'brancher B),
     /// Indicates that it is not known whether a solution exists. This is likely due to a
     /// [`TerminationCondition`] triggering.
-    Unknown(&'solver Solver),
+    Unknown(&'solver Solver, &'brancher B),
 }
 
 /// The result of a call to [`Solver::satisfy_under_assumptions`].

--- a/pumpkin-crates/core/src/api/outputs/solution_iterator.rs
+++ b/pumpkin-crates/core/src/api/outputs/solution_iterator.rs
@@ -64,14 +64,14 @@ impl<'solver, 'brancher, 'termination, B: Brancher, T: TerminationCondition>
                 self.next_blocking_clause = Some(get_blocking_clause(solution.as_reference()));
                 IterationResult::Solution(solution)
             }
-            Unsatisfiable(_) => {
+            Unsatisfiable(_, _) => {
                 if self.has_solution {
                     IterationResult::Finished
                 } else {
                     IterationResult::Unsatisfiable
                 }
             }
-            Unknown(_) => IterationResult::Unknown,
+            Unknown(_, _) => IterationResult::Unknown,
         };
 
         match result {

--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -324,12 +324,12 @@ impl Solver {
                 self.satisfaction_solver.restore_state_at_root(brancher);
                 let _ = self.satisfaction_solver.conclude_proof_unsat();
 
-                SatisfactionResult::Unsatisfiable(self)
+                SatisfactionResult::Unsatisfiable(self, brancher)
             }
             CSPSolverExecutionFlag::Timeout => {
                 // Reset the state whenever we return a result
                 self.satisfaction_solver.restore_state_at_root(brancher);
-                SatisfactionResult::Unknown(self)
+                SatisfactionResult::Unknown(self, brancher)
             }
         }
     }

--- a/pumpkin-crates/core/src/optimisation/linear_sat_unsat.rs
+++ b/pumpkin-crates/core/src/optimisation/linear_sat_unsat.rs
@@ -55,8 +55,8 @@ where
         // First we will solve the satisfaction problem without constraining the objective.
         let mut best_solution: Solution = match solver.satisfy(brancher, termination) {
             SatisfactionResult::Satisfiable(satisfiable) => satisfiable.solution().into(),
-            SatisfactionResult::Unsatisfiable(_) => return OptimisationResult::Unsatisfiable,
-            SatisfactionResult::Unknown(_) => return OptimisationResult::Unknown,
+            SatisfactionResult::Unsatisfiable(_, _) => return OptimisationResult::Unsatisfiable,
+            SatisfactionResult::Unknown(_, _) => return OptimisationResult::Unknown,
         };
 
         loop {

--- a/pumpkin-crates/core/src/optimisation/linear_unsat_sat.rs
+++ b/pumpkin-crates/core/src/optimisation/linear_unsat_sat.rs
@@ -58,8 +58,8 @@ where
         // First we will solve the satisfaction problem without constraining the objective.
         let primal_solution: Solution = match solver.satisfy(brancher, termination) {
             SatisfactionResult::Satisfiable(satisfiable) => satisfiable.solution().into(),
-            SatisfactionResult::Unsatisfiable(_) => return OptimisationResult::Unsatisfiable,
-            SatisfactionResult::Unknown(_) => return OptimisationResult::Unknown,
+            SatisfactionResult::Unsatisfiable(_, _) => return OptimisationResult::Unsatisfiable,
+            SatisfactionResult::Unknown(_, _) => return OptimisationResult::Unknown,
         };
 
         self.solution_callback.on_solution_callback(

--- a/pumpkin-solver/examples/bibd.rs
+++ b/pumpkin-solver/examples/bibd.rs
@@ -169,10 +169,10 @@ fn main() {
 
             println!("{row_separator}");
         }
-        SatisfactionResult::Unsatisfiable(_) => {
+        SatisfactionResult::Unsatisfiable(_, _) => {
             println!("UNSATISFIABLE")
         }
-        SatisfactionResult::Unknown(_) => {
+        SatisfactionResult::Unknown(_, _) => {
             println!("UNKNOWN")
         }
     };

--- a/pumpkin-solver/examples/disjunctive_scheduling.rs
+++ b/pumpkin-solver/examples/disjunctive_scheduling.rs
@@ -90,7 +90,7 @@ fn main() {
     let mut brancher = solver.default_brancher();
     if matches!(
         solver.satisfy(&mut brancher, &mut Indefinite),
-        SatisfactionResult::Unsatisfiable(_),
+        SatisfactionResult::Unsatisfiable(_, _),
     ) {
         panic!("Infeasibility Detected")
     }
@@ -121,7 +121,7 @@ fn main() {
                     .join(" - ")
             );
         }
-        SatisfactionResult::Unsatisfiable(_) => panic!("Infeasibility Detected"),
-        SatisfactionResult::Unknown(_) => println!("Timeout."),
+        SatisfactionResult::Unsatisfiable(_, _) => panic!("Infeasibility Detected"),
+        SatisfactionResult::Unknown(_, _) => println!("Timeout."),
     };
 }

--- a/pumpkin-solver/examples/nqueens.rs
+++ b/pumpkin-solver/examples/nqueens.rs
@@ -107,10 +107,10 @@ fn main() {
 
             println!("{row_separator}");
         }
-        SatisfactionResult::Unsatisfiable(_) => {
+        SatisfactionResult::Unsatisfiable(_, _) => {
             println!("{n}-queens is unsatisfiable.");
         }
-        SatisfactionResult::Unknown(_) => {
+        SatisfactionResult::Unknown(_, _) => {
             println!("Timeout.");
         }
     };

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/mod.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/mod.rs
@@ -61,6 +61,11 @@ pub(crate) struct FlatZincOptions {
     pub(crate) proof_type: Option<ProofType>,
 }
 
+fn log_statistics(solver: &Solver, brancher: &impl Brancher) {
+    brancher.log_statistics(StatisticLogger::default());
+    solver.log_statistics();
+}
+
 fn solution_callback(
     brancher: &impl Brancher,
     instance_objective_function: Option<DomainId>,
@@ -161,19 +166,19 @@ pub(crate) fn solve(
                 print_solution_from_solver(optimal_solution.as_reference(), &instance.outputs)
             }
             println!("==========");
-            solver.log_statistics();
+            log_statistics(&solver, &brancher);
         }
         OptimisationResult::Satisfiable(_) => {
             // Solutions are printed in the callback.
-            solver.log_statistics();
+            log_statistics(&solver, &brancher);
         }
         OptimisationResult::Unsatisfiable => {
             println!("{MSG_UNSATISFIABLE}");
-            solver.log_statistics();
+            log_statistics(&solver, &brancher);
         }
         OptimisationResult::Unknown => {
             println!("{MSG_UNKNOWN}");
-            solver.log_statistics();
+            log_statistics(&solver, &brancher);
         }
     };
 
@@ -206,20 +211,20 @@ fn satisfy(
                 IteratedSolution::Finished => {
                     assert!(has_found_solution);
                     println!("==========");
-                    solver.log_statistics();
+                    log_statistics(solver, &brancher);
                     break;
                 }
                 IteratedSolution::Unknown => {
                     if !has_found_solution {
                         println!("{MSG_UNKNOWN}");
                     }
-                    solver.log_statistics();
+                    log_statistics(solver, &brancher);
                     break;
                 }
                 IteratedSolution::Unsatisfiable => {
                     assert!(!has_found_solution);
                     println!("{MSG_UNSATISFIABLE}");
-                    solver.log_statistics();
+                    log_statistics(solver, &brancher);
                     break;
                 }
             }
@@ -234,13 +239,13 @@ fn satisfy(
                 satisfiable.solver(),
                 satisfiable.solution(),
             ),
-            SatisfactionResult::Unsatisfiable(solver) => {
+            SatisfactionResult::Unsatisfiable(solver, brancher) => {
                 println!("{MSG_UNSATISFIABLE}");
-                solver.log_statistics();
+                log_statistics(solver, brancher);
             }
-            SatisfactionResult::Unknown(solver) => {
+            SatisfactionResult::Unknown(solver, brancher) => {
                 println!("{MSG_UNKNOWN}");
-                solver.log_statistics();
+                log_statistics(solver, brancher);
             }
         }
     }

--- a/pumpkin-solver/src/bin/pumpkin-solver/main.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/main.rs
@@ -633,12 +633,12 @@ fn cnf_problem(
                 )
             );
         }
-        SatisfactionResult::Unsatisfiable(solver) => {
+        SatisfactionResult::Unsatisfiable(solver, _) => {
             solver.log_statistics();
 
             println!("s UNSATISFIABLE");
         }
-        SatisfactionResult::Unknown(solver) => {
+        SatisfactionResult::Unknown(solver, _) => {
             solver.log_statistics();
             println!("s UNKNOWN");
         }

--- a/pumpkin-solver/src/bin/pumpkin-solver/maxsat/optimisation/linear_search.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/maxsat/optimisation/linear_search.rs
@@ -101,14 +101,14 @@ impl LinearSearch {
                         process_time.elapsed().as_millis(),
                     );
                 }
-                SatisfactionResult::Unsatisfiable(solver) => {
+                SatisfactionResult::Unsatisfiable(solver, _) => {
                     solver.log_statistics_with_objective(best_objective_value as i64);
 
                     return MaxSatOptimisationResult::Optimal {
                         solution: best_solution,
                     };
                 }
-                SatisfactionResult::Unknown(solver) => {
+                SatisfactionResult::Unknown(solver, _) => {
                     solver.log_statistics_with_objective(best_objective_value as i64);
                     return MaxSatOptimisationResult::Satisfiable { best_solution };
                 }

--- a/pumpkin-solver/src/bin/pumpkin-solver/maxsat/optimisation/optimisation_solver.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/maxsat/optimisation/optimisation_solver.rs
@@ -54,8 +54,8 @@ impl OptimisationSolver {
 
                     InitialSolveResult::Solution(satisfiable.solution().into())
                 }
-                SatisfactionResult::Unsatisfiable(_) => InitialSolveResult::Unsatisfiable,
-                SatisfactionResult::Unknown(_) => InitialSolveResult::Unknown,
+                SatisfactionResult::Unsatisfiable(_, _) => InitialSolveResult::Unsatisfiable,
+                SatisfactionResult::Unknown(_, _) => InitialSolveResult::Unknown,
             }
         };
 

--- a/pumpkin-solver/tests/solver_test.rs
+++ b/pumpkin-solver/tests/solver_test.rs
@@ -34,7 +34,7 @@ fn proof_with_reified_literals() {
 
     let mut brancher = solver.default_brancher();
     let result = solver.satisfy(&mut brancher, &mut Indefinite);
-    assert!(matches!(result, SatisfactionResult::Unsatisfiable(_)));
+    assert!(matches!(result, SatisfactionResult::Unsatisfiable(_, _)));
 }
 
 #[test]
@@ -61,5 +61,5 @@ fn proof_with_equality_unit_nogood_step() {
 
     let mut brancher = solver.default_brancher();
     let result = solver.satisfy(&mut brancher, &mut Indefinite);
-    assert!(matches!(result, SatisfactionResult::Unsatisfiable(_)));
+    assert!(matches!(result, SatisfactionResult::Unsatisfiable(_, _)));
 }


### PR DESCRIPTION
Currently, we only print engine statistics upon completion/termination and not branching statistics.

This PR addresses this by also printing the branched statistics.