### PR TITLE
fix: Reduce expensiveness of predicate notification

### DIFF
--- a/pumpkin-crates/core/src/engine/cp/assignments.rs
+++ b/pumpkin-crates/core/src/engine/cp/assignments.rs
@@ -66,6 +66,19 @@ impl Assignments {
         self.domains[domain_id].get_holes_from_current_decision_level(self.get_decision_level())
     }
 
+    /// Returns all of the holes in the domain which were created at the current decision level
+    /// above the provided index
+    pub(crate) fn get_holes_on_current_decision_level_above_index(
+        &self,
+        domain_id: DomainId,
+        trail_index: usize,
+    ) -> impl Iterator<Item = i32> + '_ {
+        self.domains[domain_id].get_holes_from_current_decision_level_above_index(
+            self.get_decision_level(),
+            trail_index,
+        )
+    }
+
     /// Returns all of the holes (currently) in the domain of `var` (including ones which were
     /// created at previous decision levels).
     pub(crate) fn get_holes(&self, domain_id: DomainId) -> impl Iterator<Item = i32> + '_ {
@@ -813,8 +826,8 @@ struct BoundUpdateInfo {
 #[derive(Clone, Debug)]
 struct HoleUpdateInfo {
     removed_value: i32,
-
     decision_level: usize,
+    trail_position: usize,
 
     triggered_lower_bound_update: bool,
     triggered_upper_bound_update: bool,
@@ -1008,6 +1021,7 @@ impl IntegerDomain {
         self.hole_updates.push(HoleUpdateInfo {
             removed_value,
             decision_level,
+            trail_position,
             triggered_lower_bound_update: false,
             triggered_upper_bound_update: false,
         });
@@ -1323,6 +1337,21 @@ impl IntegerDomain {
             .iter()
             .rev()
             .take_while(move |entry| entry.decision_level == current_decision_level)
+            .map(|entry| entry.removed_value)
+    }
+
+    /// Returns the holes which were created on the current decision level above the provided index.
+    pub(crate) fn get_holes_from_current_decision_level_above_index(
+        &self,
+        current_decision_level: usize,
+        trail_index: usize,
+    ) -> impl Iterator<Item = i32> + '_ {
+        self.hole_updates
+            .iter()
+            .rev()
+            .take_while(move |entry| {
+                entry.decision_level == current_decision_level && entry.trail_position > trail_index
+            })
             .map(|entry| entry.removed_value)
     }
 

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_notifier.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_notifier.rs
@@ -142,7 +142,6 @@ impl PredicateNotifier {
             domain,
             predicate_type,
             assignments,
-            &mut self.predicate_to_id,
             trailed_values,
             &mut self.predicate_id_assignments,
             removed_value,

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_notifier.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_notifier.rs
@@ -149,7 +149,7 @@ impl PredicateNotifier {
         if self.domain_id_to_predicate_tracker.len() <= predicate.get_domain().index() {
             self.domain_id_to_predicate_tracker.resize(
                 predicate.get_domain().index() + 1,
-                PredicateTrackerForDomain::new(),
+                PredicateTrackerForDomain::new(trailed_values),
             );
         }
 

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_notifier.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_notifier.rs
@@ -79,13 +79,7 @@ impl PredicateNotifier {
     ) {
         match event {
             DomainEvent::Assign => {
-                self.on_update_predicate(
-                    domain,
-                    PredicateType::Equal,
-                    assignments,
-                    trailed_values,
-                    None,
-                );
+                self.on_update_predicate(domain, PredicateType::Equal, assignments, trailed_values);
             }
             DomainEvent::LowerBound => {
                 self.on_update_predicate(
@@ -93,7 +87,6 @@ impl PredicateNotifier {
                     PredicateType::LowerBound,
                     assignments,
                     trailed_values,
-                    None,
                 );
             }
             DomainEvent::UpperBound => {
@@ -102,20 +95,16 @@ impl PredicateNotifier {
                     PredicateType::UpperBound,
                     assignments,
                     trailed_values,
-                    None,
                 );
             }
-            DomainEvent::Removal => assignments
-                .get_holes_on_current_decision_level(domain)
-                .for_each(|value| {
-                    self.on_update_predicate(
-                        domain,
-                        PredicateType::NotEqual,
-                        assignments,
-                        trailed_values,
-                        Some(value),
-                    );
-                }),
+            DomainEvent::Removal => {
+                self.on_update_predicate(
+                    domain,
+                    PredicateType::NotEqual,
+                    assignments,
+                    trailed_values,
+                );
+            }
         }
     }
 
@@ -130,7 +119,6 @@ impl PredicateNotifier {
         predicate_type: PredicateType,
         assignments: &Assignments,
         trailed_values: &mut TrailedValues,
-        removed_value: Option<i32>,
     ) {
         if self.domain_id_to_predicate_tracker.len() <= domain.index() {
             // If no predicate has been registered for this domain id then we do nothing
@@ -144,7 +132,6 @@ impl PredicateNotifier {
             assignments,
             trailed_values,
             &mut self.predicate_id_assignments,
-            removed_value,
         );
     }
 

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_tracker_for_domain.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_tracker_for_domain.rs
@@ -62,46 +62,55 @@ impl PredicateTrackerForDomain {
         domain: DomainId,
         predicate_type: PredicateType,
         assignments: &Assignments,
-        stateful_trail: &mut TrailedValues,
+        trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
     ) {
         if !self.lower_bound.is_empty()
             && (predicate_type.is_lower_bound() || predicate_type.is_upper_bound())
+            && !self.lower_bound.is_fixed(trailed_values)
         {
             self.lower_bound.on_update(
                 predicate_type.into_predicate(domain, assignments, None),
-                stateful_trail,
+                trailed_values,
                 predicate_id_assignments,
             );
         }
 
         if !self.upper_bound.is_empty()
             && (predicate_type.is_lower_bound() || predicate_type.is_upper_bound())
+            && !self.upper_bound.is_fixed(trailed_values)
         {
             self.upper_bound.on_update(
                 predicate_type.into_predicate(domain, assignments, None),
-                stateful_trail,
+                trailed_values,
                 predicate_id_assignments,
             );
         }
 
         if predicate_type.is_disequality() {
             if !self.disequality.is_empty() || !self.equality.is_empty() {
+                let disequality_is_fixed = self.disequality.is_fixed(trailed_values);
+                let equality_is_fixed = self.equality.is_fixed(trailed_values);
+
+                if disequality_is_fixed && equality_is_fixed {
+                    return;
+                }
+
                 for removed_value in assignments.get_holes_on_current_decision_level(domain) {
                     let predicate =
                         predicate_type.into_predicate(domain, assignments, Some(removed_value));
-                    if !self.disequality.is_empty() {
+                    if !self.disequality.is_empty() && !disequality_is_fixed {
                         self.disequality.on_update(
                             predicate,
-                            stateful_trail,
+                            trailed_values,
                             predicate_id_assignments,
                         );
                     }
 
-                    if !self.equality.is_empty() {
+                    if !self.equality.is_empty() && !equality_is_fixed {
                         self.equality.on_update(
                             predicate,
-                            stateful_trail,
+                            trailed_values,
                             predicate_id_assignments,
                         );
                     }
@@ -109,14 +118,14 @@ impl PredicateTrackerForDomain {
             }
         } else {
             let predicate = predicate_type.into_predicate(domain, assignments, None);
-            if !self.disequality.is_empty() {
+            if !self.disequality.is_empty() && !self.disequality.is_fixed(trailed_values) {
                 self.disequality
-                    .on_update(predicate, stateful_trail, predicate_id_assignments);
+                    .on_update(predicate, trailed_values, predicate_id_assignments);
             }
 
-            if !self.equality.is_empty() {
+            if !self.equality.is_empty() && !self.equality.is_fixed(trailed_values) {
                 self.equality
-                    .on_update(predicate, stateful_trail, predicate_id_assignments);
+                    .on_update(predicate, trailed_values, predicate_id_assignments);
             }
         }
     }

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_tracker_for_domain.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_tracker_for_domain.rs
@@ -6,7 +6,6 @@ use super::predicate_trackers::LowerBoundTracker;
 use super::predicate_trackers::UpperBoundTracker;
 use super::PredicateIdAssignments;
 use crate::basic_types::PredicateId;
-use crate::basic_types::PredicateIdGenerator;
 use crate::engine::Assignments;
 use crate::engine::TrailedValues;
 use crate::predicates::Predicate;
@@ -63,7 +62,6 @@ impl PredicateTrackerForDomain {
         domain: DomainId,
         predicate_type: PredicateType,
         assignments: &Assignments,
-        predicate_id_generator: &mut PredicateIdGenerator,
         stateful_trail: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
         removed_value: Option<i32>,
@@ -75,7 +73,6 @@ impl PredicateTrackerForDomain {
                 predicate_type.into_predicate(domain, assignments, removed_value),
                 stateful_trail,
                 predicate_id_assignments,
-                None,
             );
         }
 
@@ -86,18 +83,13 @@ impl PredicateTrackerForDomain {
                 predicate_type.into_predicate(domain, assignments, removed_value),
                 stateful_trail,
                 predicate_id_assignments,
-                None,
             );
         }
 
         if !self.disequality.is_empty() {
             let predicate = predicate_type.into_predicate(domain, assignments, removed_value);
-            self.disequality.on_update(
-                predicate,
-                stateful_trail,
-                predicate_id_assignments,
-                Some(predicate_id_generator.get_id(predicate)),
-            );
+            self.disequality
+                .on_update(predicate, stateful_trail, predicate_id_assignments);
         }
 
         if !self.equality.is_empty() {
@@ -105,7 +97,6 @@ impl PredicateTrackerForDomain {
                 predicate_type.into_predicate(domain, assignments, removed_value),
                 stateful_trail,
                 predicate_id_assignments,
-                None,
             );
         }
     }

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/disequality_tracker.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/disequality_tracker.rs
@@ -23,6 +23,9 @@ impl DisequalityTracker {
         }
     }
 
+    /// Returns the trail index which was last seen when processing a `!=` predicate.
+    ///
+    /// This is used to prevent updating multiple times for the same removals.
     pub(crate) fn get_last_seen_trail_index(&self, trailed_values: &TrailedValues) -> usize {
         trailed_values.read(self.last_seen_trail_index) as usize
     }

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/disequality_tracker.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/disequality_tracker.rs
@@ -1,9 +1,7 @@
 use super::DomainTracker;
 use super::HasTracker;
-use super::PredicateId;
 use super::PredicateTracker;
 use super::TrailedValues;
-use crate::engine::notifications::predicate_notification::predicate_trackers::DomainTrackerInformation;
 use crate::engine::notifications::predicate_notification::PredicateIdAssignments;
 use crate::predicate;
 use crate::predicates::Predicate;
@@ -42,7 +40,6 @@ impl DomainTracker for DisequalityTracker {
         predicate: Predicate,
         trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
-        predicate_id: Option<PredicateId>,
     ) {
         // We are interested in all types of predicates
         let value = predicate.get_right_hand_side();
@@ -135,11 +132,13 @@ impl DomainTracker for DisequalityTracker {
             // disequalities
             //
             // TODO: This could be optimised
-            if self.get_values().contains(&value) {
-                self.predicate_id_has_been_satisfied(
-                    predicate_id.unwrap(),
-                    predicate_id_assignments,
-                )
+            if let Some(index) = self
+                .watcher
+                .values
+                .iter()
+                .position(|&stored_value| stored_value == value)
+            {
+                self.predicate_has_been_satisfied(index, predicate_id_assignments)
             }
         } else {
             panic!()

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/disequality_tracker.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/disequality_tracker.rs
@@ -3,6 +3,7 @@ use super::HasTracker;
 use super::PredicateTracker;
 use super::TrailedValues;
 use crate::engine::notifications::predicate_notification::PredicateIdAssignments;
+use crate::engine::TrailedInteger;
 use crate::predicate;
 use crate::predicates::Predicate;
 
@@ -10,13 +11,20 @@ use crate::predicates::Predicate;
 #[derive(Debug, Clone)]
 pub(crate) struct DisequalityTracker {
     watcher: PredicateTracker,
+
+    last_seen_trail_index: TrailedInteger,
 }
 
 impl DisequalityTracker {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(trailed_values: &mut TrailedValues) -> Self {
         Self {
             watcher: PredicateTracker::new(),
+            last_seen_trail_index: trailed_values.grow(0),
         }
+    }
+
+    pub(crate) fn get_last_seen_trail_index(&self, trailed_values: &TrailedValues) -> usize {
+        trailed_values.read(self.last_seen_trail_index) as usize
     }
 }
 
@@ -40,6 +48,7 @@ impl DomainTracker for DisequalityTracker {
         predicate: Predicate,
         trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
+        trail_entry: usize,
     ) {
         // We are interested in all types of predicates
         let value = predicate.get_right_hand_side();
@@ -128,6 +137,7 @@ impl DomainTracker for DisequalityTracker {
                 trailed_values.assign(self.watcher.max_assigned, greater);
             }
         } else if predicate.is_not_equal_predicate() {
+            trailed_values.assign(self.last_seen_trail_index, trail_entry as i64);
             // A relatively simple case stating that a predicate has now become satisfied for
             // disequalities
             //

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/equality_tracker.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/equality_tracker.rs
@@ -23,6 +23,9 @@ impl EqualityTracker {
         }
     }
 
+    /// Returns the trail index which was last seen when processing a `!=` predicate.
+    ///
+    /// This is used to prevent updating multiple times for the same removals.
     pub(crate) fn get_last_seen_trail_index(&self, trailed_values: &TrailedValues) -> usize {
         trailed_values.read(self.last_seen_trail_index) as usize
     }

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/equality_tracker.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/equality_tracker.rs
@@ -3,6 +3,7 @@ use super::HasTracker;
 use super::PredicateTracker;
 use super::TrailedValues;
 use crate::engine::notifications::predicate_notification::PredicateIdAssignments;
+use crate::engine::TrailedInteger;
 use crate::predicate;
 use crate::predicates::Predicate;
 
@@ -10,13 +11,20 @@ use crate::predicates::Predicate;
 #[derive(Debug, Clone)]
 pub(crate) struct EqualityTracker {
     watcher: PredicateTracker,
+
+    last_seen_trail_index: TrailedInteger,
 }
 
 impl EqualityTracker {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(trailed_values: &mut TrailedValues) -> Self {
         Self {
             watcher: PredicateTracker::new(),
+            last_seen_trail_index: trailed_values.grow(0),
         }
+    }
+
+    pub(crate) fn get_last_seen_trail_index(&self, trailed_values: &TrailedValues) -> usize {
+        trailed_values.read(self.last_seen_trail_index) as usize
     }
 }
 
@@ -40,6 +48,7 @@ impl DomainTracker for EqualityTracker {
         predicate: Predicate,
         trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
+        trail_entry: usize,
     ) {
         let value = predicate.get_right_hand_side();
         if predicate.is_lower_bound_predicate() {
@@ -77,6 +86,8 @@ impl DomainTracker for EqualityTracker {
                 smaller = self.watcher.smaller[smaller as usize];
             }
         } else if predicate.is_not_equal_predicate() {
+            trailed_values.assign(self.last_seen_trail_index, trail_entry as i64);
+
             // If the right-hand side of the disequality predicate is smaller than the value
             // pointed to by `min_assigned` then no updates can take place
             if value <= self.watcher.values[trailed_values.read(self.watcher.min_assigned) as usize]

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/lower_bound_tracker.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/lower_bound_tracker.rs
@@ -40,6 +40,7 @@ impl DomainTracker for LowerBoundTracker {
         predicate: Predicate,
         trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
+        _trail_entry: usize,
     ) {
         // We only consider lower-bound and upper-bound updates
         let value = predicate.get_right_hand_side();

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/lower_bound_tracker.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/lower_bound_tracker.rs
@@ -1,6 +1,5 @@
 use super::DomainTracker;
 use super::HasTracker;
-use super::PredicateId;
 use super::PredicateTracker;
 use super::TrailedValues;
 use crate::engine::notifications::predicate_notification::PredicateIdAssignments;
@@ -41,7 +40,6 @@ impl DomainTracker for LowerBoundTracker {
         predicate: Predicate,
         trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
-        _predicate_id: Option<PredicateId>,
     ) {
         // We only consider lower-bound and upper-bound updates
         let value = predicate.get_right_hand_side();

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/mod.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/mod.rs
@@ -209,19 +209,6 @@ pub(crate) trait DomainTracker: DomainTrackerInformation {
     /// `LowerBoundTracker::get_predicate_for_value(5)` will return the [`Predicate`] `[x >= 5].`
     fn get_predicate_for_value(&self, value: i32) -> Predicate;
 
-    /// Allows the [`DomainTracker`] to indicate that a tracked [`PredicateId`] has been satisfied.
-    fn predicate_id_has_been_satisfied(
-        &self,
-        predicate_id: PredicateId,
-        predicate_id_assignments: &mut PredicateIdAssignments,
-    ) {
-        if predicate_id.id == u32::MAX {
-            // If it is a placeholder then we ignore it
-            return;
-        }
-        predicate_id_assignments.store_predicate(predicate_id, PredicateValue::AssignedTrue);
-    }
-
     /// Allows the [`DomainTracker`] to indicate that a tracked [`Predicate`] has been satisfied.
     fn predicate_has_been_satisfied(
         &self,
@@ -345,6 +332,5 @@ pub(crate) trait DomainTracker: DomainTrackerInformation {
         predicate: Predicate,
         trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
-        predicate_id: Option<PredicateId>,
     );
 }

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/mod.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/mod.rs
@@ -360,5 +360,6 @@ pub(crate) trait DomainTracker: DomainTrackerInformation {
         predicate: Predicate,
         trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
+        trail_entry: usize,
     );
 }

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/upper_bound_tracker.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/upper_bound_tracker.rs
@@ -40,6 +40,7 @@ impl DomainTracker for UpperBoundTracker {
         predicate: Predicate,
         trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
+        _trail_entry: usize,
     ) {
         // We only consider lower-bound and upper-bound updates
         let value = predicate.get_right_hand_side();

--- a/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/upper_bound_tracker.rs
+++ b/pumpkin-crates/core/src/engine/notifications/predicate_notification/predicate_trackers/upper_bound_tracker.rs
@@ -1,6 +1,5 @@
 use super::DomainTracker;
 use super::HasTracker;
-use super::PredicateId;
 use super::PredicateTracker;
 use super::TrailedValues;
 use crate::engine::notifications::predicate_notification::PredicateIdAssignments;
@@ -41,7 +40,6 @@ impl DomainTracker for UpperBoundTracker {
         predicate: Predicate,
         trailed_values: &mut TrailedValues,
         predicate_id_assignments: &mut PredicateIdAssignments,
-        _predicate_id: Option<PredicateId>,
     ) {
         // We only consider lower-bound and upper-bound updates
         let value = predicate.get_right_hand_side();

--- a/pumpkin-crates/core/src/engine/predicates/predicate.rs
+++ b/pumpkin-crates/core/src/engine/predicates/predicate.rs
@@ -58,6 +58,10 @@ impl PredicateType {
         matches!(self, PredicateType::UpperBound)
     }
 
+    pub(crate) fn is_disequality(&self) -> bool {
+        matches!(self, PredicateType::NotEqual)
+    }
+
     pub(crate) fn into_predicate(
         self,
         domain: DomainId,


### PR DESCRIPTION
One of the bottlenecks of the solver is the notification system; this PR proposes several changes to address this:
1. Moving the traversal of the holes in the domains to only be done if they are being tracked
2. Introducing a method which checks whether a tracker is fixed, and thus, cannot generate any more updates
3. Only go through holes once
4. Rewrite the equality tracker for disequality predicates to be more efficient