### PR TITLE
refactor: adjust statistic names according to minizinc specification

### DIFF
--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -38,6 +38,7 @@ use crate::results::solution_iterator::SolutionIterator;
 use crate::results::unsatisfiable::UnsatisfiableUnderAssumptions;
 use crate::statistics::log_statistic;
 use crate::statistics::log_statistic_postfix;
+use crate::statistics::StatisticLogger;
 
 /// The main interaction point which allows the creation of variables, the addition of constraints,
 /// and solving problems.
@@ -118,14 +119,24 @@ impl Solver {
     }
 
     /// Logs the statistics currently present in the solver with the provided objective value.
-    pub fn log_statistics_with_objective(&self, objective_value: i64) {
+    pub fn log_statistics_with_objective(
+        &self,
+        brancher: Option<&impl Brancher>,
+        objective_value: i64,
+        verbose: bool,
+    ) {
         log_statistic("objective", objective_value);
-        self.log_statistics();
+        self.log_statistics(brancher, verbose);
     }
 
     /// Logs the statistics currently present in the solver.
-    pub fn log_statistics(&self) {
-        self.satisfaction_solver.log_statistics();
+    pub fn log_statistics(&self, brancher: Option<&impl Brancher>, verbose: bool) {
+        self.satisfaction_solver.log_statistics(verbose);
+        if verbose {
+            if let Some(brancher) = brancher {
+                brancher.log_statistics(StatisticLogger::new(["brancher"]));
+            }
+        }
         log_statistic_postfix();
     }
 

--- a/pumpkin-crates/core/src/engine/conflict_analysis/minimisers/recursive_minimiser.rs
+++ b/pumpkin-crates/core/src/engine/conflict_analysis/minimisers/recursive_minimiser.rs
@@ -68,7 +68,7 @@ impl RecursiveMinimiser {
         context
             .counters
             .learned_clause_statistics
-            .average_number_of_removed_literals_recursive
+            .average_number_of_removed_atomic_constraints_recursive
             .add_term(num_predicates_removed as u64);
     }
 

--- a/pumpkin-crates/core/src/engine/conflict_analysis/resolvers/resolution_resolver.rs
+++ b/pumpkin-crates/core/src/engine/conflict_analysis/resolvers/resolution_resolver.rs
@@ -489,7 +489,7 @@ impl ResolutionResolver {
             context
                 .counters
                 .learned_clause_statistics
-                .average_number_of_removed_literals_semantic
+                .average_number_of_removed_atomic_constraints_semantic
                 .add_term((size_before_semantic_minimisation - clean_nogood.len()) as u64);
         }
 

--- a/pumpkin-crates/core/src/engine/cp/propagation/store.rs
+++ b/pumpkin-crates/core/src/engine/cp/propagation/store.rs
@@ -15,6 +15,10 @@ pub(crate) struct PropagatorStore {
 }
 
 impl PropagatorStore {
+    pub(crate) fn num_propagators(&self) -> usize {
+        self.propagators.len()
+    }
+
     pub(crate) fn iter_propagators(&self) -> impl Iterator<Item = &dyn Propagator> + '_ {
         self.propagators.iter().map(|b| b.as_ref())
     }

--- a/pumpkin-crates/core/src/engine/solver_statistics.rs
+++ b/pumpkin-crates/core/src/engine/solver_statistics.rs
@@ -1,45 +1,81 @@
 use crate::basic_types::moving_averages::CumulativeMovingAverage;
 use crate::create_statistics_struct;
+use crate::engine::propagation::store::PropagatorStore;
+use crate::engine::Assignments;
+use crate::statistics::log_statistic;
+use crate::statistics::Statistic;
+use crate::statistics::StatisticLogger;
 
-create_statistics_struct!(
-    /// Structure responsible for storing several statistics of the solving process of the
-    /// [`ConstraintSatisfactionSolver`].
-    SolverStatistics {
-        /// Core statistics of the solver engine (e.g. the number of decisions)
-        engine_statistics: EngineStatistics,
-        /// The statistics related to clause learning
-        learned_clause_statistics: LearnedClauseStatistics
-    }
-);
-
-create_statistics_struct!(
+/// Structure responsible for storing several statistics of the solving process of the
+/// [`ConstraintSatisfactionSolver`].
+#[derive(Debug, Default)]
+pub(crate) struct SolverStatistics {
     /// Core statistics of the solver engine (e.g. the number of decisions)
-    EngineStatistics {
-        /// The number of decisions taken by the solver
-        num_decisions: u64,
-        /// The number of conflicts encountered by the solver
-        num_conflicts: u64,
-        /// The number of times the solver has restarted
-        num_restarts: u64,
-        /// The average number of (integer) propagations made by the solver
-        num_propagations: u64,
-        /// The amount of time which is spent in the solver
-        time_spent_in_solver: u64,
-});
+    pub(crate) engine_statistics: EngineStatistics,
+    /// The statistics related to clause learning
+    pub(crate) learned_clause_statistics: LearnedClauseStatistics,
+}
+
+impl SolverStatistics {
+    pub(crate) fn log(
+        &self,
+        assignments: &Assignments,
+        propagators: &PropagatorStore,
+        statistic_logger: StatisticLogger,
+        verbose: bool,
+    ) {
+        log_statistic("nodes", self.engine_statistics.num_decisions);
+        log_statistic("failures", self.engine_statistics.num_conflicts);
+        log_statistic("restarts", self.engine_statistics.num_restarts);
+        log_statistic("variables", assignments.num_domains());
+        log_statistic("propagators", propagators.num_propagators());
+        log_statistic("propagations", self.engine_statistics.num_propagations);
+        log_statistic("peakDepth", self.engine_statistics.peak_depth);
+        log_statistic("nogoods", self.engine_statistics.num_conflicts);
+        log_statistic("backjumps", self.engine_statistics.num_backjumps);
+        log_statistic(
+            "solveTime",
+            self.engine_statistics.time_spent_in_solver as f64 / 1000_f64,
+        );
+        if verbose {
+            self.learned_clause_statistics.log(statistic_logger)
+        }
+    }
+}
+
+/// Core statistics of the solver engine (e.g. the number of decisions)
+#[derive(Debug, Default)]
+pub(crate) struct EngineStatistics {
+    /// The number of decisions taken by the solver
+    pub(crate) num_decisions: u64,
+    /// The number of conflicts encountered by the solver
+    pub(crate) num_conflicts: u64,
+    /// The number of times the solver has restarted
+    pub(crate) num_restarts: u64,
+    /// The average number of (integer) propagations made by the solver
+    pub(crate) num_propagations: u64,
+    /// The amount of time which is spent in the solver
+    pub(crate) time_spent_in_solver: u64,
+    /// The peak depth of the seach tree
+    pub(crate) peak_depth: u64,
+    /// The number of backjumps (i.e. when a learned nogood resulted in backtracking more than a
+    /// single level)
+    pub(crate) num_backjumps: u64,
+}
 
 create_statistics_struct!(
     /// The statistics related to clause learning
     LearnedClauseStatistics {
         /// The average number of elements in the conflict explanation
         average_conflict_size: CumulativeMovingAverage<u64>,
-        /// The average number of literals removed by recursive minimisation during conflict analysis
-        average_number_of_removed_literals_recursive: CumulativeMovingAverage<u64>,
-        /// The average number of literals removed by semantic minimisation during conflict analysis
-        average_number_of_removed_literals_semantic: CumulativeMovingAverage<u64>,
+        /// The average number of atomic constraints removed by recursive minimisation during conflict analysis
+        average_number_of_removed_atomic_constraints_recursive: CumulativeMovingAverage<u64>,
+        /// The average number of atomic constraints removed by semantic minimisation during conflict analysis
+        average_number_of_removed_atomic_constraints_semantic: CumulativeMovingAverage<u64>,
         /// The number of learned clauses which have a size of 1
-        num_unit_clauses_learned: u64,
-        /// The average length of the learned clauses
-        average_learned_clause_length: CumulativeMovingAverage<u64>,
+        num_unit_nogoods_learned: u64,
+        /// The average length of the learned nogood
+        average_learned_nogood_length: CumulativeMovingAverage<u64>,
         /// The average number of levels which have been backtracked by the solver (e.g. when a learned clause is created)
         average_backtrack_amount: CumulativeMovingAverage<u64>,
         /// The average literal-block distance (LBD) metric for newly added learned nogoods

--- a/pumpkin-solver/src/bin/pumpkin-solver/main.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/main.rs
@@ -601,6 +601,7 @@ fn run() -> PumpkinResult<()> {
                 ),
                 optimisation_strategy: args.optimisation_strategy,
                 proof_type: args.proof_path.map(|_| args.proof_type),
+                verbose: args.verbose,
             },
         )?,
     }
@@ -622,7 +623,9 @@ fn cnf_problem(
     let mut brancher = solver.default_brancher();
     match solver.satisfy(&mut brancher, &mut termination) {
         SatisfactionResult::Satisfiable(satisfiable) => {
-            satisfiable.solver().log_statistics();
+            satisfiable
+                .solver()
+                .log_statistics(Some(satisfiable.brancher()), true);
             println!("s SATISFIABLE");
             println!(
                 "v {}",
@@ -633,13 +636,13 @@ fn cnf_problem(
                 )
             );
         }
-        SatisfactionResult::Unsatisfiable(solver, _) => {
-            solver.log_statistics();
+        SatisfactionResult::Unsatisfiable(solver, brancher) => {
+            solver.log_statistics(Some(brancher), true);
 
             println!("s UNSATISFIABLE");
         }
-        SatisfactionResult::Unknown(solver, _) => {
-            solver.log_statistics();
+        SatisfactionResult::Unknown(solver, brancher) => {
+            solver.log_statistics(Some(brancher), true);
             println!("s UNKNOWN");
         }
     }

--- a/pumpkin-solver/src/bin/pumpkin-solver/maxsat/optimisation/linear_search.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/maxsat/optimisation/linear_search.rs
@@ -37,7 +37,7 @@ impl LinearSearch {
         let mut best_objective_value =
             objective_function.evaluate_assignment(best_solution.as_reference());
 
-        solver.log_statistics_with_objective(best_objective_value as i64);
+        solver.log_statistics_with_objective(Some(&brancher), best_objective_value as i64, true);
         println!("o {best_objective_value}");
         info!(
             "Current objective is {} after {} seconds ({} ms)",
@@ -53,7 +53,11 @@ impl LinearSearch {
 
         loop {
             if best_objective_value == objective_function.get_constant_term() {
-                solver.log_statistics_with_objective(best_objective_value as i64);
+                solver.log_statistics_with_objective(
+                    Some(&brancher),
+                    best_objective_value as i64,
+                    true,
+                );
                 return MaxSatOptimisationResult::Optimal {
                     solution: best_solution,
                 };
@@ -65,7 +69,11 @@ impl LinearSearch {
             // in case some cases infeasibility can be detected while constraining the upper bound
             //  meaning the current best solution is optimal
             if encoding_status.is_err() {
-                solver.log_statistics_with_objective(best_objective_value as i64);
+                solver.log_statistics_with_objective(
+                    Some(&brancher),
+                    best_objective_value as i64,
+                    true,
+                );
                 return MaxSatOptimisationResult::Optimal {
                     solution: best_solution,
                 };
@@ -89,9 +97,11 @@ impl LinearSearch {
                     best_objective_value = new_objective_value;
                     best_solution = satisfiable.solution().into();
 
-                    satisfiable
-                        .solver()
-                        .log_statistics_with_objective(best_objective_value as i64);
+                    satisfiable.solver().log_statistics_with_objective(
+                        Some(satisfiable.brancher()),
+                        best_objective_value as i64,
+                        true,
+                    );
 
                     println!("o {best_objective_value}");
                     info!(
@@ -101,15 +111,23 @@ impl LinearSearch {
                         process_time.elapsed().as_millis(),
                     );
                 }
-                SatisfactionResult::Unsatisfiable(solver, _) => {
-                    solver.log_statistics_with_objective(best_objective_value as i64);
+                SatisfactionResult::Unsatisfiable(solver, brancher) => {
+                    solver.log_statistics_with_objective(
+                        Some(brancher),
+                        best_objective_value as i64,
+                        true,
+                    );
 
                     return MaxSatOptimisationResult::Optimal {
                         solution: best_solution,
                     };
                 }
-                SatisfactionResult::Unknown(solver, _) => {
-                    solver.log_statistics_with_objective(best_objective_value as i64);
+                SatisfactionResult::Unknown(solver, brancher) => {
+                    solver.log_statistics_with_objective(
+                        Some(brancher),
+                        best_objective_value as i64,
+                        true,
+                    );
                     return MaxSatOptimisationResult::Satisfiable { best_solution };
                 }
             }


### PR DESCRIPTION
As accurately pointed out by @zayenz in #261 ; we do not print statistics according to the [MiniZinc specification](https://docs.minizinc.dev/en/stable/fzn-spec.html#statistics-output).

This PR addresses this by printing (most) of the statistics as specified; additionally, it locks other statistics behind the `-v` flag.