### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -25,9 +25,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -55,35 +55,35 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
  "object",
 ]
@@ -144,15 +144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata 0.4.14",
  "serde",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "cast"
@@ -162,9 +162,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chumsky"
@@ -182,7 +182,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14377e276b2c8300513dff55ba4cc4142b44e5d6de6d00eb5b2307d650bb4ec1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
  "regex-automata 0.3.9",
  "serde",
  "stacker",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "drcp-format"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "thiserror",
 ]
@@ -371,18 +371,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.6"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6b7c3d347de0a9f7bfd2f853be43fe32fa6fac30c70f6d6d67a1e936b87ee"
+checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da3ea9e1d1a3b1593e15781f930120e72aa7501610b2f82e5b6739c72e8eac5"
+checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -410,16 +410,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.5"
+name = "errno"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -446,6 +456,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fzn-rs"
 version = "0.1.0"
 dependencies = [
@@ -467,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -480,14 +515,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -503,9 +544,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "humantime"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "ident_case"
@@ -515,36 +556,39 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -557,15 +601,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -573,27 +617,27 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -621,6 +665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -629,7 +674,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -708,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -723,9 +768,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -734,10 +779,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.1"
+name = "pin-project-lite"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -777,18 +834,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -838,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bitfield",
  "bitfield-struct",
@@ -894,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-solver"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cc",
  "clap",
@@ -989,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1028,14 +1085,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.9",
 ]
 
 [[package]]
@@ -1051,13 +1108,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.9",
 ]
 
 [[package]]
@@ -1068,9 +1125,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rustc_version"
@@ -1086,12 +1143,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1140,15 +1191,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1169,24 +1220,37 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
-name = "stacker"
-version = "0.1.22"
+name = "simd-adler32"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "stacker"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1203,9 +1267,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1214,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "termcolor"
@@ -1235,18 +1299,18 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1255,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1304,9 +1368,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1317,11 +1381,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -1330,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1340,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1353,18 +1418,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.56"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
+checksum = "45649196a53b0b7a15101d845d44d2dda7374fc1b5b5e2bbf58b7577ff4b346d"
 dependencies = [
  "async-trait",
  "cast",
@@ -1379,13 +1444,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.56"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
+checksum = "f579cdd0123ac74b94e1a4a72bd963cf30ebac343f2df347da0b8df24cdebed2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1393,10 +1459,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.83"
+name = "wasm-bindgen-test-shared"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1414,12 +1486,18 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1428,6 +1506,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1505,20 +1592,26 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/drcp-format/CHANGELOG.md
+++ b/drcp-format/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1](https://github.com/ConSol-Lab/Pumpkin/compare/drcp-format-v0.3.0...drcp-format-v0.3.1) - 2026-02-10
+
+### Other
+
+- Update rust edition to 2024 ([#311](https://github.com/ConSol-Lab/Pumpkin/pull/311))
+- *(drcp-format)* Update README
+- *(drcp-format)* Improve parser speed ([#293](https://github.com/ConSol-Lab/Pumpkin/pull/293))
+
 ## [0.3.0](https://github.com/ConSol-Lab/Pumpkin/compare/drcp-format-v0.2.1...drcp-format-v0.3.0) (2025-07-10)
 
 

--- a/drcp-format/Cargo.toml
+++ b/drcp-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drcp-format"
-version = "0.3.0"
+version = "0.3.1"
 description = "Parse and write DRCP and literal definition files."
 license.workspace = true
 authors.workspace = true

--- a/fzn-rs-derive/CHANGELOG.md
+++ b/fzn-rs-derive/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/ConSol-Lab/Pumpkin/releases/tag/fzn-rs-derive-v0.1.0) - 2026-02-10
+
+### Added
+
+- Introducing `fzn-rs`, a better FlatZinc parser that is easier to re-use across projects ([#238](https://github.com/ConSol-Lab/Pumpkin/pull/238))

--- a/fzn-rs/CHANGELOG.md
+++ b/fzn-rs/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/ConSol-Lab/Pumpkin/releases/tag/fzn-rs-v0.1.0) - 2026-02-10
+
+### Added
+
+- Introducing `fzn-rs`, a better FlatZinc parser that is easier to re-use across projects ([#238](https://github.com/ConSol-Lab/Pumpkin/pull/238))

--- a/pumpkin-checker/CHANGELOG.md
+++ b/pumpkin-checker/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-checker-v0.1.0) - 2026-02-10
+
+### Added
+
+- *(pumpkin-core)* Propagator for the hypercube linear constraint ([#347](https://github.com/ConSol-Lab/Pumpkin/pull/347))
+- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))
+- *(pumpkin-checker)* Introduce the uncertified proof checker ([#328](https://github.com/ConSol-Lab/Pumpkin/pull/328))
+
+### Other
+
+- *(pumpkin-checker)* Add test cases for verifiers ([#352](https://github.com/ConSol-Lab/Pumpkin/pull/352))
+- *(pumpkin-solver)* Run proof checker on integration tests ([#329](https://github.com/ConSol-Lab/Pumpkin/pull/329))

--- a/pumpkin-checker/Cargo.toml
+++ b/pumpkin-checker/Cargo.toml
@@ -7,12 +7,12 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
-pumpkin-core = { version = "0.2.2", path = "../pumpkin-crates/core/" }
+pumpkin-core = { version = "0.2.3", path = "../pumpkin-crates/core/" }
 pumpkin-checking = { version = "0.2.2", path = "../pumpkin-crates/checking/" }
 pumpkin-propagators = { version = "0.2.2", path = "../pumpkin-crates/propagators/" }
 anyhow = "1.0.99"
 clap = { version = "4.5.47", features = ["derive"] }
-drcp-format = { version = "0.3.0", path = "../drcp-format" }
+drcp-format = { version = "0.3.1", path = "../drcp-format" }
 flate2 = "1.1.2"
 fzn-rs = { version = "0.1.0", path = "../fzn-rs" }
 thiserror = "2.0.16"

--- a/pumpkin-crates/checking/CHANGELOG.md
+++ b/pumpkin-crates/checking/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-checking-v0.2.2) - 2026-02-10
+
+### Added
+
+- *(pumpkin-core)* Propagator for the hypercube linear constraint ([#347](https://github.com/ConSol-Lab/Pumpkin/pull/347))
+- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))
+
+### Other
+
+- *(pumpkin-checker)* Add test cases for verifiers ([#352](https://github.com/ConSol-Lab/Pumpkin/pull/352))

--- a/pumpkin-crates/conflict-resolvers/CHANGELOG.md
+++ b/pumpkin-crates/conflict-resolvers/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-conflict-resolvers-v0.2.2) - 2026-02-10
+
+### Added
+
+- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))
+
+### Other
+
+- *(pumpkin-checker)* Add test cases for verifiers ([#352](https://github.com/ConSol-Lab/Pumpkin/pull/352))

--- a/pumpkin-crates/conflict-resolvers/Cargo.toml
+++ b/pumpkin-crates/conflict-resolvers/Cargo.toml
@@ -11,4 +11,4 @@ description = "The conflict resolvers of the Pumpkin constraint programming solv
 workspace = true
 
 [dependencies]
-pumpkin-core = { version = "0.2.2", path = "../core" }
+pumpkin-core = { version = "0.2.3", path = "../core" }

--- a/pumpkin-crates/constraints/CHANGELOG.md
+++ b/pumpkin-crates/constraints/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-constraints-v0.2.2) - 2026-02-10
+
+### Added
+
+- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))
+- Extract propagators into separate crate ([#337](https://github.com/ConSol-Lab/Pumpkin/pull/337))

--- a/pumpkin-crates/constraints/Cargo.toml
+++ b/pumpkin-crates/constraints/Cargo.toml
@@ -11,7 +11,7 @@ description = "The constraints of the Pumpkin constraint programming solver."
 workspace = true
 
 [dependencies]
-pumpkin-core = { version = "0.2.2", path = "../core" }
+pumpkin-core = { version = "0.2.3", path = "../core" }
 pumpkin-propagators = {version = "0.2.2", path="../propagators"}
 
 [dev-dependencies]

--- a/pumpkin-crates/core/CHANGELOG.md
+++ b/pumpkin-crates/core/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.2.3](https://github.com/ConSol-Lab/Pumpkin/compare/pumpkin-core-v0.2.2...pumpkin-core-v0.2.3) - 2026-02-10
+
+### Added
+
+- *(pumpkin-core)* Propagator for the hypercube linear constraint ([#347](https://github.com/ConSol-Lab/Pumpkin/pull/347))
+- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))
+- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))
+- *(pumpkin-solver-py)* Support warm starting for optimisation models ([#344](https://github.com/ConSol-Lab/Pumpkin/pull/344))
+- *(pumpkin-solver-py)* Add incrementality to python interface ([#315](https://github.com/ConSol-Lab/Pumpkin/pull/315))
+- Extract propagators into separate crate ([#337](https://github.com/ConSol-Lab/Pumpkin/pull/337))
+- *(pumpkin-core)* Crash if a propagator constructor does not register anything ([#338](https://github.com/ConSol-Lab/Pumpkin/pull/338))
+- *(pumpkin-core)* Make propagator API public ([#333](https://github.com/ConSol-Lab/Pumpkin/pull/333))
+- Add interface for nogood minimiser ([#326](https://github.com/ConSol-Lab/Pumpkin/pull/326))
+- Implement State API ([#319](https://github.com/ConSol-Lab/Pumpkin/pull/319))
+- *(pumpkin-core)* WebAssembly support for pumpkin-core ([#327](https://github.com/ConSol-Lab/Pumpkin/pull/327))
+
+### Fixed
+
+- *(pumpkin-solver-py)* Forward brancher events in PythonBrancher ([#358](https://github.com/ConSol-Lab/Pumpkin/pull/358))
+- *(pumpkin-core)* Do not check for event registration when already panicking ([#346](https://github.com/ConSol-Lab/Pumpkin/pull/346))
+- Sign error in greater_than constraint ([#334](https://github.com/ConSol-Lab/Pumpkin/pull/334))
+- Generate constraint tags via State ([#335](https://github.com/ConSol-Lab/Pumpkin/pull/335))
+- *(pumpkin-core)* Allow propagators to register for predicates becoming true ([#331](https://github.com/ConSol-Lab/Pumpkin/pull/331))
+- Off-by-one error when explaining empty domain conflict ([#322](https://github.com/ConSol-Lab/Pumpkin/pull/322))
+- *(pumpkin-core)* Don't use binary equality when logging proof ([#320](https://github.com/ConSol-Lab/Pumpkin/pull/320))
+- *(pumpkin-core)* Declare solving after conflict resolution ([#317](https://github.com/ConSol-Lab/Pumpkin/pull/317))
+
+### Other
+
+- *(pumpkin-checker)* Add test cases for verifiers ([#352](https://github.com/ConSol-Lab/Pumpkin/pull/352))
+- Stop watching predicates without any watchers in nogood propagator ([#351](https://github.com/ConSol-Lab/Pumpkin/pull/351))
+- Simplify predicate notification system ([#348](https://github.com/ConSol-Lab/Pumpkin/pull/348))
+- `InferenceCode` wraps constraint tag and inference label directory ([#339](https://github.com/ConSol-Lab/Pumpkin/pull/339))
+- *(pumpkin-core)* Explicitly register predicates in NogoodPropagator ([#332](https://github.com/ConSol-Lab/Pumpkin/pull/332))
+- *(pumpkin-solver)* Run proof checker on integration tests ([#329](https://github.com/ConSol-Lab/Pumpkin/pull/329))
+- *(pumpkin-core)* Use clippy to detect disallowed types ([#325](https://github.com/ConSol-Lab/Pumpkin/pull/325))
+- *(pumpkin-core)* Empty domain conflict is a predicate and reason ([#314](https://github.com/ConSol-Lab/Pumpkin/pull/314))
+- *(pumpkin-core)* Separate conflict resolvers further from solver ([#310](https://github.com/ConSol-Lab/Pumpkin/pull/310))
+- Update rust edition to 2024 ([#311](https://github.com/ConSol-Lab/Pumpkin/pull/311))
+
 ## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/compare/pumpkin-core-v0.2.1...pumpkin-core-v0.2.2) (2025-11-10)
 
 

--- a/pumpkin-crates/core/Cargo.toml
+++ b/pumpkin-crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pumpkin-core"
-version = "0.2.2"
+version = "0.2.3"
 repository.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -20,7 +20,7 @@ fnv = "1.0.7" # We require features which are on the `main` branch of the reposi
 rand = { version = "0.8.5", features = [ "small_rng", "alloc" ] }
 once_cell = "1.19.0"
 downcast-rs = "1.2.1"
-drcp-format = { version = "0.3.0", path = "../../drcp-format" }
+drcp-format = { version = "0.3.1", path = "../../drcp-format" }
 convert_case = "0.8.0"
 itertools = "0.13.0"
 bitfield-struct = "0.9.2"

--- a/pumpkin-crates/propagators/CHANGELOG.md
+++ b/pumpkin-crates/propagators/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-propagators-v0.2.2) - 2026-02-10
+
+### Added
+
+- Calculate minimal profile for explaining time-table conflict ([#353](https://github.com/ConSol-Lab/Pumpkin/pull/353))
+- *(pumpkin-core)* Propagator for the hypercube linear constraint ([#347](https://github.com/ConSol-Lab/Pumpkin/pull/347))
+- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))
+- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))
+- Extract propagators into separate crate ([#337](https://github.com/ConSol-Lab/Pumpkin/pull/337))
+
+### Fixed
+
+- Use saturating multiplication in integer multiplication propagator ([#350](https://github.com/ConSol-Lab/Pumpkin/pull/350))
+- Explanation check for Cumulative after full explanation is created ([#349](https://github.com/ConSol-Lab/Pumpkin/pull/349))
+
+### Other
+
+- `InferenceCode` wraps constraint tag and inference label directory ([#339](https://github.com/ConSol-Lab/Pumpkin/pull/339))

--- a/pumpkin-crates/propagators/Cargo.toml
+++ b/pumpkin-crates/propagators/Cargo.toml
@@ -11,7 +11,7 @@ description = "The propagators of the Pumpkin constraint programming solver."
 workspace = true
 
 [dependencies]
-pumpkin-core = { version = "0.2.2", path = "../core" }
+pumpkin-core = { version = "0.2.3", path = "../core" }
 pumpkin-checking = { version = "0.2.2", path = "../checking" }
 enumset = "1.1.2"
 bitfield-struct = "0.9.2"
@@ -21,7 +21,7 @@ clap = { version = "4.5.40", optional = true, features=["derive"]}
 [dev-dependencies]
 pumpkin-constraints = { version = "0.2.2", path = "../constraints" }
 pumpkin-conflict-resolvers = {version = "0.2.2", path = "../conflict-resolvers/"}
-pumpkin-solver = { version = "0.2.2", path="../../pumpkin-solver"}
+pumpkin-solver = { version = "0.2.3", path="../../pumpkin-solver"}
 
 [features]
 clap = ["dep:clap", "pumpkin-core/clap"]

--- a/pumpkin-solver-py/Cargo.toml
+++ b/pumpkin-solver-py/Cargo.toml
@@ -17,7 +17,7 @@ doc = false
 
 [dependencies]
 pyo3 = { version = "0.25.1", features= ["extension-module"] }
-pumpkin-solver = { version = "0.2.2", path = "../pumpkin-solver" }
+pumpkin-solver = { version = "0.2.3", path = "../pumpkin-solver" }
 pumpkin-constraints = { version = "0.2.2", path = "../pumpkin-crates/constraints", features=["clap"] }
 pumpkin-conflict-resolvers = {version = "0.2.2", path = "../pumpkin-crates/conflict-resolvers/"}
 

--- a/pumpkin-solver/CHANGELOG.md
+++ b/pumpkin-solver/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3](https://github.com/ConSol-Lab/Pumpkin/compare/pumpkin-solver-v0.2.2...pumpkin-solver-v0.2.3) - 2026-02-10
+
+### Added
+
+- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))
+- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))
+- *(pumpkin-solver-py)* Support warm starting for optimisation models ([#344](https://github.com/ConSol-Lab/Pumpkin/pull/344))
+- Extract propagators into separate crate ([#337](https://github.com/ConSol-Lab/Pumpkin/pull/337))
+
+### Fixed
+
+- *(pumpkin-solver)* Stop search when a SIGTERM signal is received ([#324](https://github.com/ConSol-Lab/Pumpkin/pull/324))
+- Off-by-one error when explaining empty domain conflict ([#322](https://github.com/ConSol-Lab/Pumpkin/pull/322))
+
+### Other
+
+- *(pumpkin-core)* Explicitly register predicates in NogoodPropagator ([#332](https://github.com/ConSol-Lab/Pumpkin/pull/332))
+- *(pumpkin-solver)* Run proof checker on integration tests ([#329](https://github.com/ConSol-Lab/Pumpkin/pull/329))
+- Update rust edition to 2024 ([#311](https://github.com/ConSol-Lab/Pumpkin/pull/311))
+- Adjust versions python interface ([#313](https://github.com/ConSol-Lab/Pumpkin/pull/313))
+
 ## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/compare/pumpkin-solver-v0.2.1...pumpkin-solver-v0.2.2) (2025-11-10)
 
 

--- a/pumpkin-solver/Cargo.toml
+++ b/pumpkin-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pumpkin-solver"
-version = "0.2.2"
+version = "0.2.3"
 description = "The Pumpkin combinatorial optimisation solver library."
 readme = "../README.md"
 authors.workspace = true
@@ -13,7 +13,7 @@ clap = { version = "4.5.17", features = ["derive"] }
 env_logger = "0.10.0"
 flatzinc = "0.3.21"
 log = "0.4.27"
-pumpkin-core = { version = "0.2.2", path = "../pumpkin-crates/core/", features = ["clap"] }
+pumpkin-core = { version = "0.2.3", path = "../pumpkin-crates/core/", features = ["clap"] }
 pumpkin-constraints = {version = "0.2.2", path = "../pumpkin-crates/constraints/"}
 pumpkin-propagators = {version = "0.2.2", path = "../pumpkin-crates/propagators/", features=["clap"]}
 pumpkin-conflict-resolvers = {version = "0.2.2", path = "../pumpkin-crates/conflict-resolvers/"}


### PR DESCRIPTION



## 🤖 New release

* `drcp-format`: 0.3.0 -> 0.3.1
* `fzn-rs-derive`: 0.1.0
* `fzn-rs`: 0.1.0
* `pumpkin-checking`: 0.2.2
* `pumpkin-core`: 0.2.2 -> 0.2.3
* `pumpkin-conflict-resolvers`: 0.2.2
* `pumpkin-propagators`: 0.2.2
* `pumpkin-constraints`: 0.2.2
* `pumpkin-solver`: 0.2.2 -> 0.2.3
* `pumpkin-checker`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `drcp-format`

<blockquote>

## [0.3.1](https://github.com/ConSol-Lab/Pumpkin/compare/drcp-format-v0.3.0...drcp-format-v0.3.1) - 2026-02-10

### Other

- Update rust edition to 2024 ([#311](https://github.com/ConSol-Lab/Pumpkin/pull/311))
- *(drcp-format)* Update README
- *(drcp-format)* Improve parser speed ([#293](https://github.com/ConSol-Lab/Pumpkin/pull/293))
</blockquote>

## `fzn-rs-derive`

<blockquote>

## [0.1.0](https://github.com/ConSol-Lab/Pumpkin/releases/tag/fzn-rs-derive-v0.1.0) - 2026-02-10

### Added

- Introducing `fzn-rs`, a better FlatZinc parser that is easier to re-use across projects ([#238](https://github.com/ConSol-Lab/Pumpkin/pull/238))
</blockquote>

## `fzn-rs`

<blockquote>

## [0.1.0](https://github.com/ConSol-Lab/Pumpkin/releases/tag/fzn-rs-v0.1.0) - 2026-02-10

### Added

- Introducing `fzn-rs`, a better FlatZinc parser that is easier to re-use across projects ([#238](https://github.com/ConSol-Lab/Pumpkin/pull/238))
</blockquote>

## `pumpkin-checking`

<blockquote>

## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-checking-v0.2.2) - 2026-02-10

### Added

- *(pumpkin-core)* Propagator for the hypercube linear constraint ([#347](https://github.com/ConSol-Lab/Pumpkin/pull/347))
- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))

### Other

- *(pumpkin-checker)* Add test cases for verifiers ([#352](https://github.com/ConSol-Lab/Pumpkin/pull/352))
</blockquote>

## `pumpkin-core`

<blockquote>

## [0.2.3](https://github.com/ConSol-Lab/Pumpkin/compare/pumpkin-core-v0.2.2...pumpkin-core-v0.2.3) - 2026-02-10

### Added

- *(pumpkin-core)* Propagator for the hypercube linear constraint ([#347](https://github.com/ConSol-Lab/Pumpkin/pull/347))
- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))
- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))
- *(pumpkin-solver-py)* Support warm starting for optimisation models ([#344](https://github.com/ConSol-Lab/Pumpkin/pull/344))
- *(pumpkin-solver-py)* Add incrementality to python interface ([#315](https://github.com/ConSol-Lab/Pumpkin/pull/315))
- Extract propagators into separate crate ([#337](https://github.com/ConSol-Lab/Pumpkin/pull/337))
- *(pumpkin-core)* Crash if a propagator constructor does not register anything ([#338](https://github.com/ConSol-Lab/Pumpkin/pull/338))
- *(pumpkin-core)* Make propagator API public ([#333](https://github.com/ConSol-Lab/Pumpkin/pull/333))
- Add interface for nogood minimiser ([#326](https://github.com/ConSol-Lab/Pumpkin/pull/326))
- Implement State API ([#319](https://github.com/ConSol-Lab/Pumpkin/pull/319))
- *(pumpkin-core)* WebAssembly support for pumpkin-core ([#327](https://github.com/ConSol-Lab/Pumpkin/pull/327))

### Fixed

- *(pumpkin-solver-py)* Forward brancher events in PythonBrancher ([#358](https://github.com/ConSol-Lab/Pumpkin/pull/358))
- *(pumpkin-core)* Do not check for event registration when already panicking ([#346](https://github.com/ConSol-Lab/Pumpkin/pull/346))
- Sign error in greater_than constraint ([#334](https://github.com/ConSol-Lab/Pumpkin/pull/334))
- Generate constraint tags via State ([#335](https://github.com/ConSol-Lab/Pumpkin/pull/335))
- *(pumpkin-core)* Allow propagators to register for predicates becoming true ([#331](https://github.com/ConSol-Lab/Pumpkin/pull/331))
- Off-by-one error when explaining empty domain conflict ([#322](https://github.com/ConSol-Lab/Pumpkin/pull/322))
- *(pumpkin-core)* Don't use binary equality when logging proof ([#320](https://github.com/ConSol-Lab/Pumpkin/pull/320))
- *(pumpkin-core)* Declare solving after conflict resolution ([#317](https://github.com/ConSol-Lab/Pumpkin/pull/317))

### Other

- *(pumpkin-checker)* Add test cases for verifiers ([#352](https://github.com/ConSol-Lab/Pumpkin/pull/352))
- Stop watching predicates without any watchers in nogood propagator ([#351](https://github.com/ConSol-Lab/Pumpkin/pull/351))
- Simplify predicate notification system ([#348](https://github.com/ConSol-Lab/Pumpkin/pull/348))
- `InferenceCode` wraps constraint tag and inference label directory ([#339](https://github.com/ConSol-Lab/Pumpkin/pull/339))
- *(pumpkin-core)* Explicitly register predicates in NogoodPropagator ([#332](https://github.com/ConSol-Lab/Pumpkin/pull/332))
- *(pumpkin-solver)* Run proof checker on integration tests ([#329](https://github.com/ConSol-Lab/Pumpkin/pull/329))
- *(pumpkin-core)* Use clippy to detect disallowed types ([#325](https://github.com/ConSol-Lab/Pumpkin/pull/325))
- *(pumpkin-core)* Empty domain conflict is a predicate and reason ([#314](https://github.com/ConSol-Lab/Pumpkin/pull/314))
- *(pumpkin-core)* Separate conflict resolvers further from solver ([#310](https://github.com/ConSol-Lab/Pumpkin/pull/310))
- Update rust edition to 2024 ([#311](https://github.com/ConSol-Lab/Pumpkin/pull/311))
</blockquote>

## `pumpkin-conflict-resolvers`

<blockquote>

## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-conflict-resolvers-v0.2.2) - 2026-02-10

### Added

- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))

### Other

- *(pumpkin-checker)* Add test cases for verifiers ([#352](https://github.com/ConSol-Lab/Pumpkin/pull/352))
</blockquote>

## `pumpkin-propagators`

<blockquote>

## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-propagators-v0.2.2) - 2026-02-10

### Added

- Calculate minimal profile for explaining time-table conflict ([#353](https://github.com/ConSol-Lab/Pumpkin/pull/353))
- *(pumpkin-core)* Propagator for the hypercube linear constraint ([#347](https://github.com/ConSol-Lab/Pumpkin/pull/347))
- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))
- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))
- Extract propagators into separate crate ([#337](https://github.com/ConSol-Lab/Pumpkin/pull/337))

### Fixed

- Use saturating multiplication in integer multiplication propagator ([#350](https://github.com/ConSol-Lab/Pumpkin/pull/350))
- Explanation check for Cumulative after full explanation is created ([#349](https://github.com/ConSol-Lab/Pumpkin/pull/349))

### Other

- `InferenceCode` wraps constraint tag and inference label directory ([#339](https://github.com/ConSol-Lab/Pumpkin/pull/339))
</blockquote>

## `pumpkin-constraints`

<blockquote>

## [0.2.2](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-constraints-v0.2.2) - 2026-02-10

### Added

- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))
- Extract propagators into separate crate ([#337](https://github.com/ConSol-Lab/Pumpkin/pull/337))
</blockquote>

## `pumpkin-solver`

<blockquote>

## [0.2.3](https://github.com/ConSol-Lab/Pumpkin/compare/pumpkin-solver-v0.2.2...pumpkin-solver-v0.2.3) - 2026-02-10

### Added

- Extract conflict resolvers and nogood minimisation into a separate crate ([#341](https://github.com/ConSol-Lab/Pumpkin/pull/341))
- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))
- *(pumpkin-solver-py)* Support warm starting for optimisation models ([#344](https://github.com/ConSol-Lab/Pumpkin/pull/344))
- Extract propagators into separate crate ([#337](https://github.com/ConSol-Lab/Pumpkin/pull/337))

### Fixed

- *(pumpkin-solver)* Stop search when a SIGTERM signal is received ([#324](https://github.com/ConSol-Lab/Pumpkin/pull/324))
- Off-by-one error when explaining empty domain conflict ([#322](https://github.com/ConSol-Lab/Pumpkin/pull/322))

### Other

- *(pumpkin-core)* Explicitly register predicates in NogoodPropagator ([#332](https://github.com/ConSol-Lab/Pumpkin/pull/332))
- *(pumpkin-solver)* Run proof checker on integration tests ([#329](https://github.com/ConSol-Lab/Pumpkin/pull/329))
- Update rust edition to 2024 ([#311](https://github.com/ConSol-Lab/Pumpkin/pull/311))
- Adjust versions python interface ([#313](https://github.com/ConSol-Lab/Pumpkin/pull/313))
</blockquote>

## `pumpkin-checker`

<blockquote>

## [0.1.0](https://github.com/ConSol-Lab/Pumpkin/releases/tag/pumpkin-checker-v0.1.0) - 2026-02-10

### Added

- *(pumpkin-core)* Propagator for the hypercube linear constraint ([#347](https://github.com/ConSol-Lab/Pumpkin/pull/347))
- *(pumpkin-core)* If the `check-propagations` flag is enabled, the state will run inference checkers on all propagations immediately ([#340](https://github.com/ConSol-Lab/Pumpkin/pull/340))
- *(pumpkin-checker)* Introduce the uncertified proof checker ([#328](https://github.com/ConSol-Lab/Pumpkin/pull/328))

### Other

- *(pumpkin-checker)* Add test cases for verifiers ([#352](https://github.com/ConSol-Lab/Pumpkin/pull/352))
- *(pumpkin-solver)* Run proof checker on integration tests ([#329](https://github.com/ConSol-Lab/Pumpkin/pull/329))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).