### PR TITLE
fix: Sign error in greater_than constraint

### DIFF
--- a/pumpkin-crates/core/src/constraints/arithmetic/inequality.rs
+++ b/pumpkin-crates/core/src/constraints/arithmetic/inequality.rs
@@ -140,3 +140,38 @@ impl<Var: IntegerVariable + 'static> NegatableConstraint for Inequality<Var> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn less_than_conflict() {
+        let mut solver = Solver::default();
+
+        let constraint_tag = solver.new_constraint_tag();
+        let x = solver.new_named_bounded_integer(0, 0, "x");
+
+        let result = less_than([x], 0, constraint_tag).post(&mut solver);
+        assert_eq!(
+            result,
+            Err(ConstraintOperationError::InfeasiblePropagator),
+            "Expected {result:?} to be an `InfeasiblePropagator` error"
+        );
+    }
+
+    #[test]
+    fn greater_than_conflict() {
+        let mut solver = Solver::default();
+
+        let constraint_tag = solver.new_constraint_tag();
+        let x = solver.new_named_bounded_integer(0, 0, "x");
+
+        let result = greater_than([x], 0, constraint_tag).post(&mut solver);
+        assert_eq!(
+            result,
+            Err(ConstraintOperationError::InfeasiblePropagator),
+            "Expected {result:?} to be an `InfeasiblePropagator` error"
+        );
+    }
+}

--- a/pumpkin-solver/tests/solver_test.rs
+++ b/pumpkin-solver/tests/solver_test.rs
@@ -2,7 +2,6 @@
 
 use std::path::PathBuf;
 
-use pumpkin_solver::ConstraintOperationError;
 use pumpkin_solver::Solver;
 use pumpkin_solver::constraints;
 use pumpkin_solver::options::SolverOptions;
@@ -63,19 +62,4 @@ fn proof_with_equality_unit_nogood_step() {
     let mut brancher = solver.default_brancher();
     let result = solver.satisfy(&mut brancher, &mut Indefinite);
     assert!(matches!(result, SatisfactionResult::Unsatisfiable(_, _)));
-}
-
-#[test]
-fn greater_than_bug() {
-    let mut solver = Solver::default();
-
-    let constraint_tag = solver.new_constraint_tag();
-    let x = solver.new_named_bounded_integer(0, 0, "x");
-    let gt = solver.add_constraint(constraints::greater_than([x], 0, constraint_tag));
-
-    match gt.post() {
-        Err(ConstraintOperationError::InfeasiblePropagator) => {}
-        Ok(()) => panic!("expected InfeasiblePropagator when posting x > 0 for x fixed to 0"),
-        Err(e) => panic!("unexpected error: {e:?}"),
-    }
 }


### PR DESCRIPTION
`greater_than(terms, rhs)` is implemented as `greater_than_or_equals(terms, rhs - 1)`, but should be `greater_than_or_equals(terms, rhs + 1)`. This is likely a copy-paste error from the implementation of `less_than`.

Note: I've added a unit test saying that "x > 0" is not satisfiable for an integer variable x which is required to be 0. This feels like an odd test to have. I'm happy to remove or change it.