### PR TITLE
Remove the terms with zero coefficients from lienar constraints

### DIFF
--- a/pumpkin-crates/core/src/engine/variables/affine_view.rs
+++ b/pumpkin-crates/core/src/engine/variables/affine_view.rs
@@ -24,6 +24,7 @@ pub struct AffineView<Inner> {
 
 impl<Inner> AffineView<Inner> {
     pub fn new(inner: Inner, scale: i32, offset: i32) -> Self {
+        assert_ne!(scale, 0, "Multiplication by zero is not invertable");
         AffineView {
             inner,
             scale,

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
@@ -672,6 +672,7 @@ fn compile_reified_binary_int_predicate<C: NegatableConstraint>(
 fn weighted_vars(weights: Rc<[i32]>, vars: Rc<[DomainId]>) -> Box<[AffineView<DomainId>]> {
     vars.iter()
         .zip(weights.iter())
+        .filter(|(_, &w)| w != 0)
         .map(|(x_i, &w_i)| x_i.scaled(w_i))
         .collect::<Box<[_]>>()
 }


### PR DESCRIPTION
Consider the following FlatZinc input:

```
array [1..3] of int: c = [1,0,-1];
var 0..1: x;
var 0..1: y;
var 0..1: z;
array [1..3] of var 0..1: vars = [x,y,z];
constraint int_lin_le(c,vars,0);
solve satisfy;
```

The current version of the solver crashes with division by zero, because it creates the affine views for *all* the terms. The bound computation in affine views assumes invertibility (through division by scale), however, affine views of the form `<VAR>.scale(0)` are not invertible.

This PR fixes this bug by discarding all such terms during FlatZinc compilation. I also add all three models I used for testing; all of them crash on `main` but successfully terminate in this branch.