### PR TITLE
chore: Add more error logging to processor

### DIFF
--- a/pumpkin-proof-processor/src/main.rs
+++ b/pumpkin-proof-processor/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> anyhow::Result<()> {
         .init();
 
     let proof_processor = parse_model(&cli.model_path).with_context(|| "Failed to parse model")?;
-    let proof_reader = 
+    let proof_reader =
         create_proof_reader(&cli.scaffold_path).with_context(|| "Failed to read proof")?;
     let proof_writer = create_proof_writer(&cli.full_proof_path)
         .with_context(|| "Failed to create proof writer")?;


### PR DESCRIPTION
Currently, when a file cannot be found, the proof processor provides the following error:
```
Error: No such file or directory (os error 2)
```
Which does not provide any information about where the error occurred.

With these changes, the error becomes:
```
Error: Error while creating proof reader for scaffold

Caused by:
    No such file or directory (os error 2)
```

I am more than open to suggestions of how to handle this properly.