### PR TITLE
fix: Provide `SelectionContext` instead of `Assignments` to `Brancher::synchronise`

### DIFF
--- a/pumpkin-crates/core/src/branching/brancher.rs
+++ b/pumpkin-crates/core/src/branching/brancher.rs
@@ -16,7 +16,6 @@ use crate::branching::SelectionContext;
 use crate::create_statistics_struct;
 use crate::engine::predicates::predicate::Predicate;
 use crate::engine::variables::DomainId;
-use crate::engine::Assignments;
 #[cfg(doc)]
 use crate::results::solution_iterator::SolutionIterator;
 use crate::statistics::StatisticLogger;
@@ -98,7 +97,7 @@ pub trait Brancher {
     ///
     /// To receive information about this event, use [`BrancherEvent::Synchronise`] in
     /// [`Self::subscribe_to_events`]
-    fn synchronise(&mut self, _assignments: &Assignments) {}
+    fn synchronise(&mut self, _context: &mut SelectionContext) {}
 
     /// This method returns whether a restart is *currently* pointless for the [`Brancher`].
     ///

--- a/pumpkin-crates/core/src/branching/branchers/alternating/alternating_brancher.rs
+++ b/pumpkin-crates/core/src/branching/branchers/alternating/alternating_brancher.rs
@@ -9,7 +9,6 @@ use crate::branching::Brancher;
 use crate::branching::SelectionContext;
 use crate::engine::predicates::predicate::Predicate;
 use crate::engine::variables::DomainId;
-use crate::engine::Assignments;
 use crate::statistics::StatisticLogger;
 use crate::DefaultBrancher;
 use crate::Solver;
@@ -113,10 +112,10 @@ impl<Strategy: AlternatingStrategy, OtherBrancher: Brancher> Brancher
         }
     }
 
-    fn synchronise(&mut self, assignments: &Assignments) {
-        self.default_brancher.synchronise(assignments);
+    fn synchronise(&mut self, context: &mut SelectionContext) {
+        self.default_brancher.synchronise(context);
         if !self.strategy.will_always_use_default() {
-            self.other_brancher.synchronise(assignments);
+            self.other_brancher.synchronise(context);
         }
     }
 

--- a/pumpkin-crates/core/src/branching/branchers/autonomous_search.rs
+++ b/pumpkin-crates/core/src/branching/branchers/autonomous_search.rs
@@ -299,9 +299,9 @@ impl<BackupBrancher: Brancher> Brancher for AutonomousSearch<BackupBrancher> {
     }
 
     /// Restores dormant predicates after backtracking.
-    fn synchronise(&mut self, assignments: &Assignments) {
+    fn synchronise(&mut self, context: &mut SelectionContext) {
         self.should_synchronise = true;
-        self.backup_brancher.synchronise(assignments);
+        self.backup_brancher.synchronise(context);
     }
 
     fn on_conflict(&mut self) {
@@ -421,7 +421,10 @@ mod tests {
         assert!(brancher.dormant_predicates.contains(&predicate));
 
         let _ = assignments.synchronise(0, &mut notification_engine);
-        brancher.synchronise(&assignments);
+        brancher.synchronise(&mut SelectionContext::new(
+            &assignments,
+            &mut TestRandom::default(),
+        ));
 
         let decision = brancher.next_decision(&mut SelectionContext::new(
             &assignments,

--- a/pumpkin-crates/core/src/branching/branchers/dynamic_brancher.rs
+++ b/pumpkin-crates/core/src/branching/branchers/dynamic_brancher.rs
@@ -15,7 +15,6 @@ use crate::branching::SelectionContext;
 use crate::containers::HashSet;
 use crate::engine::predicates::predicate::Predicate;
 use crate::engine::variables::DomainId;
-use crate::engine::Assignments;
 use crate::statistics::StatisticLogger;
 
 /// An implementation of a [`Brancher`] which takes a [`Vec`] of `Box<dyn Brancher>` and
@@ -149,10 +148,10 @@ impl Brancher for DynamicBrancher {
             .for_each(|&brancher_index| self.branchers[brancher_index].on_restart());
     }
 
-    fn synchronise(&mut self, assignments: &Assignments) {
+    fn synchronise(&mut self, context: &mut SelectionContext) {
         self.relevant_event_to_index[BrancherEvent::Synchronise]
             .iter()
-            .for_each(|&brancher_index| self.branchers[brancher_index].synchronise(assignments));
+            .for_each(|&brancher_index| self.branchers[brancher_index].synchronise(context));
     }
 
     fn is_restart_pointless(&mut self) -> bool {

--- a/pumpkin-crates/core/src/branching/branchers/warm_start.rs
+++ b/pumpkin-crates/core/src/branching/branchers/warm_start.rs
@@ -1,7 +1,6 @@
 use crate::branching::Brancher;
 use crate::branching::BrancherEvent;
 use crate::branching::SelectionContext;
-use crate::engine::Assignments;
 use crate::predicate;
 use crate::predicates::Predicate;
 use crate::pumpkin_assert_eq_simple;
@@ -57,7 +56,7 @@ impl<Var: IntegerVariable> Brancher for WarmStart<Var> {
         None
     }
 
-    fn synchronise(&mut self, _assignments: &Assignments) {
+    fn synchronise(&mut self, _context: &mut SelectionContext) {
         self.index = 0
     }
 

--- a/pumpkin-crates/core/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-crates/core/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -27,6 +27,7 @@ use crate::proof::ProofLog;
 use crate::proof::RootExplanationContext;
 use crate::propagators::nogoods::NogoodPropagator;
 use crate::pumpkin_assert_simple;
+use crate::Random;
 
 /// Used during conflict analysis to provide the necessary information.
 ///
@@ -51,6 +52,8 @@ pub(crate) struct ConflictAnalysisContext<'a> {
     pub(crate) unit_nogood_inference_codes: &'a HashMap<Predicate, InferenceCode>,
     pub(crate) trailed_values: &'a mut TrailedValues,
     pub(crate) variable_names: &'a VariableNames,
+
+    pub(crate) rng: &'a mut dyn Random,
 }
 
 impl Debug for ConflictAnalysisContext<'_> {
@@ -97,6 +100,7 @@ impl ConflictAnalysisContext<'_> {
             backtrack_level,
             self.brancher,
             self.trailed_values,
+            self.rng,
         )
     }
 

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -568,6 +568,7 @@ impl ConstraintSatisfactionSolver {
                     unit_nogood_inference_codes: &self.unit_nogood_inference_codes,
                     trailed_values: &mut self.trailed_values,
                     variable_names: &self.variable_names,
+                    rng: &mut self.internal_parameters.random_generator,
                 };
 
                 let mut resolver = ResolutionResolver::with_mode(AnalysisMode::AllDecision);
@@ -636,6 +637,7 @@ impl ConstraintSatisfactionSolver {
                 0,
                 brancher,
                 &mut self.trailed_values,
+                &mut self.internal_parameters.random_generator,
             );
             self.state.declare_ready();
         } else if self.state.internal_state == CSPSolverStateInternal::ContainsSolution {
@@ -829,6 +831,7 @@ impl ConstraintSatisfactionSolver {
             unit_nogood_inference_codes: &self.unit_nogood_inference_codes,
             trailed_values: &mut self.trailed_values,
             variable_names: &self.variable_names,
+            rng: &mut self.internal_parameters.random_generator,
         };
 
         let learned_nogood = self
@@ -971,6 +974,7 @@ impl ConstraintSatisfactionSolver {
             0,
             brancher,
             &mut self.trailed_values,
+            &mut self.internal_parameters.random_generator,
         );
 
         self.restart_strategy.notify_restart();
@@ -989,6 +993,7 @@ impl ConstraintSatisfactionSolver {
         backtrack_level: usize,
         brancher: &mut BrancherType,
         trailed_values: &mut TrailedValues,
+        rng: &mut dyn Random,
     ) {
         pumpkin_assert_simple!(backtrack_level < assignments.get_decision_level());
 
@@ -1014,7 +1019,7 @@ impl ConstraintSatisfactionSolver {
             propagator.synchronise(context);
         }
 
-        brancher.synchronise(assignments);
+        brancher.synchronise(&mut SelectionContext::new(assignments, rng));
 
         let _ = notification_engine.process_backtrack_events(assignments, propagators);
         notification_engine.clear_event_drain();


### PR DESCRIPTION
A custom `Brancher` cannot be implemented due to `Assignments` not being public; we fix this by changing the function signature to take the already existing `SelectionContext`.

Closes #309.