### PR TITLE
refactor(pumpkin-core): Use a typed propagator handle to identify propagators

### DIFF
--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -40,6 +40,8 @@ use crate::statistics::log_statistic;
 use crate::statistics::log_statistic_postfix;
 use crate::statistics::StatisticLogger;
 
+pub use crate::engine::propagation::store::PropagatorHandle;
+
 /// The main interaction point which allows the creation of variables, the addition of constraints,
 /// and solving problems.
 ///
@@ -497,7 +499,7 @@ impl Solver {
     pub(crate) fn add_propagator<Constructor>(
         &mut self,
         constructor: Constructor,
-    ) -> Result<(), ConstraintOperationError>
+    ) -> Result<PropagatorHandle<Constructor::PropagatorImpl>, ConstraintOperationError>
     where
         Constructor: PropagatorConstructor,
         Constructor::PropagatorImpl: 'static,

--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -19,6 +19,7 @@ use crate::constraints::ConstraintPoster;
 use crate::containers::HashSet;
 use crate::engine::predicates::predicate::Predicate;
 use crate::engine::propagation::constructor::PropagatorConstructor;
+pub use crate::engine::propagation::store::PropagatorHandle;
 use crate::engine::termination::TerminationCondition;
 use crate::engine::variables::DomainId;
 use crate::engine::variables::IntegerVariable;
@@ -39,8 +40,6 @@ use crate::results::unsatisfiable::UnsatisfiableUnderAssumptions;
 use crate::statistics::log_statistic;
 use crate::statistics::log_statistic_postfix;
 use crate::statistics::StatisticLogger;
-
-pub use crate::engine::propagation::store::PropagatorHandle;
 
 /// The main interaction point which allows the creation of variables, the addition of constraints,
 /// and solving problems.

--- a/pumpkin-crates/core/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-crates/core/src/constraints/arithmetic/equality.rs
@@ -86,7 +86,7 @@ where
 {
     fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
         if self.terms.len() == 2 && !solver.is_logging_full_proof() {
-            solver.add_propagator(BinaryEqualsPropagatorArgs {
+            let _ = solver.add_propagator(BinaryEqualsPropagatorArgs {
                 a: self.terms[0].clone(),
                 b: self.terms[1].scaled(-1).offset(self.rhs),
                 constraint_tag: self.constraint_tag,
@@ -111,7 +111,7 @@ where
         reification_literal: Literal,
     ) -> Result<(), ConstraintOperationError> {
         if self.terms.len() == 2 {
-            solver.add_propagator(ReifiedPropagatorArgs {
+            let _ = solver.add_propagator(ReifiedPropagatorArgs {
                 propagator: BinaryEqualsPropagatorArgs {
                     a: self.terms[0].clone(),
                     b: self.terms[1].scaled(-1).offset(self.rhs),
@@ -163,11 +163,13 @@ where
         } = self;
 
         if terms.len() == 2 {
-            solver.add_propagator(BinaryNotEqualsPropagatorArgs {
+            let _ = solver.add_propagator(BinaryNotEqualsPropagatorArgs {
                 a: terms[0].clone(),
                 b: terms[1].scaled(-1).offset(self.rhs),
                 constraint_tag: self.constraint_tag,
-            })
+            })?;
+
+            Ok(())
         } else {
             LinearNotEqualPropagatorArgs {
                 terms: terms.into(),
@@ -190,14 +192,15 @@ where
         } = self;
 
         if terms.len() == 2 {
-            solver.add_propagator(ReifiedPropagatorArgs {
+            let _ = solver.add_propagator(ReifiedPropagatorArgs {
                 propagator: BinaryNotEqualsPropagatorArgs {
                     a: terms[0].clone(),
                     b: terms[1].scaled(-1).offset(self.rhs),
                     constraint_tag: self.constraint_tag,
                 },
                 reification_literal,
-            })
+            })?;
+            Ok(())
         } else {
             LinearNotEqualPropagatorArgs {
                 terms: terms.into(),

--- a/pumpkin-crates/core/src/constraints/mod.rs
+++ b/pumpkin-crates/core/src/constraints/mod.rs
@@ -88,7 +88,8 @@ where
     ConcretePropagator: PropagatorConstructor + 'static,
 {
     fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
-        solver.add_propagator(self)
+        let _ = solver.add_propagator(self)?;
+        Ok(())
     }
 
     fn implied_by(
@@ -96,10 +97,11 @@ where
         solver: &mut Solver,
         reification_literal: Literal,
     ) -> Result<(), ConstraintOperationError> {
-        solver.add_propagator(ReifiedPropagatorArgs {
+        let _ = solver.add_propagator(ReifiedPropagatorArgs {
             propagator: self,
             reification_literal,
-        })
+        })?;
+        Ok(())
     }
 }
 

--- a/pumpkin-crates/core/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-crates/core/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -25,6 +25,7 @@ use crate::proof::explain_root_assignment;
 use crate::proof::InferenceCode;
 use crate::proof::ProofLog;
 use crate::proof::RootExplanationContext;
+use crate::propagators::nogoods::NogoodPropagator;
 use crate::pumpkin_assert_simple;
 
 /// Used during conflict analysis to provide the necessary information.
@@ -222,7 +223,7 @@ impl ConflictAnalysisContext<'_> {
 
             assert!(reason_exists, "reason reference should not be stale");
 
-            if propagator_id == ConstraintSatisfactionSolver::get_nogood_propagator_id()
+            if propagators.is_propagator::<NogoodPropagator>(propagator_id)
                 && reason_buffer.as_ref().is_empty()
             {
                 // This means that a unit nogood was propagated, we indicate that this nogood step

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -30,7 +30,6 @@ use crate::basic_types::CSPSolverExecutionFlag;
 use crate::basic_types::ConstraintOperationError;
 use crate::basic_types::Inconsistency;
 use crate::basic_types::PredicateId;
-use crate::basic_types::PropagationStatusCP;
 use crate::basic_types::PropositionalConjunction;
 use crate::basic_types::Random;
 use crate::basic_types::SolutionReference;
@@ -112,6 +111,7 @@ pub struct ConstraintSatisfactionSolver {
     /// The list of propagators. Propagators live here and are queried when events (domain changes)
     /// happen. The list is only traversed during synchronisation for now.
     propagators: PropagatorStore,
+    nogood_propagator_handle: PropagatorHandle<NogoodPropagator>,
 
     /// Tracks information about the restarts. Occassionally the solver will undo all its decisions
     /// and start the search from the root note. Note that learned clauses and other state
@@ -217,10 +217,6 @@ impl Default for SatisfactionSolverOptions {
 }
 
 impl ConstraintSatisfactionSolver {
-    pub(crate) fn get_nogood_propagator_id() -> PropagatorId {
-        PropagatorId(0)
-    }
-
     /// This is a temporary accessor to help refactoring.
     pub fn get_solution_reference(&self) -> SolutionReference<'_> {
         SolutionReference::new(&self.assignments)
@@ -282,14 +278,27 @@ impl ConstraintSatisfactionSolver {
 // methods that offer basic functionality
 impl ConstraintSatisfactionSolver {
     pub fn new(solver_options: SatisfactionSolverOptions) -> Self {
-        let mut csp_solver: ConstraintSatisfactionSolver = ConstraintSatisfactionSolver {
+        let mut propagators = PropagatorStore::default();
+
+        let nogood_propagator_slot = propagators.new_propagator();
+        let nogood_propagator = NogoodPropagator::with_options(
+            nogood_propagator_slot.key(),
+            // 1_000_000 bytes in 1 MB
+            (solver_options.memory_preallocated * 1_000_000) / size_of::<PredicateId>(),
+            solver_options.learning_options,
+        );
+
+        let nogood_propagator_handle = nogood_propagator_slot.populate(nogood_propagator);
+
+        let mut csp_solver = ConstraintSatisfactionSolver {
             state: CSPSolverState::default(),
             assumptions: Vec::default(),
             assignments: Assignments::default(),
             propagator_queue: PropagatorQueue::new(5),
             reason_store: ReasonStore::default(),
             restart_strategy: RestartStrategy::new(solver_options.restart_options),
-            propagators: PropagatorStore::default(),
+            propagators,
+            nogood_propagator_handle,
             solver_statistics: SolverStatistics::default(),
             variable_names: VariableNames::default(),
             semantic_minimiser: SemanticMinimiser::default(),
@@ -312,13 +321,6 @@ impl ConstraintSatisfactionSolver {
         csp_solver
             .variable_names
             .add_integer(dummy_id, "Dummy".to_owned());
-
-        let _ = csp_solver.add_propagator(NogoodPropagator::with_options(
-            // 1_000_000 bytes in 1 MB
-            (csp_solver.internal_parameters.memory_preallocated * 1_000_000)
-                / size_of::<PredicateId>(),
-            csp_solver.internal_parameters.learning_options,
-        ));
 
         assert!(dummy_id.id() == 0);
         assert!(csp_solver.assignments.get_lower_bound(dummy_id) == 1);
@@ -722,7 +724,9 @@ impl ConstraintSatisfactionSolver {
     }
 
     fn decay_nogood_activities(&mut self) {
-        match self.propagators[Self::get_nogood_propagator_id()].downcast_mut::<NogoodPropagator>()
+        match self
+            .propagators
+            .get_propagator_mut(self.nogood_propagator_handle)
         {
             Some(nogood_propagator) => {
                 nogood_propagator.decay_nogood_activities();
@@ -914,31 +918,20 @@ impl ConstraintSatisfactionSolver {
             &mut self.reason_store,
             &mut self.semantic_minimiser,
             &mut self.notification_engine,
-            Self::get_nogood_propagator_id(),
+            self.nogood_propagator_handle.untyped(),
         );
 
-        ConstraintSatisfactionSolver::add_asserting_nogood_to_nogood_propagator(
-            &mut self.propagators[Self::get_nogood_propagator_id()],
-            inference_code,
+        let nogood_propagator = self
+            .propagators
+            .get_propagator_mut(self.nogood_propagator_handle)
+            .expect("nogood propagator handle should refer to nogood propagator");
+
+        nogood_propagator.add_asserting_nogood(
             learned_nogood.predicates,
+            inference_code,
             &mut context,
             &mut self.solver_statistics,
-        )
-    }
-
-    pub(crate) fn add_asserting_nogood_to_nogood_propagator(
-        nogood_propagator: &mut dyn Propagator,
-        inference_code: InferenceCode,
-        nogood: Vec<Predicate>,
-        context: &mut PropagationContextMut,
-        statistics: &mut SolverStatistics,
-    ) {
-        match nogood_propagator.downcast_mut::<NogoodPropagator>() {
-            Some(nogood_propagator) => {
-                nogood_propagator.add_asserting_nogood(nogood, inference_code, context, statistics)
-            }
-            None => panic!("Provided propagator should be the nogood propagator"),
-        }
+        );
     }
 
     /// Performs a restart during the search process; it is only called when it has been determined
@@ -1138,6 +1131,7 @@ impl ConstraintSatisfactionSolver {
                 &mut self.assignments,
                 &mut self.trailed_values,
                 &mut self.propagators,
+                self.nogood_propagator_handle,
                 &mut self.propagator_queue,
             );
         // Keep propagating until there are unprocessed propagators, or a conflict is detected.
@@ -1172,6 +1166,7 @@ impl ConstraintSatisfactionSolver {
                             &mut self.assignments,
                             &mut self.trailed_values,
                             &mut self.propagators,
+                            self.nogood_propagator_handle,
                             &mut self.propagator_queue,
                         );
                 }
@@ -1358,7 +1353,7 @@ impl ConstraintSatisfactionSolver {
             &mut self.assignments,
         );
 
-        let propagator = Box::new(constructor.create(constructor_context));
+        let propagator = constructor.create(constructor_context);
 
         pumpkin_assert_simple!(
             propagator.priority() <= 3,
@@ -1417,16 +1412,16 @@ impl ConstraintSatisfactionSolver {
             &mut self.reason_store,
             &mut self.semantic_minimiser,
             &mut self.notification_engine,
-            Self::get_nogood_propagator_id(),
+            self.nogood_propagator_handle.untyped(),
         );
-        let nogood_propagator_id = Self::get_nogood_propagator_id();
 
-        let addition_result = ConstraintSatisfactionSolver::add_nogood_to_nogood_propagator(
-            &mut self.propagators[nogood_propagator_id],
-            nogood,
-            inference_code,
-            &mut propagation_context,
-        );
+        let nogood_propagator = self
+            .propagators
+            .get_propagator_mut(self.nogood_propagator_handle)
+            .expect("nogood propagator handle should refer to nogood propagator");
+
+        let addition_result =
+            nogood_propagator.add_nogood(nogood, inference_code, &mut propagation_context);
 
         if addition_result.is_err() || self.state.is_conflicting() {
             self.prepare_for_conflict_resolution();
@@ -1469,22 +1464,6 @@ impl ConstraintSatisfactionSolver {
             conflict_nogood: empty_domain_reason,
         };
         self.state.declare_conflict(stored_conflict_info);
-    }
-
-    fn add_nogood_to_nogood_propagator(
-        nogood_propagator: &mut dyn Propagator,
-        nogood: Vec<Predicate>,
-        inference_code: InferenceCode,
-        context: &mut PropagationContextMut,
-    ) -> PropagationStatusCP {
-        match nogood_propagator.downcast_mut::<NogoodPropagator>() {
-            Some(nogood_propagator) => {
-                nogood_propagator.add_nogood(nogood, inference_code, context)
-            }
-            None => {
-                panic!("Provided propagator should be the nogood propagator",)
-            }
-        }
     }
 
     /// Creates a clause from `literals` and adds it to the current formula.

--- a/pumpkin-crates/core/src/engine/debug_helper.rs
+++ b/pumpkin-crates/core/src/engine/debug_helper.rs
@@ -11,7 +11,6 @@ use super::predicates::predicate::Predicate;
 use super::propagation::store::PropagatorStore;
 use super::propagation::ExplanationContext;
 use super::reason::ReasonStore;
-use super::ConstraintSatisfactionSolver;
 use super::TrailedValues;
 use crate::basic_types::Inconsistency;
 use crate::basic_types::PropositionalConjunction;
@@ -19,6 +18,7 @@ use crate::engine::cp::Assignments;
 use crate::engine::propagation::PropagationContextMut;
 use crate::engine::propagation::Propagator;
 use crate::engine::propagation::PropagatorId;
+use crate::propagators::nogoods::NogoodPropagator;
 
 #[derive(Copy, Clone)]
 pub(crate) struct DebugDyn<'a> {
@@ -156,7 +156,7 @@ impl DebugHelper {
         propagators: &mut PropagatorStore,
         notification_engine: &NotificationEngine,
     ) -> bool {
-        if propagator_id == ConstraintSatisfactionSolver::get_nogood_propagator_id() {
+        if propagators.is_propagator::<NogoodPropagator>(propagator_id) {
             return true;
         }
 

--- a/pumpkin-crates/core/src/engine/notifications/mod.rs
+++ b/pumpkin-crates/core/src/engine/notifications/mod.rs
@@ -18,16 +18,17 @@ use crate::engine::propagation::contexts::PropagationContextWithTrailedValues;
 use crate::engine::propagation::store::PropagatorStore;
 use crate::engine::propagation::EnqueueDecision;
 use crate::engine::propagation::LocalId;
+use crate::engine::propagation::Propagator;
 use crate::engine::propagation::PropagatorId;
 use crate::engine::Assignments;
-use crate::engine::ConstraintSatisfactionSolver;
 use crate::engine::PropagatorQueue;
 use crate::engine::TrailedValues;
 use crate::predicates::Predicate;
+use crate::propagators::nogoods::NogoodPropagator;
 use crate::pumpkin_assert_extreme;
-use crate::pumpkin_assert_moderate;
 use crate::pumpkin_assert_simple;
 use crate::variables::DomainId;
+use crate::PropagatorHandle;
 
 #[derive(Debug)]
 pub(crate) struct NotificationEngine {
@@ -45,35 +46,12 @@ pub(crate) struct NotificationEngine {
     backtrack_events: EventSink,
 }
 
-#[cfg(not(test))]
 impl Default for NotificationEngine {
     fn default() -> Self {
         let mut result = Self {
             watch_list_domain_events: Default::default(),
             predicate_notifier: Default::default(),
             last_notified_trail_index: 0,
-            events: Default::default(),
-            backtrack_events: Default::default(),
-        };
-        // Grow for the dummy predicate
-        result.grow();
-        result
-    }
-}
-
-#[cfg(test)]
-impl Default for NotificationEngine {
-    fn default() -> Self {
-        let watch_list_domain_events = WatchListDomainEvents {
-            watchers: Default::default(),
-            is_watching_anything: true,
-            is_watching_any_backtrack_events: true,
-        };
-
-        let mut result = Self {
-            watch_list_domain_events,
-            predicate_notifier: Default::default(),
-            last_notified_trail_index: usize::MAX,
             events: Default::default(),
             backtrack_events: Default::default(),
         };
@@ -245,6 +223,7 @@ impl NotificationEngine {
         assignments: &mut Assignments,
         trailed_values: &mut TrailedValues,
         propagators: &mut PropagatorStore,
+        nogood_propagator_handle: PropagatorHandle<NogoodPropagator>,
         propagator_queue: &mut PropagatorQueue,
     ) {
         // We first take the events because otherwise we get mutability issues when calling methods
@@ -257,6 +236,7 @@ impl NotificationEngine {
                 .on_update(trailed_values, assignments, event, domain);
             // Special case: the nogood propagator is notified about each event.
             Self::notify_nogood_propagator(
+                nogood_propagator_handle.untyped(),
                 &mut self.predicate_notifier.predicate_id_assignments,
                 event,
                 domain,
@@ -288,9 +268,15 @@ impl NotificationEngine {
 
         self.events = events;
 
-        // Then we notify the propagators that a predicate has been satisfied
-        self.notify_predicate_id_satisfied(propagators);
-        self.notify_predicate_id_falsified(propagators);
+        // Then we notify the propagators that a predicate has been satisfied.
+        //
+        // Currently, only the nogood propagator is notified.
+        let nogood_propagator = propagators
+            .get_propagator_mut(nogood_propagator_handle)
+            .expect("nogood propagator handle refers to a nogood propagator");
+        self.notify_predicate_id_satisfied(nogood_propagator);
+        // At the moment this does nothing yet, but we call it to drain predicates.
+        self.notify_predicate_id_falsified();
 
         self.last_notified_trail_index = assignments.num_trail_entries();
     }
@@ -328,24 +314,22 @@ impl NotificationEngine {
     /// Notifies propagators that certain [`Predicate`]s have been falsified.
     ///
     /// Currently, no propagators are informed of this information.
-    fn notify_predicate_id_falsified(&mut self, _propagators: &mut PropagatorStore) {
+    fn notify_predicate_id_falsified(&mut self) {
         for _predicate_id in self.predicate_notifier.drain_falsified_predicates() {
             // At the moment this does nothing
         }
     }
 
-    /// Notifies propagators that certain [`Predicate`]s have been satisfied.
-    ///
-    /// Currently, only the [`NogoodPropagator`] is notified.
-    fn notify_predicate_id_satisfied(&mut self, propagators: &mut PropagatorStore) {
+    /// Notifies the propagator that certain [`Predicate`]s have been satisfied.
+    fn notify_predicate_id_satisfied(&mut self, propagator: &mut dyn Propagator) {
         for predicate_id in self.predicate_notifier.drain_satisfied_predicates() {
-            let nogood_propagator =
-                &mut propagators[ConstraintSatisfactionSolver::get_nogood_propagator_id()];
-            nogood_propagator.notify_predicate_id_satisfied(predicate_id);
+            propagator.notify_predicate_id_satisfied(predicate_id);
         }
     }
 
+    #[allow(clippy::too_many_arguments, reason = "to be refactored later")]
     fn notify_nogood_propagator(
+        nogood_propagator_id: PropagatorId,
         predicate_id_assignments: &mut PredicateIdAssignments,
         event: DomainEvent,
         domain: DomainId,
@@ -354,11 +338,6 @@ impl NotificationEngine {
         assignments: &mut Assignments,
         trailed_values: &mut TrailedValues,
     ) {
-        pumpkin_assert_moderate!(
-            propagators[ConstraintSatisfactionSolver::get_nogood_propagator_id()].name()
-                == "NogoodPropagator"
-        );
-        let nogood_propagator_id = ConstraintSatisfactionSolver::get_nogood_propagator_id();
         // The nogood propagator is implicitly subscribed to every domain event for every variable.
         // For this reason, its local id matches the domain id.
         // This is special only for the nogood propagator.
@@ -470,9 +449,10 @@ impl NotificationEngine {
             }
         }
 
-        // Then we notify the propagators that a predicate has been satisfied
-        self.notify_predicate_id_satisfied(propagators);
-        self.notify_predicate_id_falsified(propagators);
+        // TODO: Do we notify the nogood propagator here as well? I don't think so, as in
+        // the test solver there may not be one.
+        let _ = self.predicate_notifier.drain_satisfied_predicates();
+        let _ = self.predicate_notifier.drain_falsified_predicates();
 
         self.last_notified_trail_index = assignments.num_trail_entries();
     }

--- a/pumpkin-crates/core/src/lib.rs
+++ b/pumpkin-crates/core/src/lib.rs
@@ -33,6 +33,7 @@ mod api;
 pub use api::*;
 
 pub use crate::api::solver::DefaultBrancher;
+pub use crate::api::solver::PropagatorHandle;
 pub use crate::api::solver::Solver;
 pub use crate::basic_types::ConstraintOperationError;
 pub use crate::basic_types::Random;

--- a/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
+++ b/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
@@ -28,7 +28,6 @@ use crate::engine::propagation::ReadDomains;
 use crate::engine::reason::Reason;
 use crate::engine::reason::ReasonStore;
 use crate::engine::Assignments;
-use crate::engine::ConstraintSatisfactionSolver;
 use crate::engine::Lbd;
 use crate::engine::SolverStatistics;
 use crate::engine::TrailedValues;
@@ -40,6 +39,7 @@ use crate::pumpkin_assert_advanced;
 use crate::pumpkin_assert_extreme;
 use crate::pumpkin_assert_moderate;
 use crate::pumpkin_assert_simple;
+use crate::PropagatorHandle;
 
 /// A propagator which propagates nogoods (i.e. a list of [`Predicate`]s which cannot all be true
 /// at the same time).
@@ -49,7 +49,7 @@ use crate::pumpkin_assert_simple;
 ///
 /// The idea for propagation is the two-watcher scheme; this is achieved by internally keeping
 /// track of watch lists.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct NogoodPropagator {
     /// The [`PredicateId`]s of the nogoods.
     nogood_predicates: ArenaAllocator,
@@ -74,6 +74,8 @@ pub(crate) struct NogoodPropagator {
     bumped_nogoods: Vec<NogoodId>,
     /// Used to return lazy reasons
     temp_nogood_reason: Vec<Predicate>,
+    /// The handle of this instance inside the solver.
+    handle: PropagatorHandle<NogoodPropagator>,
 }
 
 /// Watcher for a single nogood.
@@ -116,13 +118,28 @@ impl NogoodPropagator {
     /// Creates a new instance of the [`NogoodPropagator`] with the provided [`LearningOptions`]
     /// and `capacity`.
     ///
+    /// The `handle` should be the handle of the propagator used in the solver.
+    ///
     /// The `capacity` indicates how many [`PredicateId`]s to preallocate to the
     /// [`ArenaAllocator`].
-    pub(crate) fn with_options(capacity: usize, parameters: LearningOptions) -> Self {
+    pub(crate) fn with_options(
+        handle: PropagatorHandle<NogoodPropagator>,
+        capacity: usize,
+        parameters: LearningOptions,
+    ) -> Self {
         Self {
+            handle,
             parameters,
             nogood_predicates: ArenaAllocator::new(capacity),
-            ..Default::default()
+            nogood_info: Default::default(),
+            inference_codes: Default::default(),
+            permanent_nogood_ids: Default::default(),
+            learned_nogood_ids: Default::default(),
+            watch_lists: Default::default(),
+            updated_predicate_ids: Default::default(),
+            lbd_helper: Default::default(),
+            bumped_nogoods: Default::default(),
+            temp_nogood_reason: Default::default(),
         }
     }
 
@@ -133,6 +150,7 @@ impl NogoodPropagator {
     ///   propagator
     /// - The reason for the predicate is the nogood propagator
     fn is_nogood_propagating(
+        handle: PropagatorHandle<NogoodPropagator>,
         nogood: &[PredicateId],
         assignments: &Assignments,
         reason_store: &ReasonStore,
@@ -149,8 +167,7 @@ impl NogoodPropagator {
                 let code = reason_store.get_lazy_code(reason_ref);
 
                 // We check whether the predicate was propagated by the nogood propagator first
-                let propagated_by_nogood_propagator =
-                    propagator_id == ConstraintSatisfactionSolver::get_nogood_propagator_id();
+                let propagated_by_nogood_propagator = propagator_id == handle.untyped();
                 // Then we check whether the lazy reason for the propagation was this particular
                 // nogood
                 let code_matches_id = code.is_none() || *code.unwrap() == id.id as u64;
@@ -728,6 +745,7 @@ impl NogoodPropagator {
 
             // Then we remove roughly the worst half of the "high" LBD tier nogood IDs
             removed_at_least_one_nogood |= NogoodPropagator::remove_roughly_worst_half_nogood_ids(
+                self.handle,
                 &mut self.learned_nogood_ids.high_lbd,
                 &mut self.nogood_info,
                 &self.nogood_predicates,
@@ -750,6 +768,7 @@ impl NogoodPropagator {
 
             // Then we remove roughly the worst half of the "mid" LBD tier nogood IDs
             removed_at_least_one_nogood |= NogoodPropagator::remove_roughly_worst_half_nogood_ids(
+                self.handle,
                 &mut self.learned_nogood_ids.mid_lbd,
                 &mut self.nogood_info,
                 &self.nogood_predicates,
@@ -770,6 +789,7 @@ impl NogoodPropagator {
 
             // Then we remove roughly the worst half of the "low" LBD tier nogood IDs
             removed_at_least_one_nogood |= NogoodPropagator::remove_roughly_worst_half_nogood_ids(
+                self.handle,
                 &mut self.learned_nogood_ids.low_lbd,
                 &mut self.nogood_info,
                 &self.nogood_predicates,
@@ -922,6 +942,7 @@ impl NogoodPropagator {
     // This means that the function may remove some nogoods from the first half if
     // some of the bottom nogoods are currently propagating.
     fn remove_roughly_worst_half_nogood_ids(
+        handle: PropagatorHandle<NogoodPropagator>,
         nogood_ids: &mut Vec<NogoodId>,
         nogood_info: &mut KeyedVec<NogoodIndex, NogoodInfo>,
         nogoods: &ArenaAllocator,
@@ -951,6 +972,7 @@ impl NogoodPropagator {
 
             // Skip nogoods which are propagating at a non-root level.
             if NogoodPropagator::is_nogood_propagating(
+                handle,
                 &nogoods[id],
                 assignments,
                 reason_store,
@@ -1260,21 +1282,10 @@ impl NogoodPropagator {
 mod tests {
     use super::NogoodPropagator;
     use crate::conjunction;
-    use crate::engine::propagation::store::PropagatorStore;
     use crate::engine::propagation::PropagationContextMut;
-    use crate::engine::propagation::PropagatorId;
     use crate::engine::test_solver::TestSolver;
+    use crate::options::LearningOptions;
     use crate::predicate;
-
-    fn downcast_to_nogood_propagator(
-        nogood_propagator: PropagatorId,
-        propagators: &mut PropagatorStore,
-    ) -> &mut NogoodPropagator {
-        match propagators[nogood_propagator].downcast_mut::<NogoodPropagator>() {
-            Some(nogood_propagator) => nogood_propagator,
-            None => panic!("Provided propagator should be the nogood propagator"),
-        }
-    }
 
     #[test]
     fn ternary_nogood_propagate() {
@@ -1285,11 +1296,13 @@ mod tests {
         let b = solver.new_variable(-4, 4);
         let c = solver.new_variable(-10, 20);
 
-        let propagator = solver
-            .new_propagator(NogoodPropagator::default())
+        let handle = solver
+            .new_propagator_with_handle(|handle| {
+                NogoodPropagator::with_options(handle, 10, LearningOptions::default())
+            })
             .expect("no empty domains");
 
-        let _ = solver.increase_lower_bound_and_notify(propagator, dummy.id(), dummy, 1);
+        let _ = solver.increase_lower_bound_and_notify(handle.untyped(), dummy.id(), dummy, 1);
 
         let nogood = conjunction!([a >= 2] & [b >= 1] & [c >= 10]);
         {
@@ -1299,22 +1312,27 @@ mod tests {
                 &mut solver.reason_store,
                 &mut solver.semantic_minimiser,
                 &mut solver.notification_engine,
-                propagator,
+                handle.untyped(),
             );
 
-            downcast_to_nogood_propagator(propagator, &mut solver.propagator_store)
+            solver
+                .propagator_store
+                .get_propagator_mut(handle)
+                .unwrap()
                 .add_nogood(nogood.into(), inference_code, &mut context)
-                .expect("");
+                .unwrap();
         }
 
-        let _ = solver.increase_lower_bound_and_notify(propagator, a.id(), a, 3);
-        let _ = solver.increase_lower_bound_and_notify(propagator, b.id(), b, 0);
+        let _ = solver.increase_lower_bound_and_notify(handle.untyped(), a.id(), a, 3);
+        let _ = solver.increase_lower_bound_and_notify(handle.untyped(), b.id(), b, 0);
 
-        solver.propagate_until_fixed_point(propagator).expect("");
+        solver
+            .propagate_until_fixed_point(handle.untyped())
+            .expect("");
 
-        let _ = solver.increase_lower_bound_and_notify(propagator, c.id(), c, 15);
+        let _ = solver.increase_lower_bound_and_notify(handle.untyped(), c.id(), c, 15);
 
-        solver.propagate(propagator).expect("");
+        solver.propagate(handle.untyped()).expect("");
 
         assert_eq!(solver.upper_bound(b), 0);
 
@@ -1330,8 +1348,10 @@ mod tests {
         let b = solver.new_variable(-4, 4);
         let c = solver.new_variable(-10, 20);
 
-        let propagator = solver
-            .new_propagator(NogoodPropagator::default())
+        let handle = solver
+            .new_propagator_with_handle(|handle| {
+                NogoodPropagator::with_options(handle, 10, LearningOptions::default())
+            })
             .expect("no empty domains");
 
         let nogood = conjunction!([a >= 2] & [b >= 1] & [c >= 10]);
@@ -1342,19 +1362,22 @@ mod tests {
                 &mut solver.reason_store,
                 &mut solver.semantic_minimiser,
                 &mut solver.notification_engine,
-                propagator,
+                handle.untyped(),
             );
 
-            downcast_to_nogood_propagator(propagator, &mut solver.propagator_store)
+            solver
+                .propagator_store
+                .get_propagator_mut(handle)
+                .unwrap()
                 .add_nogood(nogood.into(), inference_code, &mut context)
-                .expect("");
+                .unwrap();
         }
 
-        let _ = solver.increase_lower_bound_and_notify(propagator, a.id(), a, 3);
-        let _ = solver.increase_lower_bound_and_notify(propagator, b.id(), b, 1);
-        let _ = solver.increase_lower_bound_and_notify(propagator, c.id(), c, 15);
+        let _ = solver.increase_lower_bound_and_notify(handle.untyped(), a.id(), a, 3);
+        let _ = solver.increase_lower_bound_and_notify(handle.untyped(), b.id(), b, 1);
+        let _ = solver.increase_lower_bound_and_notify(handle.untyped(), c.id(), c, 15);
 
-        let result = solver.propagate_until_fixed_point(propagator);
+        let result = solver.propagate_until_fixed_point(handle.untyped());
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Propagator IDs are type-erased handles to propagator instances. However, throughout the solver we rely on the nogood propagator in particular to be downcastable. In this PR we introduce an API that makes it easy to obtain concrete propagator types from the propagator store. Additionally, we use this API in all places that previously relied on a hard-coded ID for the nogood propagator.