### PR TITLE
feat(pumpkin-solver): Write proofs with gzip encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +317,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flatzinc"
@@ -427,6 +452,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -559,6 +593,7 @@ dependencies = [
  "drcp-format",
  "enum-map",
  "enumset",
+ "flate2",
  "fnv",
  "itertools",
  "log",

--- a/pumpkin-crates/core/Cargo.toml
+++ b/pumpkin-crates/core/Cargo.toml
@@ -26,7 +26,10 @@ bitfield-struct = "0.9.2"
 num = "0.4.3"
 enum-map = "2.7.3"
 clap = { version = "4.5.40", optional = true }
+flate2 = { version = "1.1.2", optional = true }
 
 [features]
+default = ["gzipped_proofs"]
 debug-checks = []
 clap = ["dep:clap"]
+gzipped_proofs = ["dep:flate2"]

--- a/pumpkin-crates/core/src/proof/mod.rs
+++ b/pumpkin-crates/core/src/proof/mod.rs
@@ -47,6 +47,13 @@ impl ProofLog {
     pub fn cp(file_path: &Path, log_hints: bool) -> std::io::Result<ProofLog> {
         let file = File::create(file_path)?;
 
+        #[cfg(feature = "gzipped_proofs")]
+        let writer = {
+            let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+            ProofWriter::new(encoder)
+        };
+
+        #[cfg(not(feature = "gzipped_proofs"))]
         let writer = ProofWriter::new(file);
 
         Ok(ProofLog {
@@ -312,8 +319,15 @@ impl ProofLog {
 }
 
 #[derive(Debug)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "there will only every be one per solver"
+)]
 enum ProofImpl {
     CpProof {
+        #[cfg(feature = "gzipped_proofs")]
+        writer: ProofWriter<flate2::write::GzEncoder<File>, i32>,
+        #[cfg(not(feature = "gzipped_proofs"))]
         writer: ProofWriter<File, i32>,
         inference_codes: KeyedVec<InferenceCode, (ConstraintTag, Arc<str>)>,
         /// The [`ConstraintTag`]s generated for this proof.

--- a/pumpkin-solver/Cargo.toml
+++ b/pumpkin-solver/Cargo.toml
@@ -30,7 +30,9 @@ pumpkin-macros = { version = "0.1.0", path = "../pumpkin-macros"}
 workspace = true
 
 [features]
+default = ["gzipped_proofs"]
 debug-checks = []
+gzipped_proofs = ["pumpkin-core/gzipped_proofs"]
 
 [build-dependencies]
 cc = "1.1.30"


### PR DESCRIPTION
Using a gzip encoder to write the proof is gated behind a cargo feature. That feature is part of the default features, as typically we want to write gzipped proofs. However, for debugging purposes, it may be useful to have easy access to the plaintext proofs as well.