### PR TITLE
fix: Generate constraint tags via State

### DIFF
--- a/pumpkin-crates/core/src/engine/conflict_analysis/conflict_analysis_context.rs
+++ b/pumpkin-crates/core/src/engine/conflict_analysis/conflict_analysis_context.rs
@@ -87,10 +87,11 @@ impl ConflictAnalysisContext<'_> {
             StoredConflictInfo::Propagator(conflict) => {
                 let _ = self.proof_log.log_inference(
                     &self.state.inference_codes,
+                    &mut self.state.constraint_tags,
                     conflict.inference_code,
                     conflict.conjunction.iter().copied(),
                     None,
-                    self.state.variable_names(),
+                    &self.state.variable_names,
                 );
 
                 conflict.conjunction
@@ -176,19 +177,21 @@ impl ConflictAnalysisContext<'_> {
 
                 let _ = proof_log.log_inference(
                     &state.inference_codes,
+                    &mut state.constraint_tags,
                     *inference_code,
                     [],
                     Some(predicate),
-                    state.variable_names(),
+                    &state.variable_names,
                 );
             } else {
                 // Otherwise we log the inference which was used to derive the nogood
                 let _ = proof_log.log_inference(
                     &state.inference_codes,
+                    &mut state.constraint_tags,
                     inference_code,
                     reason_buffer.as_ref().iter().copied(),
                     Some(predicate),
-                    state.variable_names(),
+                    &state.variable_names,
                 );
             }
         }
@@ -219,10 +222,11 @@ impl ConflictAnalysisContext<'_> {
         // We also need to log this last propagation to the proof log as an inference.
         let _ = self.proof_log.log_inference(
             &self.state.inference_codes,
+            &mut self.state.constraint_tags,
             conflict.trigger_inference_code,
             empty_domain_reason.iter().copied(),
             Some(conflict.trigger_predicate),
-            self.state.variable_names(),
+            &self.state.variable_names,
         );
 
         let old_lower_bound = self.state.lower_bound(conflict_domain);

--- a/pumpkin-crates/core/src/engine/conflict_analysis/resolvers/resolution_resolver.rs
+++ b/pumpkin-crates/core/src/engine/conflict_analysis/resolvers/resolution_resolver.rs
@@ -101,7 +101,8 @@ impl ConflictResolver for ResolutionResolver {
             .proof_log
             .log_deduction(
                 learned_nogood.predicates.iter().copied(),
-                context.state.variable_names(),
+                &context.state.variable_names,
+                &mut context.state.constraint_tags,
             )
             .expect("Failed to write proof log");
 

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -335,7 +335,7 @@ impl ConstraintSatisfactionSolver {
 
     /// Create a new [`ConstraintTag`].
     pub fn new_constraint_tag(&mut self) -> ConstraintTag {
-        self.internal_parameters.proof_log.new_constraint_tag()
+        self.state.new_constraint_tag()
     }
 
     pub fn create_new_literal(&mut self, name: Option<Arc<str>>) -> Literal {
@@ -834,10 +834,11 @@ impl ConstraintSatisfactionSolver {
             let inference_premises = reason.iter().copied().chain(std::iter::once(!propagated));
             let _ = self.internal_parameters.proof_log.log_inference(
                 &self.state.inference_codes,
+                &mut self.state.constraint_tags,
                 inference_code,
                 inference_premises,
                 None,
-                self.state.variable_names(),
+                &self.state.variable_names,
             );
 
             // Since inference steps are only related to the nogood they directly precede,
@@ -869,10 +870,11 @@ impl ConstraintSatisfactionSolver {
             }
 
             // Log the nogood which adds the root-level knowledge to the proof.
-            let constraint_tag = self
-                .internal_parameters
-                .proof_log
-                .log_deduction([!propagated], self.state.variable_names());
+            let constraint_tag = self.internal_parameters.proof_log.log_deduction(
+                [!propagated],
+                &self.state.variable_names,
+                &mut self.state.constraint_tags,
+            );
 
             if let Ok(constraint_tag) = constraint_tag {
                 let inference_code = self

--- a/pumpkin-crates/core/src/proof/finalizer.rs
+++ b/pumpkin-crates/core/src/proof/finalizer.rs
@@ -41,9 +41,11 @@ pub(crate) fn finalize_proof(context: FinalizingContext<'_>) {
         })
         .collect::<Vec<_>>();
 
-    let _ = context
-        .proof_log
-        .log_deduction(final_nogood, context.state.variable_names());
+    let _ = context.proof_log.log_deduction(
+        final_nogood,
+        &context.state.variable_names,
+        &mut context.state.constraint_tags,
+    );
 }
 
 pub(crate) struct RootExplanationContext<'a> {
@@ -86,9 +88,11 @@ fn get_required_assumptions(
 
     // If the predicate is a root-level assignment, add the appropriate inference to the proof.
     if context.state.assignments.is_initial_bound(predicate) {
-        let _ = context
-            .proof_log
-            .log_domain_inference(predicate, context.state.variable_names());
+        let _ = context.proof_log.log_domain_inference(
+            predicate,
+            &context.state.variable_names,
+            &mut context.state.constraint_tags,
+        );
         return vec![];
     }
 
@@ -96,10 +100,11 @@ fn get_required_assumptions(
     if let Some(inference_code) = context.unit_nogood_inference_codes.get(&predicate) {
         let _ = context.proof_log.log_inference(
             &context.state.inference_codes,
+            &mut context.state.constraint_tags,
             *inference_code,
             [],
             Some(predicate),
-            context.state.variable_names(),
+            &context.state.variable_names,
         );
         return vec![];
     }


### PR DESCRIPTION
Currently, we can only generate `ConstraintTag`s via the solver; however, all propagators take as input a constraint tag. This means that we have an odd dependency between having to create a `Solver` (which contains a `State`) to create a `ConstraintTag` before we can post a propagator to the `State`.

This PR addresses this by moving the generation of `ConstraintTag`s via the `State`.