### PR TITLE
refactor(pumpkin-solver): Bulk create propagators before root propagation in FlatZinc reader

### DIFF
--- a/pumpkin-crates/constraints/src/constraints/all_different.rs
+++ b/pumpkin-crates/constraints/src/constraints/all_different.rs
@@ -2,9 +2,8 @@ use pumpkin_core::constraints::Constraint;
 use pumpkin_core::proof::ConstraintTag;
 use pumpkin_core::variables::IntegerVariable;
 
-use crate::EqualityConsistency;
-
 use super::binary_not_equals;
+use crate::EqualityConsistency;
 
 /// Creates the [`Constraint`] that enforces that all the given `variables` are distinct.
 pub fn all_different<Var: IntegerVariable + 'static>(

--- a/pumpkin-crates/constraints/src/constraints/all_different.rs
+++ b/pumpkin-crates/constraints/src/constraints/all_different.rs
@@ -2,6 +2,8 @@ use pumpkin_core::constraints::Constraint;
 use pumpkin_core::proof::ConstraintTag;
 use pumpkin_core::variables::IntegerVariable;
 
+use crate::EqualityConsistency;
+
 use super::binary_not_equals;
 
 /// Creates the [`Constraint`] that enforces that all the given `variables` are distinct.
@@ -18,6 +20,7 @@ pub fn all_different<Var: IntegerVariable + 'static>(
                 variables[i].clone(),
                 variables[j].clone(),
                 constraint_tag,
+                EqualityConsistency::Bound,
             ));
         }
     }

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
@@ -1,9 +1,9 @@
 use pumpkin_core::ConstraintOperationError;
-use pumpkin_core::Solver;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::options::ReifiedPropagatorArgs;
 use pumpkin_core::proof::ConstraintTag;
+use pumpkin_core::state::State;
 use pumpkin_core::variables::IntegerVariable;
 use pumpkin_core::variables::Literal;
 use pumpkin_core::variables::TransformableVariable;
@@ -87,7 +87,7 @@ where
 {
     fn post(self, state: &mut State) {
         if self.terms.len() == 2 && !solver.is_logging_proof() {
-            let _ = solver.add_propagator(BinaryEqualsPropagatorArgs {
+            let _ = state.add_propagator(BinaryEqualsPropagatorArgs {
                 a: self.terms[0].clone(),
                 b: self.terms[1].scaled(-1).offset(self.rhs),
                 constraint_tag: self.constraint_tag,
@@ -102,13 +102,11 @@ where
                 .collect::<Box<[_]>>();
             less_than_or_equals(negated, -self.rhs, self.constraint_tag).post(solver)?;
         }
-
-        Ok(())
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
         if self.terms.len() == 2 && !solver.is_logging_proof() {
-            let _ = solver.add_propagator(ReifiedPropagatorArgs {
+            let _ = state.add_propagator(ReifiedPropagatorArgs {
                 propagator: BinaryEqualsPropagatorArgs {
                     a: self.terms[0].clone(),
                     b: self.terms[1].scaled(-1).offset(self.rhs),
@@ -128,8 +126,6 @@ where
             less_than_or_equals(negated, -self.rhs, self.constraint_tag)
                 .implied_by(solver, reification_literal)?;
         }
-
-        Ok(())
     }
 }
 
@@ -160,13 +156,11 @@ where
         } = self;
 
         if terms.len() == 2 {
-            let _ = solver.add_propagator(BinaryNotEqualsPropagatorArgs {
+            let _ = state.add_propagator(BinaryNotEqualsPropagatorArgs {
                 a: terms[0].clone(),
                 b: terms[1].scaled(-1).offset(self.rhs),
                 constraint_tag: self.constraint_tag,
             })?;
-
-            Ok(())
         } else {
             LinearNotEqualPropagatorArgs {
                 terms: terms.into(),
@@ -185,7 +179,7 @@ where
         } = self;
 
         if terms.len() == 2 {
-            let _ = solver.add_propagator(ReifiedPropagatorArgs {
+            let _ = state.add_propagator(ReifiedPropagatorArgs {
                 propagator: BinaryNotEqualsPropagatorArgs {
                     a: terms[0].clone(),
                     b: terms[1].scaled(-1).offset(self.rhs),
@@ -193,7 +187,6 @@ where
                 },
                 reification_literal,
             })?;
-            Ok(())
         } else {
             LinearNotEqualPropagatorArgs {
                 terms: terms.into(),

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
@@ -1,4 +1,3 @@
-use pumpkin_core::ConstraintOperationError;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::options::ReifiedPropagatorArgs;

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
@@ -13,10 +13,17 @@ use pumpkin_propagators::arithmetic::LinearNotEqualPropagatorArgs;
 
 use super::less_than_or_equals;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EqualityConsistency {
+    Bound,
+    Domain,
+}
+
 struct EqualConstraint<Var> {
     terms: Box<[Var]>,
     rhs: i32,
     constraint_tag: ConstraintTag,
+    consistency: EqualityConsistency,
 }
 
 /// Creates the [`NegatableConstraint`] `∑ terms_i = rhs`.
@@ -26,11 +33,13 @@ pub fn equals<Var: IntegerVariable + Clone + 'static>(
     terms: impl Into<Box<[Var]>>,
     rhs: i32,
     constraint_tag: ConstraintTag,
+    consistency: EqualityConsistency,
 ) -> impl NegatableConstraint {
     EqualConstraint {
         terms: terms.into(),
         rhs,
         constraint_tag,
+        consistency,
     }
 }
 
@@ -41,11 +50,13 @@ pub fn binary_equals<Var: IntegerVariable + 'static>(
     lhs: Var,
     rhs: Var,
     constraint_tag: ConstraintTag,
+    consistency: EqualityConsistency,
 ) -> impl NegatableConstraint {
     EqualConstraint {
         terms: [lhs.scaled(1), rhs.scaled(-1)].into(),
         rhs: 0,
         constraint_tag,
+        consistency,
     }
 }
 
@@ -53,6 +64,7 @@ struct NotEqualConstraint<Var> {
     terms: Box<[Var]>,
     rhs: i32,
     constraint_tag: ConstraintTag,
+    consistency: EqualityConsistency,
 }
 
 /// Create the [`NegatableConstraint`] `∑ terms_i != rhs`.
@@ -62,8 +74,9 @@ pub fn not_equals<Var: IntegerVariable + Clone + 'static>(
     terms: impl Into<Box<[Var]>>,
     rhs: i32,
     constraint_tag: ConstraintTag,
+    consistency: EqualityConsistency,
 ) -> impl NegatableConstraint {
-    equals(terms, rhs, constraint_tag).negation()
+    equals(terms, rhs, constraint_tag, consistency).negation()
 }
 
 /// Creates the [`NegatableConstraint`] `lhs != rhs`.
@@ -73,11 +86,13 @@ pub fn binary_not_equals<Var: IntegerVariable + 'static>(
     lhs: Var,
     rhs: Var,
     constraint_tag: ConstraintTag,
+    consistency: EqualityConsistency,
 ) -> impl NegatableConstraint {
     NotEqualConstraint {
         terms: [lhs.scaled(1), rhs.scaled(-1)].into(),
         rhs: 0,
         constraint_tag,
+        consistency,
     }
 }
 
@@ -86,7 +101,7 @@ where
     Var: IntegerVariable + Clone + 'static,
 {
     fn post(self, state: &mut State) {
-        if self.terms.len() == 2 && !solver.is_logging_proof() {
+        if self.terms.len() == 2 && self.consistency == EqualityConsistency::Domain {
             let _ = state.add_propagator(BinaryEqualsPropagatorArgs {
                 a: self.terms[0].clone(),
                 b: self.terms[1].scaled(-1).offset(self.rhs),
@@ -105,7 +120,7 @@ where
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
-        if self.terms.len() == 2 && !solver.is_logging_proof() {
+        if self.terms.len() == 2 && self.consistency == EqualityConsistency::Domain {
             let _ = state.add_propagator(ReifiedPropagatorArgs {
                 propagator: BinaryEqualsPropagatorArgs {
                     a: self.terms[0].clone(),
@@ -140,6 +155,7 @@ where
             terms: self.terms.clone(),
             rhs: self.rhs,
             constraint_tag: self.constraint_tag,
+            consistency: self.consistency,
         }
     }
 }
@@ -153,6 +169,7 @@ where
             terms,
             rhs,
             constraint_tag,
+            consistency: _,
         } = self;
 
         if terms.len() == 2 {
@@ -176,6 +193,7 @@ where
             terms,
             rhs,
             constraint_tag,
+            consistency: _,
         } = self;
 
         if terms.len() == 2 {
@@ -209,6 +227,7 @@ where
             terms: self.terms.clone(),
             rhs: self.rhs,
             constraint_tag: self.constraint_tag,
+            consistency: self.consistency,
         }
     }
 }

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
@@ -91,16 +91,16 @@ where
                 a: self.terms[0].clone(),
                 b: self.terms[1].scaled(-1).offset(self.rhs),
                 constraint_tag: self.constraint_tag,
-            })?;
+            });
         } else {
-            less_than_or_equals(self.terms.clone(), self.rhs, self.constraint_tag).post(solver)?;
+            less_than_or_equals(self.terms.clone(), self.rhs, self.constraint_tag).post(state);
 
             let negated = self
                 .terms
                 .iter()
                 .map(|var| var.scaled(-1))
                 .collect::<Box<[_]>>();
-            less_than_or_equals(negated, -self.rhs, self.constraint_tag).post(solver)?;
+            less_than_or_equals(negated, -self.rhs, self.constraint_tag).post(state);
         }
     }
 
@@ -113,10 +113,10 @@ where
                     constraint_tag: self.constraint_tag,
                 },
                 reification_literal,
-            })?;
+            });
         } else {
             less_than_or_equals(self.terms.clone(), self.rhs, self.constraint_tag)
-                .implied_by(solver, reification_literal)?;
+                .implied_by(state, reification_literal);
 
             let negated = self
                 .terms
@@ -124,7 +124,7 @@ where
                 .map(|var| var.scaled(-1))
                 .collect::<Box<[_]>>();
             less_than_or_equals(negated, -self.rhs, self.constraint_tag)
-                .implied_by(solver, reification_literal)?;
+                .implied_by(state, reification_literal);
         }
     }
 }
@@ -160,14 +160,14 @@ where
                 a: terms[0].clone(),
                 b: terms[1].scaled(-1).offset(self.rhs),
                 constraint_tag: self.constraint_tag,
-            })?;
+            });
         } else {
             LinearNotEqualPropagatorArgs {
                 terms: terms.into(),
                 rhs,
                 constraint_tag,
             }
-            .post(solver)
+            .post(state)
         }
     }
 
@@ -186,14 +186,14 @@ where
                     constraint_tag: self.constraint_tag,
                 },
                 reification_literal,
-            })?;
+            });
         } else {
             LinearNotEqualPropagatorArgs {
                 terms: terms.into(),
                 rhs,
                 constraint_tag,
             }
-            .implied_by(solver, reification_literal)
+            .implied_by(state, reification_literal)
         }
     }
 }

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
@@ -12,9 +12,15 @@ use pumpkin_propagators::arithmetic::LinearNotEqualPropagatorArgs;
 
 use super::less_than_or_equals;
 
+/// The requested consistency level.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EqualityConsistency {
+    /// Use bound consistent propagation.
     Bound,
+    /// If the constraint is over two variables, use domain consistent propagation.
+    ///
+    /// This is only useful when variables are actually equal. In the future this will likely
+    /// become a preprocessing step to unify the variables.
     Domain,
 }
 

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/equality.rs
@@ -85,7 +85,7 @@ impl<Var> Constraint for EqualConstraint<Var>
 where
     Var: IntegerVariable + Clone + 'static,
 {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State) {
         if self.terms.len() == 2 && !solver.is_logging_proof() {
             let _ = solver.add_propagator(BinaryEqualsPropagatorArgs {
                 a: self.terms[0].clone(),
@@ -106,11 +106,7 @@ where
         Ok(())
     }
 
-    fn implied_by(
-        self,
-        solver: &mut Solver,
-        reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         if self.terms.len() == 2 && !solver.is_logging_proof() {
             let _ = solver.add_propagator(ReifiedPropagatorArgs {
                 propagator: BinaryEqualsPropagatorArgs {
@@ -156,7 +152,7 @@ impl<Var> Constraint for NotEqualConstraint<Var>
 where
     Var: IntegerVariable + Clone + 'static,
 {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State) {
         let NotEqualConstraint {
             terms,
             rhs,
@@ -181,11 +177,7 @@ where
         }
     }
 
-    fn implied_by(
-        self,
-        solver: &mut Solver,
-        reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         let NotEqualConstraint {
             terms,
             rhs,

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/inequality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/inequality.rs
@@ -107,7 +107,7 @@ struct Inequality<Var> {
 }
 
 impl<Var: IntegerVariable + 'static> Constraint for Inequality<Var> {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State)  {
         LinearLessOrEqualPropagatorArgs {
             x: self.terms,
             c: self.rhs,
@@ -118,9 +118,9 @@ impl<Var: IntegerVariable + 'static> Constraint for Inequality<Var> {
 
     fn implied_by(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         LinearLessOrEqualPropagatorArgs {
             x: self.terms,
             c: self.rhs,

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/inequality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/inequality.rs
@@ -1,4 +1,3 @@
-use pumpkin_core::ConstraintOperationError;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::proof::ConstraintTag;
@@ -135,40 +134,5 @@ impl<Var: IntegerVariable + 'static> NegatableConstraint for Inequality<Var> {
             rhs: -self.rhs - 1,
             constraint_tag: self.constraint_tag,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn less_than_conflict() {
-        let mut solver = Solver::default();
-
-        let constraint_tag = solver.new_constraint_tag();
-        let x = solver.new_named_bounded_integer(0, 0, "x");
-
-        let result = less_than([x], 0, constraint_tag).post(&mut solver);
-        assert_eq!(
-            result,
-            Err(ConstraintOperationError::InfeasiblePropagator),
-            "Expected {result:?} to be an `InfeasiblePropagator` error"
-        );
-    }
-
-    #[test]
-    fn greater_than_conflict() {
-        let mut solver = Solver::default();
-
-        let constraint_tag = solver.new_constraint_tag();
-        let x = solver.new_named_bounded_integer(0, 0, "x");
-
-        let result = greater_than([x], 0, constraint_tag).post(&mut solver);
-        assert_eq!(
-            result,
-            Err(ConstraintOperationError::InfeasiblePropagator),
-            "Expected {result:?} to be an `InfeasiblePropagator` error"
-        );
     }
 }

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/inequality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/inequality.rs
@@ -113,7 +113,7 @@ impl<Var: IntegerVariable + 'static> Constraint for Inequality<Var> {
             c: self.rhs,
             constraint_tag: self.constraint_tag,
         }
-        .post(solver)
+        .post(state)
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
@@ -122,7 +122,7 @@ impl<Var: IntegerVariable + 'static> Constraint for Inequality<Var> {
             c: self.rhs,
             constraint_tag: self.constraint_tag,
         }
-        .implied_by(solver, reification_literal)
+        .implied_by(state, reification_literal)
     }
 }
 

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/inequality.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/inequality.rs
@@ -1,8 +1,8 @@
 use pumpkin_core::ConstraintOperationError;
-use pumpkin_core::Solver;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::proof::ConstraintTag;
+use pumpkin_core::state::State;
 use pumpkin_core::variables::IntegerVariable;
 use pumpkin_core::variables::Literal;
 use pumpkin_propagators::arithmetic::LinearLessOrEqualPropagatorArgs;
@@ -107,7 +107,7 @@ struct Inequality<Var> {
 }
 
 impl<Var: IntegerVariable + 'static> Constraint for Inequality<Var> {
-    fn post(self, state: &mut State)  {
+    fn post(self, state: &mut State) {
         LinearLessOrEqualPropagatorArgs {
             x: self.terms,
             c: self.rhs,
@@ -116,11 +116,7 @@ impl<Var: IntegerVariable + 'static> Constraint for Inequality<Var> {
         .post(solver)
     }
 
-    fn implied_by(
-        self,
-        state: &mut State,
-        reification_literal: Literal,
-    )  {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         LinearLessOrEqualPropagatorArgs {
             x: self.terms,
             c: self.rhs,

--- a/pumpkin-crates/constraints/src/constraints/arithmetic/mod.rs
+++ b/pumpkin-crates/constraints/src/constraints/arithmetic/mod.rs
@@ -18,7 +18,12 @@ pub fn plus<Var: IntegerVariable + 'static>(
     c: Var,
     constraint_tag: ConstraintTag,
 ) -> impl Constraint {
-    equals([a.scaled(1), b.scaled(1), c.scaled(-1)], 0, constraint_tag)
+    equals(
+        [a.scaled(1), b.scaled(1), c.scaled(-1)],
+        0,
+        constraint_tag,
+        EqualityConsistency::Bound,
+    )
 }
 
 /// Creates the [`Constraint`] `a * b = c`.

--- a/pumpkin-crates/constraints/src/constraints/boolean.rs
+++ b/pumpkin-crates/constraints/src/constraints/boolean.rs
@@ -7,6 +7,8 @@ use pumpkin_core::variables::DomainId;
 use pumpkin_core::variables::Literal;
 use pumpkin_core::variables::TransformableVariable;
 
+use crate::EqualityConsistency;
+
 use super::equals;
 use super::less_than_or_equals;
 
@@ -83,13 +85,14 @@ impl Constraint for BooleanEqual {
     fn post(self, state: &mut State) {
         let domains = self.create_domains();
 
-        equals(domains, 0, self.constraint_tag).post(state)
+        equals(domains, 0, self.constraint_tag, EqualityConsistency::Bound).post(state)
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
         let domains = self.create_domains();
 
-        equals(domains, 0, self.constraint_tag).implied_by(state, reification_literal)
+        equals(domains, 0, self.constraint_tag, EqualityConsistency::Bound)
+            .implied_by(state, reification_literal)
     }
 }
 

--- a/pumpkin-crates/constraints/src/constraints/boolean.rs
+++ b/pumpkin-crates/constraints/src/constraints/boolean.rs
@@ -51,14 +51,14 @@ impl Constraint for BooleanLessThanOrEqual {
     fn post(self, state: &mut State) {
         let domains = self.create_domains();
 
-        less_than_or_equals(domains, self.rhs, self.constraint_tag).post(solver)
+        less_than_or_equals(domains, self.rhs, self.constraint_tag).post(state)
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
         let domains = self.create_domains();
 
         less_than_or_equals(domains, self.rhs, self.constraint_tag)
-            .implied_by(solver, reification_literal)
+            .implied_by(state, reification_literal)
     }
 }
 
@@ -83,13 +83,13 @@ impl Constraint for BooleanEqual {
     fn post(self, state: &mut State) {
         let domains = self.create_domains();
 
-        equals(domains, 0, self.constraint_tag).post(solver)
+        equals(domains, 0, self.constraint_tag).post(state)
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
         let domains = self.create_domains();
 
-        equals(domains, 0, self.constraint_tag).implied_by(solver, reification_literal)
+        equals(domains, 0, self.constraint_tag).implied_by(state, reification_literal)
     }
 }
 

--- a/pumpkin-crates/constraints/src/constraints/boolean.rs
+++ b/pumpkin-crates/constraints/src/constraints/boolean.rs
@@ -1,4 +1,3 @@
-use pumpkin_core::ConstraintOperationError;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::proof::ConstraintTag;
 use pumpkin_core::state::State;

--- a/pumpkin-crates/constraints/src/constraints/boolean.rs
+++ b/pumpkin-crates/constraints/src/constraints/boolean.rs
@@ -1,7 +1,7 @@
 use pumpkin_core::ConstraintOperationError;
-use pumpkin_core::Solver;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::proof::ConstraintTag;
+use pumpkin_core::state::State;
 use pumpkin_core::variables::AffineView;
 use pumpkin_core::variables::DomainId;
 use pumpkin_core::variables::Literal;
@@ -48,17 +48,13 @@ struct BooleanLessThanOrEqual {
 }
 
 impl Constraint for BooleanLessThanOrEqual {
-    fn post(self, state: &mut State)  {
+    fn post(self, state: &mut State) {
         let domains = self.create_domains();
 
         less_than_or_equals(domains, self.rhs, self.constraint_tag).post(solver)
     }
 
-    fn implied_by(
-        self,
-        state: &mut State,
-        reification_literal: Literal,
-    )  {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         let domains = self.create_domains();
 
         less_than_or_equals(domains, self.rhs, self.constraint_tag)
@@ -84,17 +80,13 @@ struct BooleanEqual {
 }
 
 impl Constraint for BooleanEqual {
-    fn post(self, state: &mut State)  {
+    fn post(self, state: &mut State) {
         let domains = self.create_domains();
 
         equals(domains, 0, self.constraint_tag).post(solver)
     }
 
-    fn implied_by(
-        self,
-        state: &mut State,
-        reification_literal: Literal,
-    )  {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         let domains = self.create_domains();
 
         equals(domains, 0, self.constraint_tag).implied_by(solver, reification_literal)

--- a/pumpkin-crates/constraints/src/constraints/boolean.rs
+++ b/pumpkin-crates/constraints/src/constraints/boolean.rs
@@ -6,10 +6,9 @@ use pumpkin_core::variables::DomainId;
 use pumpkin_core::variables::Literal;
 use pumpkin_core::variables::TransformableVariable;
 
-use crate::EqualityConsistency;
-
 use super::equals;
 use super::less_than_or_equals;
+use crate::EqualityConsistency;
 
 /// Creates the [`Constraint`] `∑ weights_i * bools_i <= rhs`.
 pub fn boolean_less_than_or_equals(

--- a/pumpkin-crates/constraints/src/constraints/boolean.rs
+++ b/pumpkin-crates/constraints/src/constraints/boolean.rs
@@ -48,7 +48,7 @@ struct BooleanLessThanOrEqual {
 }
 
 impl Constraint for BooleanLessThanOrEqual {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State)  {
         let domains = self.create_domains();
 
         less_than_or_equals(domains, self.rhs, self.constraint_tag).post(solver)
@@ -56,9 +56,9 @@ impl Constraint for BooleanLessThanOrEqual {
 
     fn implied_by(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         let domains = self.create_domains();
 
         less_than_or_equals(domains, self.rhs, self.constraint_tag)
@@ -84,7 +84,7 @@ struct BooleanEqual {
 }
 
 impl Constraint for BooleanEqual {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State)  {
         let domains = self.create_domains();
 
         equals(domains, 0, self.constraint_tag).post(solver)
@@ -92,9 +92,9 @@ impl Constraint for BooleanEqual {
 
     fn implied_by(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         let domains = self.create_domains();
 
         equals(domains, 0, self.constraint_tag).implied_by(solver, reification_literal)

--- a/pumpkin-crates/constraints/src/constraints/clause.rs
+++ b/pumpkin-crates/constraints/src/constraints/clause.rs
@@ -1,17 +1,18 @@
 use pumpkin_core::ConstraintOperationError;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
+use pumpkin_core::predicates::Predicate;
 use pumpkin_core::proof::ConstraintTag;
 use pumpkin_core::propagators::nogoods::NogoodPropagator;
 use pumpkin_core::state::PropagatorHandle;
 use pumpkin_core::state::State;
 use pumpkin_core::variables::Literal;
 
-/// Creates the [`NegatableConstraint`] `\/ literal`
+/// Creates the [`NegatableConstraint`] `\/ predicate`
 ///
-/// Its negation is `/\ !literal`
+/// Its negation is `/\ !predicate`
 pub fn clause(
-    literals: impl IntoIterator<Item = Literal>,
+    literals: impl IntoIterator<Item = Predicate>,
     constraint_tag: ConstraintTag,
     propagator_handle: PropagatorHandle<NogoodPropagator>,
 ) -> impl NegatableConstraint {
@@ -22,11 +23,11 @@ pub fn clause(
     }
 }
 
-/// Creates the [`NegatableConstraint`] `/\ literal`
+/// Creates the [`NegatableConstraint`] `/\ predicate`
 ///
-/// Its negation is `\/ !literal`
+/// Its negation is `\/ !predicate`
 pub fn conjunction(
-    literals: impl IntoIterator<Item = Literal>,
+    literals: impl IntoIterator<Item = Predicate>,
     constraint_tag: ConstraintTag,
     propagator_handle: PropagatorHandle<NogoodPropagator>,
 ) -> impl NegatableConstraint {
@@ -38,7 +39,7 @@ pub fn conjunction(
 }
 
 struct Clause {
-    literals: Vec<Literal>,
+    literals: Vec<Predicate>,
     constraint_tag: ConstraintTag,
     propagator_handle: PropagatorHandle<NogoodPropagator>,
 }
@@ -57,7 +58,7 @@ impl Constraint for Clause {
 
         // Since we are adding this constraint as a nogood, every literal is negated.
         propagator.add_nogood(
-            literals.into_iter().map(|lit| lit.get_false_predicate()),
+            literals.into_iter().map(|predicate| !predicate),
             constraint_tag,
         );
     }
@@ -72,7 +73,7 @@ impl Constraint for Clause {
         clause(
             literals
                 .into_iter()
-                .chain(std::iter::once(reification_literal)),
+                .chain(std::iter::once(reification_literal.get_false_predicate())),
             constraint_tag,
             propagator_handle,
         )
@@ -99,7 +100,7 @@ impl NegatableConstraint for Clause {
 }
 
 struct Conjunction {
-    literals: Vec<Literal>,
+    literals: Vec<Predicate>,
     constraint_tag: ConstraintTag,
     propagator_handle: PropagatorHandle<NogoodPropagator>,
 }
@@ -126,7 +127,7 @@ impl Constraint for Conjunction {
 
         for literal in literals {
             clause(
-                [!reification_literal, literal],
+                [reification_literal.get_false_predicate(), literal],
                 constraint_tag,
                 propagator_handle,
             )

--- a/pumpkin-crates/constraints/src/constraints/clause.rs
+++ b/pumpkin-crates/constraints/src/constraints/clause.rs
@@ -1,8 +1,8 @@
 use pumpkin_core::ConstraintOperationError;
-use pumpkin_core::Solver;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::proof::ConstraintTag;
+use pumpkin_core::state::State;
 use pumpkin_core::variables::Literal;
 
 /// Creates the [`NegatableConstraint`] `\/ literal`
@@ -28,7 +28,7 @@ pub fn conjunction(
 struct Clause(Vec<Literal>, ConstraintTag);
 
 impl Constraint for Clause {
-    fn post(self, state: &mut State)  {
+    fn post(self, state: &mut State) {
         let Clause(clause, constraint_tag) = self;
 
         solver.add_clause(
@@ -37,11 +37,7 @@ impl Constraint for Clause {
         )
     }
 
-    fn implied_by(
-        self,
-        state: &mut State,
-        reification_literal: Literal,
-    )  {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         let Clause(clause, constraint_tag) = self;
 
         solver.add_clause(
@@ -67,7 +63,7 @@ impl NegatableConstraint for Clause {
 struct Conjunction(Vec<Literal>, ConstraintTag);
 
 impl Constraint for Conjunction {
-    fn post(self, state: &mut State)  {
+    fn post(self, state: &mut State) {
         let Conjunction(conjunction, constraint_tag) = self;
 
         conjunction
@@ -75,11 +71,7 @@ impl Constraint for Conjunction {
             .try_for_each(|lit| solver.add_clause([lit.get_true_predicate()], constraint_tag))
     }
 
-    fn implied_by(
-        self,
-        state: &mut State,
-        reification_literal: Literal,
-    )  {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         let Conjunction(conjunction, constraint_tag) = self;
 
         conjunction.into_iter().try_for_each(|lit| {

--- a/pumpkin-crates/constraints/src/constraints/clause.rs
+++ b/pumpkin-crates/constraints/src/constraints/clause.rs
@@ -28,7 +28,7 @@ pub fn conjunction(
 struct Clause(Vec<Literal>, ConstraintTag);
 
 impl Constraint for Clause {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State)  {
         let Clause(clause, constraint_tag) = self;
 
         solver.add_clause(
@@ -39,9 +39,9 @@ impl Constraint for Clause {
 
     fn implied_by(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         let Clause(clause, constraint_tag) = self;
 
         solver.add_clause(
@@ -67,7 +67,7 @@ impl NegatableConstraint for Clause {
 struct Conjunction(Vec<Literal>, ConstraintTag);
 
 impl Constraint for Conjunction {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State)  {
         let Conjunction(conjunction, constraint_tag) = self;
 
         conjunction
@@ -77,9 +77,9 @@ impl Constraint for Conjunction {
 
     fn implied_by(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         let Conjunction(conjunction, constraint_tag) = self;
 
         conjunction.into_iter().try_for_each(|lit| {

--- a/pumpkin-crates/constraints/src/constraints/clause.rs
+++ b/pumpkin-crates/constraints/src/constraints/clause.rs
@@ -1,4 +1,3 @@
-use pumpkin_core::ConstraintOperationError;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::predicates::Predicate;

--- a/pumpkin-crates/constraints/src/constraints/clause.rs
+++ b/pumpkin-crates/constraints/src/constraints/clause.rs
@@ -2,6 +2,8 @@ use pumpkin_core::ConstraintOperationError;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::proof::ConstraintTag;
+use pumpkin_core::propagators::nogoods::NogoodPropagator;
+use pumpkin_core::state::PropagatorHandle;
 use pumpkin_core::state::State;
 use pumpkin_core::variables::Literal;
 
@@ -9,44 +11,72 @@ use pumpkin_core::variables::Literal;
 ///
 /// Its negation is `/\ !literal`
 pub fn clause(
-    literals: impl Into<Vec<Literal>>,
+    literals: impl IntoIterator<Item = Literal>,
     constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
 ) -> impl NegatableConstraint {
-    Clause(literals.into(), constraint_tag)
+    Clause {
+        literals: literals.into_iter().collect(),
+        constraint_tag,
+        propagator_handle,
+    }
 }
 
 /// Creates the [`NegatableConstraint`] `/\ literal`
 ///
 /// Its negation is `\/ !literal`
 pub fn conjunction(
-    literals: impl Into<Vec<Literal>>,
+    literals: impl IntoIterator<Item = Literal>,
     constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
 ) -> impl NegatableConstraint {
-    Conjunction(literals.into(), constraint_tag)
+    Conjunction {
+        literals: literals.into_iter().collect(),
+        constraint_tag,
+        propagator_handle,
+    }
 }
 
-struct Clause(Vec<Literal>, ConstraintTag);
+struct Clause {
+    literals: Vec<Literal>,
+    constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
+}
 
 impl Constraint for Clause {
     fn post(self, state: &mut State) {
-        let Clause(clause, constraint_tag) = self;
-
-        solver.add_clause(
-            clause.iter().map(|literal| literal.get_true_predicate()),
+        let Clause {
+            literals,
             constraint_tag,
-        )
+            propagator_handle,
+        } = self;
+
+        let propagator = state
+            .get_propagator_mut(propagator_handle)
+            .expect("handle does not point to existing nogood propagator");
+
+        // Since we are adding this constraint as a nogood, every literal is negated.
+        propagator.add_nogood(
+            literals.into_iter().map(|lit| lit.get_false_predicate()),
+            constraint_tag,
+        );
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
-        let Clause(clause, constraint_tag) = self;
-
-        solver.add_clause(
-            clause
-                .into_iter()
-                .chain(std::iter::once(!reification_literal))
-                .map(|literal| literal.get_true_predicate()),
+        let Clause {
+            literals,
             constraint_tag,
+            propagator_handle,
+        } = self;
+
+        clause(
+            literals
+                .into_iter()
+                .chain(std::iter::once(reification_literal)),
+            constraint_tag,
+            propagator_handle,
         )
+        .post(state)
     }
 }
 
@@ -54,35 +84,54 @@ impl NegatableConstraint for Clause {
     type NegatedConstraint = Conjunction;
 
     fn negation(&self) -> Self::NegatedConstraint {
-        let Clause(clause, constraint_tag) = self;
+        let Clause {
+            literals,
+            constraint_tag,
+            propagator_handle,
+        } = self;
 
-        Conjunction(clause.iter().map(|&lit| !lit).collect(), *constraint_tag)
+        Conjunction {
+            literals: literals.iter().map(|&lit| !lit).collect(),
+            constraint_tag: *constraint_tag,
+            propagator_handle: *propagator_handle,
+        }
     }
 }
 
-struct Conjunction(Vec<Literal>, ConstraintTag);
+struct Conjunction {
+    literals: Vec<Literal>,
+    constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
+}
 
 impl Constraint for Conjunction {
     fn post(self, state: &mut State) {
-        let Conjunction(conjunction, constraint_tag) = self;
+        let Conjunction {
+            literals,
+            constraint_tag,
+            propagator_handle,
+        } = self;
 
-        conjunction
-            .into_iter()
-            .try_for_each(|lit| solver.add_clause([lit.get_true_predicate()], constraint_tag))
+        for literal in literals {
+            clause([literal], constraint_tag, propagator_handle).post(state);
+        }
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
-        let Conjunction(conjunction, constraint_tag) = self;
+        let Conjunction {
+            literals,
+            constraint_tag,
+            propagator_handle,
+        } = self;
 
-        conjunction.into_iter().try_for_each(|lit| {
-            solver.add_clause(
-                [
-                    (!(reification_literal)).get_true_predicate(),
-                    lit.get_true_predicate(),
-                ],
+        for literal in literals {
+            clause(
+                [!reification_literal, literal],
                 constraint_tag,
+                propagator_handle,
             )
-        })
+            .post(state);
+        }
     }
 }
 
@@ -90,11 +139,16 @@ impl NegatableConstraint for Conjunction {
     type NegatedConstraint = Clause;
 
     fn negation(&self) -> Self::NegatedConstraint {
-        let Conjunction(conjunction, constraint_tag) = self;
+        let Conjunction {
+            literals,
+            constraint_tag,
+            propagator_handle,
+        } = self;
 
-        Clause(
-            conjunction.iter().map(|&lit| !lit).collect(),
-            *constraint_tag,
-        )
+        Clause {
+            literals: literals.iter().map(|&lit| !lit).collect(),
+            constraint_tag: *constraint_tag,
+            propagator_handle: *propagator_handle,
+        }
     }
 }

--- a/pumpkin-crates/constraints/src/constraints/cumulative.rs
+++ b/pumpkin-crates/constraints/src/constraints/cumulative.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 
-use pumpkin_core::ConstraintOperationError;
 use pumpkin_core::asserts::pumpkin_assert_simple;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::proof::ConstraintTag;

--- a/pumpkin-crates/constraints/src/constraints/cumulative.rs
+++ b/pumpkin-crates/constraints/src/constraints/cumulative.rs
@@ -174,7 +174,7 @@ impl<Var: IntegerVariable + 'static> CumulativeConstraint<Var> {
 }
 
 impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint<Var> {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State)  {
         match self.options.propagation_method {
             CumulativePropagationMethod::TimeTablePerPoint => TimeTablePerPointPropagator::new(
                 &self.tasks,
@@ -234,9 +234,9 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
 
     fn implied_by(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         match self.options.propagation_method {
             CumulativePropagationMethod::TimeTablePerPoint => TimeTablePerPointPropagator::new(
                 &self.tasks,

--- a/pumpkin-crates/constraints/src/constraints/cumulative.rs
+++ b/pumpkin-crates/constraints/src/constraints/cumulative.rs
@@ -1,10 +1,10 @@
 use std::fmt::Debug;
 
 use pumpkin_core::ConstraintOperationError;
-use pumpkin_core::Solver;
 use pumpkin_core::asserts::pumpkin_assert_simple;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::proof::ConstraintTag;
+use pumpkin_core::state::State;
 use pumpkin_core::variables::IntegerVariable;
 use pumpkin_core::variables::Literal;
 use pumpkin_propagators::cumulative::ArgTask;
@@ -39,7 +39,7 @@ use pumpkin_propagators::cumulative::time_table::TimeTablePerPointPropagator;
 /// // We can infer that Task 0 and Task 1 execute at the same time
 /// // while Task 2 will start after them
 /// # use pumpkin_core::termination::Indefinite;
-/// # use pumpkin_core::Solver;
+/// # use pumpkin_core::state::State;
 /// # use pumpkin_core::results::SatisfactionResult;
 /// # use pumpkin_core::constraints;
 /// # use pumpkin_core::constraints::Constraint;
@@ -174,7 +174,7 @@ impl<Var: IntegerVariable + 'static> CumulativeConstraint<Var> {
 }
 
 impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint<Var> {
-    fn post(self, state: &mut State)  {
+    fn post(self, state: &mut State) {
         match self.options.propagation_method {
             CumulativePropagationMethod::TimeTablePerPoint => TimeTablePerPointPropagator::new(
                 &self.tasks,
@@ -232,11 +232,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
         }
     }
 
-    fn implied_by(
-        self,
-        state: &mut State,
-        reification_literal: Literal,
-    )  {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         match self.options.propagation_method {
             CumulativePropagationMethod::TimeTablePerPoint => TimeTablePerPointPropagator::new(
                 &self.tasks,

--- a/pumpkin-crates/constraints/src/constraints/cumulative.rs
+++ b/pumpkin-crates/constraints/src/constraints/cumulative.rs
@@ -182,7 +182,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                 self.options.propagator_options,
                 self.constraint_tag,
             )
-            .post(solver),
+            .post(state),
 
             CumulativePropagationMethod::TimeTablePerPointIncremental => {
                 TimeTablePerPointIncrementalPropagator::<Var, false>::new(
@@ -191,7 +191,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .post(solver)
+                .post(state)
             }
             CumulativePropagationMethod::TimeTablePerPointIncrementalSynchronised => {
                 TimeTablePerPointIncrementalPropagator::<Var, true>::new(
@@ -200,7 +200,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .post(solver)
+                .post(state)
             }
             CumulativePropagationMethod::TimeTableOverInterval => {
                 TimeTableOverIntervalPropagator::new(
@@ -209,7 +209,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .post(solver)
+                .post(state)
             }
             CumulativePropagationMethod::TimeTableOverIntervalIncremental => {
                 TimeTableOverIntervalIncrementalPropagator::<Var, false>::new(
@@ -218,7 +218,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .post(solver)
+                .post(state)
             }
             CumulativePropagationMethod::TimeTableOverIntervalIncrementalSynchronised => {
                 TimeTableOverIntervalIncrementalPropagator::<Var, true>::new(
@@ -227,7 +227,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .post(solver)
+                .post(state)
             }
         }
     }
@@ -240,7 +240,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                 self.options.propagator_options,
                 self.constraint_tag,
             )
-            .implied_by(solver, reification_literal),
+            .implied_by(state, reification_literal),
             CumulativePropagationMethod::TimeTablePerPointIncremental => {
                 TimeTablePerPointIncrementalPropagator::<Var, false>::new(
                     &self.tasks,
@@ -248,7 +248,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .implied_by(solver, reification_literal)
+                .implied_by(state, reification_literal)
             }
             CumulativePropagationMethod::TimeTablePerPointIncrementalSynchronised => {
                 TimeTablePerPointIncrementalPropagator::<Var, true>::new(
@@ -257,7 +257,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .implied_by(solver, reification_literal)
+                .implied_by(state, reification_literal)
             }
             CumulativePropagationMethod::TimeTableOverInterval => {
                 TimeTableOverIntervalPropagator::new(
@@ -266,7 +266,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .implied_by(solver, reification_literal)
+                .implied_by(state, reification_literal)
             }
             CumulativePropagationMethod::TimeTableOverIntervalIncremental => {
                 TimeTableOverIntervalIncrementalPropagator::<Var, false>::new(
@@ -275,7 +275,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .implied_by(solver, reification_literal)
+                .implied_by(state, reification_literal)
             }
             CumulativePropagationMethod::TimeTableOverIntervalIncrementalSynchronised => {
                 TimeTableOverIntervalIncrementalPropagator::<Var, true>::new(
@@ -284,7 +284,7 @@ impl<Var: IntegerVariable + 'static + Debug> Constraint for CumulativeConstraint
                     self.options.propagator_options,
                     self.constraint_tag,
                 )
-                .implied_by(solver, reification_literal)
+                .implied_by(state, reification_literal)
             }
         }
     }

--- a/pumpkin-crates/constraints/src/constraints/cumulative.rs
+++ b/pumpkin-crates/constraints/src/constraints/cumulative.rs
@@ -38,7 +38,7 @@ use pumpkin_propagators::cumulative::time_table::TimeTablePerPointPropagator;
 /// // We can infer that Task 0 and Task 1 execute at the same time
 /// // while Task 2 will start after them
 /// # use pumpkin_core::termination::Indefinite;
-/// # use pumpkin_core::state::State;
+/// # use pumpkin_core::Solver;
 /// # use pumpkin_core::results::SatisfactionResult;
 /// # use pumpkin_core::constraints;
 /// # use pumpkin_core::constraints::Constraint;

--- a/pumpkin-crates/constraints/src/constraints/disjunctive_strict.rs
+++ b/pumpkin-crates/constraints/src/constraints/disjunctive_strict.rs
@@ -42,7 +42,7 @@ struct DisjunctiveConstraint<Var> {
 impl<Var: IntegerVariable + 'static> Constraint for DisjunctiveConstraint<Var> {
     fn post(self, state: &mut State) {
         // We post both the propagator on the lower-bound and the propagator on the upper-bound.
-        DisjunctiveConstructor::new(self.tasks.clone(), self.constraint_tag).post(solver)?;
+        DisjunctiveConstructor::new(self.tasks.clone(), self.constraint_tag).post(state);
         DisjunctiveConstructor::new(
             self.tasks.iter().map(|task| ArgDisjunctiveTask {
                 // The propagations on the upper-bound take place by "reversing" the tasks such
@@ -52,13 +52,13 @@ impl<Var: IntegerVariable + 'static> Constraint for DisjunctiveConstraint<Var> {
             }),
             self.constraint_tag,
         )
-        .post(solver)
+        .post(state)
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
         // We post both the propagator on the lower-bound and the propagator on the upper-bound.
         DisjunctiveConstructor::new(self.tasks.clone(), self.constraint_tag)
-            .implied_by(solver, reification_literal)?;
+            .implied_by(state, reification_literal);
         DisjunctiveConstructor::new(
             self.tasks.iter().map(|task| ArgDisjunctiveTask {
                 // The propagations on the upper-bound take place by "reversing" the tasks such
@@ -68,6 +68,6 @@ impl<Var: IntegerVariable + 'static> Constraint for DisjunctiveConstraint<Var> {
             }),
             self.constraint_tag,
         )
-        .implied_by(solver, reification_literal)
+        .implied_by(state, reification_literal)
     }
 }

--- a/pumpkin-crates/constraints/src/constraints/disjunctive_strict.rs
+++ b/pumpkin-crates/constraints/src/constraints/disjunctive_strict.rs
@@ -40,7 +40,7 @@ struct DisjunctiveConstraint<Var> {
 }
 
 impl<Var: IntegerVariable + 'static> Constraint for DisjunctiveConstraint<Var> {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State)  {
         // We post both the propagator on the lower-bound and the propagator on the upper-bound.
         DisjunctiveConstructor::new(self.tasks.clone(), self.constraint_tag).post(solver)?;
         DisjunctiveConstructor::new(
@@ -57,9 +57,9 @@ impl<Var: IntegerVariable + 'static> Constraint for DisjunctiveConstraint<Var> {
 
     fn implied_by(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         // We post both the propagator on the lower-bound and the propagator on the upper-bound.
         DisjunctiveConstructor::new(self.tasks.clone(), self.constraint_tag)
             .implied_by(solver, reification_literal)?;

--- a/pumpkin-crates/constraints/src/constraints/disjunctive_strict.rs
+++ b/pumpkin-crates/constraints/src/constraints/disjunctive_strict.rs
@@ -1,4 +1,3 @@
-use pumpkin_core::ConstraintOperationError;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::proof::ConstraintTag;
 use pumpkin_core::state::State;

--- a/pumpkin-crates/constraints/src/constraints/disjunctive_strict.rs
+++ b/pumpkin-crates/constraints/src/constraints/disjunctive_strict.rs
@@ -1,7 +1,7 @@
 use pumpkin_core::ConstraintOperationError;
-use pumpkin_core::Solver;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::proof::ConstraintTag;
+use pumpkin_core::state::State;
 use pumpkin_core::variables::IntegerVariable;
 use pumpkin_core::variables::Literal;
 use pumpkin_core::variables::TransformableVariable;
@@ -40,7 +40,7 @@ struct DisjunctiveConstraint<Var> {
 }
 
 impl<Var: IntegerVariable + 'static> Constraint for DisjunctiveConstraint<Var> {
-    fn post(self, state: &mut State)  {
+    fn post(self, state: &mut State) {
         // We post both the propagator on the lower-bound and the propagator on the upper-bound.
         DisjunctiveConstructor::new(self.tasks.clone(), self.constraint_tag).post(solver)?;
         DisjunctiveConstructor::new(
@@ -55,11 +55,7 @@ impl<Var: IntegerVariable + 'static> Constraint for DisjunctiveConstraint<Var> {
         .post(solver)
     }
 
-    fn implied_by(
-        self,
-        state: &mut State,
-        reification_literal: Literal,
-    )  {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         // We post both the propagator on the lower-bound and the propagator on the upper-bound.
         DisjunctiveConstructor::new(self.tasks.clone(), self.constraint_tag)
             .implied_by(solver, reification_literal)?;

--- a/pumpkin-crates/constraints/src/constraints/mod.rs
+++ b/pumpkin-crates/constraints/src/constraints/mod.rs
@@ -7,7 +7,7 @@
 //! # Example
 //! ```
 //! # use pumpkin_core::constraints;
-//! # use pumpkin_core::Solver;
+//! # use pumpkin_core::state::State;
 //! let mut solver = Solver::default();
 //!
 //! let a = solver.new_bounded_integer(0, 3);

--- a/pumpkin-crates/constraints/src/constraints/mod.rs
+++ b/pumpkin-crates/constraints/src/constraints/mod.rs
@@ -7,7 +7,7 @@
 //! # Example
 //! ```
 //! # use pumpkin_core::constraints;
-//! # use pumpkin_core::state::State;
+//! # use pumpkin_core::Solver;
 //! let mut solver = Solver::default();
 //!
 //! let a = solver.new_bounded_integer(0, 3);
@@ -17,7 +17,12 @@
 //! let constraint_tag = solver.new_constraint_tag();
 //!
 //! solver
-//!     .add_constraint(pumpkin_constraints::equals([a, b], 0, constraint_tag))
+//!     .add_constraint(pumpkin_constraints::equals(
+//!         [a, b],
+//!         0,
+//!         constraint_tag,
+//!         pumpkin_constraints::EqualityConsistency::Bound,
+//!     ))
 //!     .post();
 //! ```
 //!

--- a/pumpkin-crates/constraints/src/constraints/table.rs
+++ b/pumpkin-crates/constraints/src/constraints/table.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
 use pumpkin_core::ConstraintOperationError;
-use pumpkin_core::Solver;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::predicate;
 use pumpkin_core::proof::ConstraintTag;
+use pumpkin_core::state::State;
 use pumpkin_core::variables::IntegerVariable;
 use pumpkin_core::variables::Literal;
 
@@ -62,11 +62,7 @@ struct Table<Var> {
 }
 
 impl<Var: IntegerVariable> Table<Var> {
-    fn encode(
-        self,
-        state: &mut State,
-        reification_literal: Option<Literal>,
-    )  {
+    fn encode(self, state: &mut State, reification_literal: Option<Literal>) {
         // 1. Create a variable `y_i` that selects the row from the table which is chosen.
         let ys: Vec<_> = (0..self.table.len())
             .map(|_| solver.new_literal())
@@ -116,21 +112,15 @@ impl<Var: IntegerVariable> Table<Var> {
         } else {
             poster.post()?;
         }
-
-        Ok(())
     }
 }
 
 impl<Var: IntegerVariable> Constraint for Table<Var> {
-    fn post(self, state: &mut State)  {
+    fn post(self, state: &mut State) {
         self.encode(solver, None)
     }
 
-    fn implied_by(
-        self,
-        state: &mut State,
-        reification_literal: Literal,
-    )  {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         self.encode(solver, Some(reification_literal))
     }
 }
@@ -158,7 +148,7 @@ struct NegativeTable<Var> {
 }
 
 impl<Var: IntegerVariable> Constraint for NegativeTable<Var> {
-    fn post(self, state: &mut State)  {
+    fn post(self, state: &mut State) {
         for row in self.table {
             let clause: Vec<_> = self
                 .xs
@@ -169,15 +159,9 @@ impl<Var: IntegerVariable> Constraint for NegativeTable<Var> {
 
             solver.add_clause(clause, self.constraint_tag)?;
         }
-
-        Ok(())
     }
 
-    fn implied_by(
-        self,
-        state: &mut State,
-        reification_literal: Literal,
-    )  {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         for row in self.table {
             let clause: Vec<_> = self
                 .xs
@@ -189,8 +173,6 @@ impl<Var: IntegerVariable> Constraint for NegativeTable<Var> {
 
             solver.add_clause(clause, self.constraint_tag)?;
         }
-
-        Ok(())
     }
 }
 

--- a/pumpkin-crates/constraints/src/constraints/table.rs
+++ b/pumpkin-crates/constraints/src/constraints/table.rs
@@ -94,7 +94,7 @@ impl<Var: IntegerVariable> Table<Var> {
                     // l -> clause
                     clause.extend(reification_literal.iter().map(|l| l.get_false_predicate()));
 
-                    solver.add_clause(clause, self.constraint_tag)?;
+                    solver.add_clause(clause, self.constraint_tag);
                 }
 
                 // `condition -> (\/ supports)`
@@ -108,9 +108,9 @@ impl<Var: IntegerVariable> Table<Var> {
         // 4. Enforce at least one `y` to be true.
         let poster = solver.add_constraint(crate::constraints::clause(ys, self.constraint_tag));
         if let Some(literal) = reification_literal {
-            poster.implied_by(literal)?;
+            poster.implied_by(literal);
         } else {
-            poster.post()?;
+            poster.post();
         }
     }
 }
@@ -157,7 +157,7 @@ impl<Var: IntegerVariable> Constraint for NegativeTable<Var> {
                 .map(|(x, value)| predicate![x != value])
                 .collect();
 
-            solver.add_clause(clause, self.constraint_tag)?;
+            solver.add_clause(clause, self.constraint_tag);
         }
     }
 
@@ -171,7 +171,7 @@ impl<Var: IntegerVariable> Constraint for NegativeTable<Var> {
                 .chain(std::iter::once(reification_literal.get_false_predicate()))
                 .collect();
 
-            solver.add_clause(clause, self.constraint_tag)?;
+            solver.add_clause(clause, self.constraint_tag);
         }
     }
 }

--- a/pumpkin-crates/constraints/src/constraints/table.rs
+++ b/pumpkin-crates/constraints/src/constraints/table.rs
@@ -5,9 +5,13 @@ use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::predicate;
 use pumpkin_core::proof::ConstraintTag;
+use pumpkin_core::propagators::nogoods::NogoodPropagator;
+use pumpkin_core::state::PropagatorHandle;
 use pumpkin_core::state::State;
 use pumpkin_core::variables::IntegerVariable;
 use pumpkin_core::variables::Literal;
+
+use crate::clause;
 
 /// Create the [table](https://sofdem.github.io/gccat/gccat/Cin_relation.html#uid22830) [`NegatableConstraint`].
 ///
@@ -24,11 +28,13 @@ pub fn table<Var: IntegerVariable + 'static>(
     xs: impl IntoIterator<Item = Var>,
     table: Vec<Vec<i32>>,
     constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
 ) -> impl NegatableConstraint {
     Table {
         xs: xs.into_iter().collect(),
         table,
         constraint_tag,
+        propagator_handle,
     }
 }
 
@@ -47,11 +53,13 @@ pub fn negative_table<Var: IntegerVariable + 'static>(
     xs: impl IntoIterator<Item = Var>,
     table: Vec<Vec<i32>>,
     constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
 ) -> impl NegatableConstraint {
     NegativeTable {
         xs: xs.into_iter().collect(),
         table,
         constraint_tag,
+        propagator_handle,
     }
 }
 
@@ -59,13 +67,14 @@ struct Table<Var> {
     xs: Vec<Var>,
     table: Vec<Vec<i32>>,
     constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
 }
 
 impl<Var: IntegerVariable> Table<Var> {
     fn encode(self, state: &mut State, reification_literal: Option<Literal>) {
         // 1. Create a variable `y_i` that selects the row from the table which is chosen.
         let ys: Vec<_> = (0..self.table.len())
-            .map(|_| solver.new_literal())
+            .map(|_| state.new_literal(None))
             .collect();
 
         // 2. Setup the implications between values and `ys`.
@@ -88,13 +97,13 @@ impl<Var: IntegerVariable> Table<Var> {
 
                 // For every `support in supports`: `support -> condition`
                 for support in supports.iter() {
-                    let mut clause = vec![support.get_false_predicate(), condition];
+                    let mut predicates = vec![support.get_false_predicate(), condition];
 
                     // Account for possible reification.
                     // l -> clause
-                    clause.extend(reification_literal.iter().map(|l| l.get_false_predicate()));
+                    predicates.extend(reification_literal.iter().map(|l| l.get_false_predicate()));
 
-                    solver.add_clause(clause, self.constraint_tag);
+                    clause(predicates, self.constraint_tag, self.propagator_handle).post(state);
                 }
 
                 // `condition -> (\/ supports)`
@@ -106,22 +115,27 @@ impl<Var: IntegerVariable> Table<Var> {
         }
 
         // 4. Enforce at least one `y` to be true.
-        let poster = solver.add_constraint(crate::constraints::clause(ys, self.constraint_tag));
+        let constraint = clause(
+            ys.into_iter().map(|y| y.get_true_predicate()),
+            self.constraint_tag,
+            self.propagator_handle,
+        );
+
         if let Some(literal) = reification_literal {
-            poster.implied_by(literal);
+            constraint.implied_by(state, literal);
         } else {
-            poster.post();
+            constraint.post(state);
         }
     }
 }
 
 impl<Var: IntegerVariable> Constraint for Table<Var> {
     fn post(self, state: &mut State) {
-        self.encode(solver, None)
+        self.encode(state, None)
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
-        self.encode(solver, Some(reification_literal))
+        self.encode(state, Some(reification_literal))
     }
 }
 
@@ -132,11 +146,13 @@ impl<Var: IntegerVariable + 'static> NegatableConstraint for Table<Var> {
         let xs = self.xs.clone();
         let table = self.table.clone();
         let constraint_tag = self.constraint_tag;
+        let propagator_handle = self.propagator_handle;
 
         NegativeTable {
             xs,
             table,
             constraint_tag,
+            propagator_handle,
         }
     }
 }
@@ -145,25 +161,26 @@ struct NegativeTable<Var> {
     xs: Vec<Var>,
     table: Vec<Vec<i32>>,
     constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
 }
 
 impl<Var: IntegerVariable> Constraint for NegativeTable<Var> {
     fn post(self, state: &mut State) {
         for row in self.table {
-            let clause: Vec<_> = self
+            let literals: Vec<_> = self
                 .xs
                 .iter()
                 .zip(row)
                 .map(|(x, value)| predicate![x != value])
                 .collect();
 
-            solver.add_clause(clause, self.constraint_tag);
+            clause(literals, self.constraint_tag, self.propagator_handle).post(state);
         }
     }
 
     fn implied_by(self, state: &mut State, reification_literal: Literal) {
         for row in self.table {
-            let clause: Vec<_> = self
+            let literals: Vec<_> = self
                 .xs
                 .iter()
                 .zip(row)
@@ -171,7 +188,7 @@ impl<Var: IntegerVariable> Constraint for NegativeTable<Var> {
                 .chain(std::iter::once(reification_literal.get_false_predicate()))
                 .collect();
 
-            solver.add_clause(clause, self.constraint_tag);
+            clause(literals, self.constraint_tag, self.propagator_handle).post(state);
         }
     }
 }
@@ -183,11 +200,13 @@ impl<Var: IntegerVariable + 'static> NegatableConstraint for NegativeTable<Var> 
         let xs = self.xs.clone();
         let table = self.table.clone();
         let constraint_tag = self.constraint_tag;
+        let propagator_handle = self.propagator_handle;
 
         Table {
             xs,
             table,
             constraint_tag,
+            propagator_handle,
         }
     }
 }

--- a/pumpkin-crates/constraints/src/constraints/table.rs
+++ b/pumpkin-crates/constraints/src/constraints/table.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use pumpkin_core::ConstraintOperationError;
 use pumpkin_core::constraints::Constraint;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_core::predicate;

--- a/pumpkin-crates/constraints/src/constraints/table.rs
+++ b/pumpkin-crates/constraints/src/constraints/table.rs
@@ -64,9 +64,9 @@ struct Table<Var> {
 impl<Var: IntegerVariable> Table<Var> {
     fn encode(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Option<Literal>,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         // 1. Create a variable `y_i` that selects the row from the table which is chosen.
         let ys: Vec<_> = (0..self.table.len())
             .map(|_| solver.new_literal())
@@ -122,15 +122,15 @@ impl<Var: IntegerVariable> Table<Var> {
 }
 
 impl<Var: IntegerVariable> Constraint for Table<Var> {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State)  {
         self.encode(solver, None)
     }
 
     fn implied_by(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         self.encode(solver, Some(reification_literal))
     }
 }
@@ -158,7 +158,7 @@ struct NegativeTable<Var> {
 }
 
 impl<Var: IntegerVariable> Constraint for NegativeTable<Var> {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
+    fn post(self, state: &mut State)  {
         for row in self.table {
             let clause: Vec<_> = self
                 .xs
@@ -175,9 +175,9 @@ impl<Var: IntegerVariable> Constraint for NegativeTable<Var> {
 
     fn implied_by(
         self,
-        solver: &mut Solver,
+        state: &mut State,
         reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    )  {
         for row in self.table {
             let clause: Vec<_> = self
                 .xs

--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -161,6 +161,11 @@ impl Solver {
     pub fn state(&self) -> &State {
         &self.satisfaction_solver.state
     }
+
+    /// The nogood propagator used to propagate learned nogoods.
+    pub fn nogood_propagator_handle(&self) -> PropagatorHandle<NogoodPropagator> {
+        self.satisfaction_solver.nogood_propagator_handle
+    }
 }
 
 /// Methods to retrieve information about variables

--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -126,6 +126,7 @@ impl Solver {
     ///
     /// If the state is inconsistent after calling propagate, then it is returned as the error
     /// variant.
+    #[allow(clippy::result_large_err, reason = "we want the original state back")]
     pub fn from_state(
         solver_options: SolverOptions,
         state: State,

--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -39,6 +39,7 @@ use crate::propagation::PropagatorConstructor;
 pub use crate::propagation::store::PropagatorHandle;
 use crate::results::solution_iterator::SolutionIterator;
 use crate::results::unsatisfiable::UnsatisfiableUnderAssumptions;
+use crate::state::State;
 use crate::statistics::StatisticLogger;
 use crate::statistics::log_statistic;
 use crate::statistics::log_statistic_postfix;
@@ -113,7 +114,12 @@ impl Default for Solver {
 impl Solver {
     /// Creates a solver with the provided [`SolverOptions`].
     pub fn with_options(solver_options: SolverOptions) -> Self {
-        let satisfaction_solver = ConstraintSatisfactionSolver::new(solver_options);
+        Solver::from_state(solver_options, State::default())
+    }
+
+    /// Create a new solver based on a given state.
+    pub fn from_state(solver_options: SolverOptions, state: State) -> Self {
+        let satisfaction_solver = ConstraintSatisfactionSolver::from_state(solver_options, state);
         let true_literal = Literal::new(Predicate::trivially_true().get_domain());
         Self {
             satisfaction_solver,

--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -5,6 +5,7 @@ use super::results::SatisfactionResult;
 use super::results::SatisfactionResultUnderAssumptions;
 use crate::basic_types::CSPSolverExecutionFlag;
 use crate::basic_types::ConstraintOperationError;
+use crate::basic_types::PredicateId;
 use crate::basic_types::Solution;
 use crate::branching::Brancher;
 use crate::branching::branchers::autonomous_search::AutonomousSearch;
@@ -37,6 +38,8 @@ use crate::predicates;
 use crate::proof::ConstraintTag;
 use crate::propagation::PropagatorConstructor;
 pub use crate::propagation::store::PropagatorHandle;
+use crate::propagators::nogoods::NogoodPropagator;
+use crate::propagators::nogoods::NogoodPropagatorConstructor;
 use crate::results::solution_iterator::SolutionIterator;
 use crate::results::unsatisfiable::UnsatisfiableUnderAssumptions;
 use crate::state::State;
@@ -97,16 +100,13 @@ use crate::statistics::log_statistic_postfix;
 pub struct Solver {
     /// The internal [`ConstraintSatisfactionSolver`] which is used to solve the problems.
     pub(crate) satisfaction_solver: ConstraintSatisfactionSolver,
-    true_literal: Literal,
 }
 
 impl Default for Solver {
     fn default() -> Self {
         let satisfaction_solver = ConstraintSatisfactionSolver::default();
-        let true_literal = Literal::new(Predicate::trivially_true().get_domain());
         Self {
             satisfaction_solver,
-            true_literal,
         }
     }
 }
@@ -114,44 +114,40 @@ impl Default for Solver {
 impl Solver {
     /// Creates a solver with the provided [`SolverOptions`].
     pub fn with_options(solver_options: SolverOptions) -> Self {
-        Solver::from_state(solver_options, State::default())
+        let mut state = State::default();
+
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::new(
+            (solver_options.memory_preallocated * 1_000_000) / size_of::<PredicateId>(),
+            solver_options.learning_options,
+        ));
+
+        Solver::from_state(solver_options, state, nogood_propagator_handle)
+            .expect("no propagation happens")
     }
 
     /// Create a new solver based on a given state.
-    pub fn from_state(solver_options: SolverOptions, state: State) -> Self {
-        let satisfaction_solver = ConstraintSatisfactionSolver::from_state(solver_options, state);
-        let true_literal = Literal::new(Predicate::trivially_true().get_domain());
-        Self {
-            satisfaction_solver,
-            true_literal,
-        }
-    }
+    ///
+    /// If the state is inconsistent after calling propagate, then it is returned as the error
+    /// variant.
+    pub fn from_state(
+        solver_options: SolverOptions,
+        state: State,
+        nogood_propagator_handle: PropagatorHandle<NogoodPropagator>,
+    ) -> Result<Self, State> {
+        let satisfaction_solver = ConstraintSatisfactionSolver::from_state(
+            solver_options,
+            state,
+            nogood_propagator_handle,
+        )?;
 
-    /// Logs the statistics currently present in the solver with the provided objective value.
-    pub fn log_statistics_with_objective(
-        &self,
-        brancher: &impl Brancher,
-        resolver: &impl ConflictResolver,
-        objective_value: i64,
-        verbose: bool,
-    ) {
-        log_statistic("objective", objective_value);
-        self.log_statistics(brancher, resolver, verbose);
+        Ok(Self {
+            satisfaction_solver,
+        })
     }
 
     /// Logs the statistics currently present in the solver.
-    pub fn log_statistics(
-        &self,
-        brancher: &impl Brancher,
-        resolver: &impl ConflictResolver,
-        verbose: bool,
-    ) {
+    pub fn log_statistics(&self, verbose: bool) {
         self.satisfaction_solver.log_statistics(verbose);
-        resolver.log_statistics(StatisticLogger::default());
-        if verbose {
-            brancher.log_statistics(StatisticLogger::default());
-        }
-        log_statistic_postfix();
     }
 
     pub fn get_solution_reference(&self) -> SolutionReference<'_> {
@@ -160,6 +156,10 @@ impl Solver {
 
     pub fn is_logging_proof(&self) -> bool {
         self.satisfaction_solver.is_logging_proof()
+    }
+
+    pub fn state(&self) -> &State {
+        &self.satisfaction_solver.state
     }
 }
 
@@ -263,12 +263,12 @@ impl Solver {
 
     /// Get a literal which is always true.
     pub fn get_true_literal(&self) -> Literal {
-        self.true_literal
+        Literal::trivially_true()
     }
 
     /// Get a literal which is always false.
     pub fn get_false_literal(&self) -> Literal {
-        !self.true_literal
+        Literal::trivially_false()
     }
 
     /// Create a new integer variable with the given bounds.
@@ -565,14 +565,6 @@ impl Solver {
         Constructor::PropagatorImpl: 'static,
     {
         self.satisfaction_solver.add_propagator(constructor)
-    }
-}
-
-/// Default brancher implementation
-impl Solver {
-    /// Creates an instance of the [`DefaultBrancher`].
-    pub fn default_brancher(&self) -> DefaultBrancher {
-        DefaultBrancher::default_over_all_variables(self.satisfaction_solver.assignments())
     }
 }
 

--- a/pumpkin-crates/core/src/api/solver.rs
+++ b/pumpkin-crates/core/src/api/solver.rs
@@ -43,9 +43,6 @@ use crate::propagators::nogoods::NogoodPropagatorConstructor;
 use crate::results::solution_iterator::SolutionIterator;
 use crate::results::unsatisfiable::UnsatisfiableUnderAssumptions;
 use crate::state::State;
-use crate::statistics::StatisticLogger;
-use crate::statistics::log_statistic;
-use crate::statistics::log_statistic_postfix;
 
 /// The main interaction point which allows the creation of variables, the addition of constraints,
 /// and solving problems.

--- a/pumpkin-crates/core/src/branching/branchers/alternating/alternating_brancher.rs
+++ b/pumpkin-crates/core/src/branching/branchers/alternating/alternating_brancher.rs
@@ -11,6 +11,7 @@ use crate::branching::brancher::BrancherEvent;
 use crate::branching::branchers::alternating::strategies::AlternatingStrategy;
 use crate::engine::predicates::predicate::Predicate;
 use crate::engine::variables::DomainId;
+use crate::state::State;
 use crate::statistics::StatisticLogger;
 
 /// A [`Brancher`] which switches between its provided brancher and [`DefaultBrancher`] based on the
@@ -34,10 +35,10 @@ pub struct AlternatingBrancher<OtherBrancher, Strategy> {
 impl<Strategy: AlternatingStrategy, OtherBrancher: Brancher>
     AlternatingBrancher<OtherBrancher, Strategy>
 {
-    pub fn new(solver: &Solver, other_brancher: OtherBrancher, strategy: Strategy) -> Self {
+    pub fn new(state: &State, other_brancher: OtherBrancher, strategy: Strategy) -> Self {
         Self {
             other_brancher,
-            default_brancher: solver.default_brancher(),
+            default_brancher: DefaultBrancher::default_over_all_variables(state),
             strategy,
         }
     }

--- a/pumpkin-crates/core/src/branching/branchers/alternating/alternating_brancher.rs
+++ b/pumpkin-crates/core/src/branching/branchers/alternating/alternating_brancher.rs
@@ -3,7 +3,6 @@
 
 use super::BrancherToUse;
 use crate::DefaultBrancher;
-use crate::Solver;
 use crate::basic_types::SolutionReference;
 use crate::branching::Brancher;
 use crate::branching::SelectionContext;

--- a/pumpkin-crates/core/src/branching/branchers/alternating/strategies/every_x_restarts.rs
+++ b/pumpkin-crates/core/src/branching/branchers/alternating/strategies/every_x_restarts.rs
@@ -82,40 +82,42 @@ impl AlternatingStrategy for EveryXRestarts {
 
 #[cfg(test)]
 mod tests {
-    use crate::Solver;
+    use crate::DefaultBrancher;
     use crate::basic_types::tests::TestRandom;
     use crate::branching::Brancher;
     use crate::branching::SelectionContext;
     use crate::branching::branchers::alternating::alternating_brancher::AlternatingBrancher;
     use crate::branching::branchers::alternating::every_x_restarts::EveryXRestarts;
-    use crate::engine::Assignments;
+    use crate::state::State;
 
     #[test]
     fn test_every_restart() {
-        let assignments = Assignments::default();
-        let solver = Solver::default();
-        let mut brancher =
-            AlternatingBrancher::new(&solver, solver.default_brancher(), EveryXRestarts::new(1));
+        let state = State::default();
+        let mut brancher = AlternatingBrancher::new(
+            &state,
+            DefaultBrancher::default_over_all_variables(&state),
+            EveryXRestarts::new(1),
+        );
 
         assert!(!brancher.is_using_default_brancher());
         brancher.on_restart();
         // next_decision is called to ensure that the brancher has actually switched
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(!brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
 
@@ -124,31 +126,33 @@ mod tests {
 
     #[test]
     fn test_every_other_restart() {
-        let assignments = Assignments::default();
-        let solver = Solver::default();
-        let mut brancher =
-            AlternatingBrancher::new(&solver, solver.default_brancher(), EveryXRestarts::new(2));
+        let state = State::default();
+        let mut brancher = AlternatingBrancher::new(
+            &state,
+            DefaultBrancher::default_over_all_variables(&state),
+            EveryXRestarts::new(2),
+        );
 
         assert!(!brancher.is_using_default_brancher());
 
         brancher.on_restart();
         // next_decision is called to ensure that the brancher has actually switched
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(!brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
 
@@ -156,7 +160,7 @@ mod tests {
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
 
@@ -164,7 +168,7 @@ mod tests {
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
 

--- a/pumpkin-crates/core/src/branching/branchers/alternating/strategies/every_x_solutions.rs
+++ b/pumpkin-crates/core/src/branching/branchers/alternating/strategies/every_x_solutions.rs
@@ -52,21 +52,23 @@ impl AlternatingStrategy for EveryXSolutions {
 
 #[cfg(test)]
 mod tests {
-    use crate::Solver;
+    use crate::DefaultBrancher;
     use crate::branching::Brancher;
     use crate::branching::branchers::alternating::alternating_brancher::AlternatingBrancher;
     use crate::branching::branchers::alternating::strategies::every_x_solutions::EveryXSolutions;
-    use crate::engine::Assignments;
     use crate::results::SolutionReference;
+    use crate::state::State;
 
     #[test]
     fn test_every_other_solution() {
-        let solver = Solver::default();
-        let mut brancher =
-            AlternatingBrancher::new(&solver, solver.default_brancher(), EveryXSolutions::new(2));
+        let state = State::default();
+        let mut brancher = AlternatingBrancher::new(
+            &state,
+            DefaultBrancher::default_over_all_variables(&state),
+            EveryXSolutions::new(2),
+        );
 
-        let assignments = Assignments::default();
-        let empty_solution_reference = SolutionReference::new(&assignments);
+        let empty_solution_reference = SolutionReference::new(&state.assignments);
 
         assert!(!brancher.is_using_default_brancher());
         brancher.on_solution(empty_solution_reference);

--- a/pumpkin-crates/core/src/branching/branchers/alternating/strategies/until_solution.rs
+++ b/pumpkin-crates/core/src/branching/branchers/alternating/strategies/until_solution.rs
@@ -84,7 +84,7 @@ impl<Strategy: AlternatingStrategy> AlternatingStrategy for UntilSolution<Strate
 
 #[cfg(test)]
 mod tests {
-    use crate::Solver;
+    use crate::DefaultBrancher;
     use crate::basic_types::tests::TestRandom;
     use crate::branching::Brancher;
     use crate::branching::SelectionContext;
@@ -92,21 +92,19 @@ mod tests {
     use crate::branching::branchers::alternating::every_x_restarts::EveryXRestarts;
     use crate::branching::branchers::alternating::other_only::OtherOnly;
     use crate::branching::branchers::alternating::until_solution::UntilSolution;
-    use crate::engine::Assignments;
-    use crate::results::Solution;
     use crate::results::SolutionReference;
+    use crate::state::State;
 
     #[test]
     fn test_switch_to_default_after_first_solution() {
-        let solver = Solver::default();
+        let state = State::default();
         let mut brancher = AlternatingBrancher::new(
-            &solver,
-            solver.default_brancher(),
+            &state,
+            DefaultBrancher::default_over_all_variables(&state),
             UntilSolution::new(OtherOnly),
         );
 
-        let assignments = Assignments::default();
-        let empty_solution_reference = SolutionReference::new(&assignments);
+        let empty_solution_reference = SolutionReference::new(&state.assignments);
 
         assert!(!brancher.is_using_default_brancher());
         brancher.on_solution(empty_solution_reference);
@@ -119,11 +117,10 @@ mod tests {
 
     #[test]
     fn test_switch_after_first_solution() {
-        let assignments = Assignments::default();
-        let solver = Solver::default();
+        let state = State::default();
         let mut brancher = AlternatingBrancher::new(
-            &solver,
-            solver.default_brancher(),
+            &state,
+            DefaultBrancher::default_over_all_variables(&state),
             UntilSolution::new(OtherOnly),
         );
 
@@ -131,42 +128,42 @@ mod tests {
         brancher.on_restart();
         // next_decision is called to ensure that the brancher has actually switched
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(!brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(!brancher.is_using_default_brancher());
 
-        brancher.on_solution(Solution::from(assignments.clone()).as_reference());
+        brancher.on_solution(SolutionReference::new(&state.assignments));
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
 
-        brancher.on_solution(Solution::from(assignments.clone()).as_reference());
+        brancher.on_solution(SolutionReference::new(&state.assignments));
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
@@ -174,11 +171,10 @@ mod tests {
 
     #[test]
     fn test_every_restart_until_first_solution() {
-        let assignments = Assignments::default();
-        let solver = Solver::default();
+        let state = State::default();
         let mut brancher = AlternatingBrancher::new(
-            &solver,
-            solver.default_brancher(),
+            &state,
+            DefaultBrancher::default_over_all_variables(&state),
             UntilSolution::new(EveryXRestarts::new(1)),
         );
 
@@ -186,42 +182,42 @@ mod tests {
         brancher.on_restart();
         // next_decision is called to ensure that the brancher has actually switched
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(!brancher.is_using_default_brancher());
 
-        brancher.on_solution(Solution::from(assignments.clone()).as_reference());
+        brancher.on_solution(SolutionReference::new(&state.assignments));
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
 
         brancher.on_restart();
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());
 
-        brancher.on_solution(Solution::from(assignments.clone()).as_reference());
+        brancher.on_solution(SolutionReference::new(&state.assignments));
         let _ = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(brancher.is_using_default_brancher());

--- a/pumpkin-crates/core/src/branching/branchers/autonomous_search.rs
+++ b/pumpkin-crates/core/src/branching/branchers/autonomous_search.rs
@@ -15,6 +15,7 @@ use crate::engine::Assignments;
 use crate::engine::predicates::predicate::Predicate;
 use crate::propagation::ReadDomains;
 use crate::results::Solution;
+use crate::state::State;
 use crate::statistics::Statistic;
 use crate::statistics::StatisticLogger;
 use crate::statistics::moving_averages::CumulativeMovingAverage;
@@ -119,7 +120,7 @@ impl DefaultBrancher {
     ///
     /// If there are no more predicates left to select, this [`Brancher`] switches to
     /// [`RandomSelector`] with [`RandomSplitter`].
-    pub fn default_over_all_variables(assignments: &Assignments) -> DefaultBrancher {
+    pub fn default_over_all_variables(state: &State) -> DefaultBrancher {
         AutonomousSearch {
             predicate_id_info: DeletablePredicateIdGenerator::default(),
             heap: KeyValueHeap::default(),
@@ -130,7 +131,7 @@ impl DefaultBrancher {
             best_known_solution: None,
             should_synchronise: false,
             backup_brancher: IndependentVariableValueBrancher::new(
-                RandomSelector::new(assignments.get_domains()),
+                RandomSelector::new(state.assignments.get_domains()),
                 RandomSplitter,
             ),
             statistics: Default::default(),

--- a/pumpkin-crates/core/src/branching/branchers/autonomous_search.rs
+++ b/pumpkin-crates/core/src/branching/branchers/autonomous_search.rs
@@ -11,7 +11,6 @@ use crate::branching::variable_selection::RandomSelector;
 use crate::containers::KeyValueHeap;
 use crate::containers::StorageKey;
 use crate::create_statistics_struct;
-use crate::engine::Assignments;
 use crate::engine::predicates::predicate::Predicate;
 use crate::propagation::ReadDomains;
 use crate::results::Solution;
@@ -359,18 +358,17 @@ mod tests {
     use crate::basic_types::tests::TestRandom;
     use crate::branching::Brancher;
     use crate::branching::SelectionContext;
-    use crate::engine::Assignments;
-    use crate::engine::notifications::NotificationEngine;
     use crate::predicate;
     use crate::results::SolutionReference;
+    use crate::state::State;
 
     #[test]
     fn brancher_picks_bumped_values() {
-        let mut assignments = Assignments::default();
-        let x = assignments.grow(0, 10);
-        let y = assignments.grow(-10, 0);
+        let mut state = State::default();
+        let x = state.new_interval_variable(0, 10, None);
+        let y = state.new_interval_variable(-10, 0, None);
 
-        let mut brancher = AutonomousSearch::default_over_all_variables(&assignments);
+        let mut brancher = AutonomousSearch::default_over_all_variables(&state);
         brancher.on_appearance_in_conflict_predicate(predicate!(x >= 5));
         brancher.on_appearance_in_conflict_predicate(predicate!(x >= 5));
         brancher.on_appearance_in_conflict_predicate(predicate!(y >= -5));
@@ -380,60 +378,59 @@ mod tests {
 
     #[test]
     fn dormant_values() {
-        let mut notification_engine = NotificationEngine::default();
-        let mut assignments = Assignments::default();
-        let x = assignments.grow(0, 10);
-        notification_engine.grow();
+        let mut state = State::default();
+        let x = state.new_interval_variable(0, 10, None);
 
-        let mut brancher = AutonomousSearch::default_over_all_variables(&assignments);
+        let mut brancher = AutonomousSearch::default_over_all_variables(&state);
 
         let predicate = predicate!(x >= 5);
         brancher.on_appearance_in_conflict_predicate(predicate);
         let decision = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert_eq!(decision, Some(predicate));
 
-        assignments.new_checkpoint();
+        state.new_checkpoint();
+
         // Decision Level 1
-        let _ = assignments.post_predicate(predicate!(x >= 5), None, &mut notification_engine);
+        let _ = state.post(predicate!(x >= 5)).expect("no conflict");
 
-        assignments.new_checkpoint();
+        state.new_checkpoint();
         // Decision Level 2
-        let _ = assignments.post_predicate(predicate!(x >= 7), None, &mut notification_engine);
+        let _ = state.post(predicate!(x >= 7)).expect("no conflict");
 
-        assignments.new_checkpoint();
+        state.new_checkpoint();
         // Decision Level 3
-        let _ = assignments.post_predicate(predicate!(x >= 10), None, &mut notification_engine);
+        let _ = state.post(predicate!(x >= 10)).expect("no conflict");
 
-        assignments.new_checkpoint();
+        state.new_checkpoint();
         // We end at decision level 4
 
         let decision = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(decision.is_none());
         assert!(brancher.dormant_predicates.contains(&predicate));
 
-        let _ = assignments.synchronise(3, &mut notification_engine);
+        let _ = state.restore_to(3);
 
         let decision = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert!(decision.is_none());
         assert!(brancher.dormant_predicates.contains(&predicate));
 
-        let _ = assignments.synchronise(0, &mut notification_engine);
+        let _ = state.restore_to(0);
         brancher.synchronise(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
 
         let decision = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert_eq!(decision, Some(predicate));
@@ -442,13 +439,13 @@ mod tests {
 
     #[test]
     fn uses_fallback() {
-        let mut assignments = Assignments::default();
-        let x = assignments.grow(0, 10);
+        let mut state = State::default();
+        let x = state.new_interval_variable(0, 10, None);
 
-        let mut brancher = AutonomousSearch::default_over_all_variables(&assignments);
+        let mut brancher = AutonomousSearch::default_over_all_variables(&state);
 
         let result = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom {
                 integers: vec![2],
                 usizes: vec![0],
@@ -462,19 +459,17 @@ mod tests {
 
     #[test]
     fn uses_stored_solution() {
-        let mut notification_engine = NotificationEngine::default();
-        let mut assignments = Assignments::default();
-        let x = assignments.grow(0, 10);
-        notification_engine.grow();
+        let mut state = State::default();
+        let x = state.new_interval_variable(0, 10, None);
 
-        assignments.new_checkpoint();
-        let _ = assignments.post_predicate(predicate!(x == 7), None, &mut notification_engine);
+        state.new_checkpoint();
+        let _ = state.post(predicate!(x == 7));
 
-        let mut brancher = AutonomousSearch::default_over_all_variables(&assignments);
+        let mut brancher = AutonomousSearch::default_over_all_variables(&state);
 
-        brancher.on_solution(SolutionReference::new(&assignments));
+        brancher.on_solution(SolutionReference::new(&state.assignments));
 
-        let _ = assignments.synchronise(0, &mut notification_engine);
+        let _ = state.restore_to(0);
 
         assert_eq!(
             predicate!(x >= 5),
@@ -496,7 +491,7 @@ mod tests {
         brancher.on_appearance_in_conflict_predicate(predicate!(x >= 5));
 
         let result = brancher.next_decision(&mut SelectionContext::new(
-            &assignments,
+            &state.assignments,
             &mut TestRandom::default(),
         ));
         assert_eq!(result, Some(predicate!(x >= 5)));

--- a/pumpkin-crates/core/src/constraints/constraint_poster.rs
+++ b/pumpkin-crates/core/src/constraints/constraint_poster.rs
@@ -29,7 +29,16 @@ impl<ConstraintImpl: Constraint> ConstraintPoster<'_, ConstraintImpl> {
     /// This method returns a [`ConstraintOperationError`] if the addition of the [`Constraint`] led
     /// to a root-level conflict.
     pub fn post(mut self) -> Result<(), ConstraintOperationError> {
-        self.constraint.take().unwrap().post(self.solver)
+        self.constraint
+            .take()
+            .unwrap()
+            .post(&mut self.solver.satisfaction_solver.state);
+
+        self.solver
+            .satisfaction_solver
+            .state
+            .propagate_to_fixed_point()
+            .map_err(|_| ConstraintOperationError::InfeasiblePropagator)
     }
 
     /// Add the half-reified version of the [`Constraint`] to the [`Solver`]; i.e. post the
@@ -41,10 +50,16 @@ impl<ConstraintImpl: Constraint> ConstraintPoster<'_, ConstraintImpl> {
         mut self,
         reification_literal: Literal,
     ) -> Result<(), ConstraintOperationError> {
-        self.constraint
-            .take()
-            .unwrap()
-            .implied_by(self.solver, reification_literal)
+        self.constraint.take().unwrap().implied_by(
+            &mut self.solver.satisfaction_solver.state,
+            reification_literal,
+        );
+
+        self.solver
+            .satisfaction_solver
+            .state
+            .propagate_to_fixed_point()
+            .map_err(|_| ConstraintOperationError::InfeasiblePropagator)
     }
 }
 
@@ -55,10 +70,16 @@ impl<ConstraintImpl: NegatableConstraint> ConstraintPoster<'_, ConstraintImpl> {
     /// This method returns a [`ConstraintOperationError`] if the addition of the [`Constraint`] led
     /// to a root-level conflict.
     pub fn reify(mut self, reification_literal: Literal) -> Result<(), ConstraintOperationError> {
-        self.constraint
-            .take()
-            .unwrap()
-            .reify(self.solver, reification_literal)
+        self.constraint.take().unwrap().reify(
+            &mut self.solver.satisfaction_solver.state,
+            reification_literal,
+        );
+
+        self.solver
+            .satisfaction_solver
+            .state
+            .propagate_to_fixed_point()
+            .map_err(|_| ConstraintOperationError::InfeasiblePropagator)
     }
 }
 

--- a/pumpkin-crates/core/src/constraints/mod.rs
+++ b/pumpkin-crates/core/src/constraints/mod.rs
@@ -1,8 +1,7 @@
 //! Defines the main building blocks of constraints.
-use crate::ConstraintOperationError;
-use crate::Solver;
 use crate::propagation::PropagatorConstructor;
 use crate::propagators::reified_propagator::ReifiedPropagatorArgs;
+use crate::state::State;
 use crate::variables::Literal;
 
 mod constraint_poster;
@@ -14,64 +13,38 @@ pub use constraint_poster::ConstraintPoster;
 /// For example, the constraint `a = b` over two variables `a` and `b` only allows assignments to
 /// `a` and `b` of the same value, and rejects any assignment where `a` and `b` differ.
 pub trait Constraint {
-    /// Add the [`Constraint`] to the [`Solver`].
-    ///
-    /// This method returns a [`ConstraintOperationError`] if the addition of the [`Constraint`] led
-    /// to a root-level conflict.
-    ///
-    /// The `tag` allows inferences to be traced to the constraint that implies them. They will
-    /// show up in the proof log.
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError>;
+    /// Add the [`Constraint`] to the [`State`] by posting appropriate propagators.
+    fn post(self, state: &mut State);
 
-    /// Add the half-reified version of the [`Constraint`] to the [`Solver`]; i.e. post the
+    /// Add the half-reified version of the [`Constraint`] to the [`State`]; i.e. post the
     /// constraint `r -> constraint` where `r` is a reification literal.
-    ///
-    /// This method returns a [`ConstraintOperationError`] if the addition of the [`Constraint`] led
-    /// to a root-level conflict.
-    ///
-    /// The `tag` allows inferences to be traced to the constraint that implies them. They will
-    /// show up in the proof log.
-    fn implied_by(
-        self,
-        solver: &mut Solver,
-        reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError>;
+    fn implied_by(self, state: &mut State, reification_literal: Literal);
 }
 
 impl<ConcretePropagator> Constraint for ConcretePropagator
 where
     ConcretePropagator: PropagatorConstructor + 'static,
 {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
-        let _ = solver.add_propagator(self)?;
-        Ok(())
+    fn post(self, state: &mut State) {
+        let _ = state.add_propagator(self);
     }
 
-    fn implied_by(
-        self,
-        solver: &mut Solver,
-        reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
-        let _ = solver.add_propagator(ReifiedPropagatorArgs {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
+        let _ = state.add_propagator(ReifiedPropagatorArgs {
             propagator: self,
             reification_literal,
-        })?;
-        Ok(())
+        });
     }
 }
 
 impl<C: Constraint> Constraint for Vec<C> {
-    fn post(self, solver: &mut Solver) -> Result<(), ConstraintOperationError> {
-        self.into_iter().try_for_each(|c| c.post(solver))
+    fn post(self, state: &mut State) {
+        self.into_iter().for_each(|c| c.post(state));
     }
 
-    fn implied_by(
-        self,
-        solver: &mut Solver,
-        reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError> {
+    fn implied_by(self, state: &mut State, reification_literal: Literal) {
         self.into_iter()
-            .try_for_each(|c| c.implied_by(solver, reification_literal))
+            .for_each(|c| c.implied_by(state, reification_literal));
     }
 }
 
@@ -88,23 +61,13 @@ pub trait NegatableConstraint: Constraint {
 
     /// Add the reified version of the [`Constraint`] to the [`Solver`]; i.e. post the constraint
     /// `r <-> constraint` where `r` is a reification literal.
-    ///
-    /// This method returns a [`ConstraintOperationError`] if the addition of the [`Constraint`] led
-    /// to a root-level conflict.
-    ///
-    /// The `tag` allows inferences to be traced to the constraint that implies them. They will
-    /// show up in the proof log.
-    fn reify(
-        self,
-        solver: &mut Solver,
-        reification_literal: Literal,
-    ) -> Result<(), ConstraintOperationError>
+    fn reify(self, state: &mut State, reification_literal: Literal)
     where
         Self: Sized,
     {
         let negation = self.negation();
 
-        self.implied_by(solver, reification_literal)?;
-        negation.implied_by(solver, !reification_literal)
+        self.implied_by(state, reification_literal);
+        negation.implied_by(state, !reification_literal);
     }
 }

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -112,7 +112,10 @@ pub struct ConstraintSatisfactionSolver {
 
 impl Default for ConstraintSatisfactionSolver {
     fn default() -> Self {
-        ConstraintSatisfactionSolver::new(SatisfactionSolverOptions::default())
+        ConstraintSatisfactionSolver::from_state(
+            SatisfactionSolverOptions::default(),
+            State::default(),
+        )
     }
 }
 
@@ -248,8 +251,8 @@ impl ConstraintSatisfactionSolver {
 
 // methods that offer basic functionality
 impl ConstraintSatisfactionSolver {
-    pub fn new(solver_options: SatisfactionSolverOptions) -> Self {
-        let mut state = State::default();
+    /// Create a new satisfaction solver based on the given state.
+    pub fn from_state(solver_options: SatisfactionSolverOptions, mut state: State) -> Self {
         let handle = state.add_propagator(NogoodPropagatorConstructor::new(
             (solver_options.memory_preallocated * 1_000_000) / size_of::<PredicateId>(),
             solver_options.learning_options,

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -253,6 +253,7 @@ impl ConstraintSatisfactionSolver {
 // methods that offer basic functionality
 impl ConstraintSatisfactionSolver {
     /// Create a new satisfaction solver based on the given state.
+    #[allow(clippy::result_large_err, reason = "we want the original state back")]
     pub fn from_state(
         solver_options: SatisfactionSolverOptions,
         mut state: State,

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -32,7 +32,6 @@ use crate::conflict_resolving::ConflictResolver;
 use crate::containers::HashMap;
 use crate::containers::HashSet;
 use crate::declare_inference_label;
-use crate::engine::Assignments;
 use crate::engine::RestartOptions;
 use crate::engine::RestartStrategy;
 use crate::engine::State;
@@ -187,10 +186,6 @@ impl Default for SatisfactionSolverOptions {
 }
 
 impl ConstraintSatisfactionSolver {
-    pub(crate) fn assignments(&self) -> &Assignments {
-        &self.state.assignments
-    }
-
     /// This is a temporary accessor to help refactoring.
     pub fn get_solution_reference(&self) -> SolutionReference<'_> {
         self.state.get_solution_reference()
@@ -1233,7 +1228,7 @@ mod tests {
         expected_flag: CSPSolverExecutionFlag,
         expected_result: CoreExtractionResult,
     ) {
-        let mut brancher = DefaultBrancher::default_over_all_variables(&solver.state.assignments);
+        let mut brancher = DefaultBrancher::default_over_all_variables(&solver.state);
         let mut resolver = NoLearningResolver;
 
         let flag = solver.solve_under_assumptions(

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -913,7 +913,8 @@ impl ConstraintSatisfactionSolver {
         let nogood_propagator =
             nogood_propagator.expect("Nogood propagator handle should refer to nogood propagator");
 
-        let addition_status = nogood_propagator.add_nogood(nogood, inference_code, &mut context);
+        let addition_status =
+            nogood_propagator.add_permanent_nogood(nogood, inference_code, &mut context);
 
         if addition_status.is_err() || self.solver_state.is_conflicting() {
             if let Err(conflict) = addition_status {

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -112,10 +112,16 @@ pub struct ConstraintSatisfactionSolver {
 
 impl Default for ConstraintSatisfactionSolver {
     fn default() -> Self {
-        ConstraintSatisfactionSolver::from_state(
-            SatisfactionSolverOptions::default(),
-            State::default(),
-        )
+        let mut state = State::default();
+        let solver_options = SatisfactionSolverOptions::default();
+
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::new(
+            (solver_options.memory_preallocated * 1_000_000) / size_of::<PredicateId>(),
+            solver_options.learning_options,
+        ));
+
+        ConstraintSatisfactionSolver::from_state(solver_options, state, nogood_propagator_handle)
+            .expect("no propagation happens")
     }
 }
 
@@ -252,22 +258,25 @@ impl ConstraintSatisfactionSolver {
 // methods that offer basic functionality
 impl ConstraintSatisfactionSolver {
     /// Create a new satisfaction solver based on the given state.
-    pub fn from_state(solver_options: SatisfactionSolverOptions, mut state: State) -> Self {
-        let handle = state.add_propagator(NogoodPropagatorConstructor::new(
-            (solver_options.memory_preallocated * 1_000_000) / size_of::<PredicateId>(),
-            solver_options.learning_options,
-        ));
+    pub fn from_state(
+        solver_options: SatisfactionSolverOptions,
+        mut state: State,
+        nogood_propagator_handle: PropagatorHandle<NogoodPropagator>,
+    ) -> Result<Self, State> {
+        if state.propagate_to_fixed_point().is_err() {
+            return Err(state);
+        }
 
-        ConstraintSatisfactionSolver {
+        Ok(ConstraintSatisfactionSolver {
             solver_state: CSPSolverState::default(),
             assumptions: Vec::default(),
             restart_strategy: RestartStrategy::new(solver_options.restart_options),
-            nogood_propagator_handle: handle,
+            nogood_propagator_handle,
             solver_statistics: SolverStatistics::default(),
             unit_nogood_inference_codes: Default::default(),
             internal_parameters: solver_options,
             state,
-        }
+        })
     }
 
     pub fn solve(

--- a/pumpkin-crates/core/src/engine/state.rs
+++ b/pumpkin-crates/core/src/engine/state.rs
@@ -126,7 +126,7 @@ impl Default for State {
 }
 
 impl State {
-    pub(crate) fn log_statistics(&self, verbose: bool) {
+    pub fn log_statistics(&self, verbose: bool) {
         log_statistic("variables", self.assignments.num_domains());
         log_statistic("propagators", self.propagators.num_propagators());
         log_statistic("failures", self.statistics.num_conflicts);

--- a/pumpkin-crates/core/src/engine/variables/literal.rs
+++ b/pumpkin-crates/core/src/engine/variables/literal.rs
@@ -31,6 +31,18 @@ impl Literal {
         }
     }
 
+    /// A literal that is assigned to true.
+    pub fn trivially_true() -> Literal {
+        Literal {
+            integer_variable: DomainId::new(0).scaled(1),
+        }
+    }
+
+    /// A literal that is assigned to false.
+    pub fn trivially_false() -> Literal {
+        !Literal::trivially_true()
+    }
+
     pub fn get_integer_variable(&self) -> AffineView<DomainId> {
         self.integer_variable
     }

--- a/pumpkin-crates/core/src/propagators/nogoods/mod.rs
+++ b/pumpkin-crates/core/src/propagators/nogoods/mod.rs
@@ -9,4 +9,4 @@ pub use checker::*;
 pub use learning_options::*;
 pub(crate) use nogood_id::*;
 pub(crate) use nogood_info::*;
-pub(crate) use nogood_propagator::*;
+pub use nogood_propagator::*;

--- a/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
+++ b/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
@@ -10,6 +10,7 @@ use crate::basic_types::PredicateId;
 use crate::basic_types::PropositionalConjunction;
 use crate::containers::KeyedVec;
 use crate::containers::StorageKey;
+use crate::declare_inference_label;
 use crate::engine::Assignments;
 use crate::engine::Lbd;
 use crate::engine::PropagationStatusCP;
@@ -19,6 +20,7 @@ use crate::engine::predicates::predicate::Predicate;
 use crate::engine::reason::Reason;
 use crate::engine::reason::ReasonStore;
 use crate::predicate;
+use crate::proof::ConstraintTag;
 use crate::proof::InferenceCode;
 use crate::propagation::EnqueueDecision;
 use crate::propagation::ExplanationContext;
@@ -38,6 +40,8 @@ use crate::pumpkin_assert_moderate;
 use crate::pumpkin_assert_simple;
 use crate::state::Conflict;
 use crate::state::PropagatorHandle;
+
+declare_inference_label!(pub Nogood);
 
 /// A propagator which propagates nogoods (i.e. a list of [`Predicate`]s which cannot all be true
 /// at the same time).
@@ -78,11 +82,15 @@ pub struct NogoodPropagator {
     /// current subtree. To test for that, we compare this handle with the propagator ID of a
     /// proapgated literal to see if this propagator propagated a predicate.
     handle: PropagatorHandle<NogoodPropagator>,
+
+    /// These are nogoods that have to be considered the next time propagation is executed.
+    newly_added_nogoods: Vec<(ConstraintTag, Vec<Predicate>)>,
 }
 
 /// [`PropagatorConstructor`] for constructing a new instance of the [`NogoodPropagator`] with the
 /// provided [`LearningOptions`] and `capacity`.
-pub(crate) struct NogoodPropagatorConstructor {
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NogoodPropagatorConstructor {
     /// How many [`PredicateId`]s to preallocate to the [`ArenaAllocator`].
     capacity: usize,
     parameters: LearningOptions,
@@ -116,6 +124,7 @@ impl PropagatorConstructor for NogoodPropagatorConstructor {
             lbd_helper: Default::default(),
             bumped_nogoods: Default::default(),
             temp_nogood_reason: Default::default(),
+            newly_added_nogoods: Default::default(),
         }
     }
 }
@@ -222,6 +231,11 @@ impl Propagator for NogoodPropagator {
             context.reason_store,
             context.notification_engine,
         );
+
+        // Add new nogoods to the propagator.
+        for (tag, nogood) in std::mem::take(&mut self.newly_added_nogoods) {
+            self.add_permanent_nogood(nogood, InferenceCode::new(tag, Nogood), &mut context)?;
+        }
 
         if self.watch_lists.len() <= context.num_predicate_ids() {
             self.watch_lists
@@ -506,19 +520,29 @@ impl NogoodPropagator {
         }
     }
 
-    /// Adds a nogood to the propagator as a permanent nogood and sets the internal state to be
-    /// infeasible if the nogood led to a conflict.
-    pub(crate) fn add_nogood(
+    /// Adds a nogood to the propagator as a permanent nogood.
+    ///
+    /// This nogood will automatically be enqueued for propagation.
+    ///
+    /// No preprocessing is done on the provided nogood. Therefore, the caller is responsible
+    /// for removing redundant literals.
+    ///
+    /// Panics if the nogood is empty.
+    pub fn add_nogood(
         &mut self,
-        nogood: Vec<Predicate>,
-        inference_code: InferenceCode,
-        context: &mut PropagationContext,
-    ) -> PropagationStatusCP {
-        self.add_permanent_nogood(nogood, inference_code, context)
+        nogood: impl IntoIterator<Item = Predicate>,
+        constraint_tag: ConstraintTag,
+    ) {
+        let nogood = nogood.into_iter().collect::<Vec<_>>();
+
+        assert!(!nogood.is_empty(), "cannot add empty nogoods");
+
+        self.newly_added_nogoods.push((constraint_tag, nogood));
     }
 
-    /// Adds a nogood which cannot be deleted by clause management.
-    fn add_permanent_nogood(
+    /// Adds a nogood to the propagator as a permanent nogood and sets the internal state to be
+    /// infeasible if the nogood led to a conflict.
+    pub(crate) fn add_permanent_nogood(
         &mut self,
         mut nogood: Vec<Predicate>,
         inference_code: InferenceCode,
@@ -1316,7 +1340,7 @@ mod tests {
             let nogood_propagator: &mut NogoodPropagator = nogood_propagator.unwrap();
 
             nogood_propagator
-                .add_nogood(nogood.into(), inference_code, &mut context)
+                .add_permanent_nogood(nogood.into(), inference_code, &mut context)
                 .unwrap();
         }
 
@@ -1353,7 +1377,7 @@ mod tests {
             let nogood_propagator: &mut NogoodPropagator = nogood_propagator.unwrap();
 
             nogood_propagator
-                .add_nogood(nogood.into(), inference_code, &mut context)
+                .add_permanent_nogood(nogood.into(), inference_code, &mut context)
                 .unwrap();
         }
 

--- a/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
+++ b/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
@@ -97,7 +97,7 @@ pub struct NogoodPropagatorConstructor {
 }
 
 impl NogoodPropagatorConstructor {
-    pub(crate) fn new(capacity: usize, parameters: LearningOptions) -> Self {
+    pub fn new(capacity: usize, parameters: LearningOptions) -> Self {
         Self {
             capacity,
             parameters,

--- a/pumpkin-crates/core/src/statistics/mod.rs
+++ b/pumpkin-crates/core/src/statistics/mod.rs
@@ -6,11 +6,7 @@ pub(crate) mod statistic_logging;
 use std::fmt::Display;
 
 pub use statistic_logger::StatisticLogger;
-pub use statistic_logging::StatisticOptions;
-pub use statistic_logging::configure_statistic_logging;
-pub use statistic_logging::log_statistic;
-pub use statistic_logging::log_statistic_postfix;
-pub use statistic_logging::should_log_statistics;
+pub use statistic_logging::*;
 
 #[cfg(doc)]
 use crate::Solver;

--- a/pumpkin-crates/core/src/statistics/statistic_logging.rs
+++ b/pumpkin-crates/core/src/statistics/statistic_logging.rs
@@ -12,6 +12,11 @@ use std::sync::RwLock;
 use convert_case::Case;
 use convert_case::Casing;
 
+use crate::Solver;
+use crate::branching::Brancher;
+use crate::conflict_resolving::ConflictResolver;
+use crate::statistics::StatisticLogger;
+
 /// The options for statistic logging containing the statistic prefix, the (optional) line which is
 /// printed after the statistics, and the (optional) casing of the statistics.
 pub struct StatisticOptions<'a> {
@@ -82,6 +87,25 @@ pub fn log_statistic(name: impl Display, value: impl Display) {
         statistic_options.statistics_writer,
         "{prefix} {name}={value}"
     );
+}
+
+pub fn log_solver_statistics(
+    solver: &Solver,
+    resolver: &impl ConflictResolver,
+    brancher: &impl Brancher,
+    objective: Option<i64>,
+    verbose: bool,
+) {
+    solver.log_statistics(verbose);
+    if let Some(objective_value) = objective {
+        log_statistic("objective", objective_value);
+    }
+
+    resolver.log_statistics(StatisticLogger::default());
+    if verbose {
+        brancher.log_statistics(StatisticLogger::default());
+    }
+    log_statistic_postfix();
 }
 
 /// Logs the postfix of the statistics (if it has been set).

--- a/pumpkin-solver-py/src/constraints/globals.rs
+++ b/pumpkin-solver-py/src/constraints/globals.rs
@@ -1,4 +1,8 @@
-use pumpkin_solver::core::constraints::Constraint;
+use pumpkin_solver::core::constraints::NegatableConstraint;
+use pumpkin_solver::core::proof::ConstraintTag;
+use pumpkin_solver::core::propagators::nogoods::NogoodPropagator;
+use pumpkin_solver::core::state::PropagatorHandle;
+use pumpkin_solver::core::variables::Literal;
 use pyo3::pyclass;
 use pyo3::pymethods;
 
@@ -6,7 +10,19 @@ use crate::model::Tag;
 use crate::variables::*;
 
 macro_rules! python_constraint {
-    ($name:ident : $constraint_func:ident { $($field:ident : $type:ty),+ $(,)? }) => {
+    ($name:ident : $constraint_func:path [nogood] { $($field:ident : $type:ty),+ $(,)? }) => {
+        python_constraint!(@impl solver, $name, $constraint_func, (solver.nogood_propagator_handle()), $($field : $type),+);
+    };
+
+    ($name:ident : $constraint_func:path [equality] { $($field:ident : $type:ty),+ $(,)? }) => {
+        python_constraint!(@impl solver, $name, $constraint_func, (pumpkin_constraints::EqualityConsistency::Bound), $($field : $type),+);
+    };
+
+    ($name:ident : $constraint_func:path { $($field:ident : $type:ty),+ $(,)? }) => {
+        python_constraint!(@impl solver, $name, $constraint_func, (), $($field : $type),+);
+    };
+
+    (@impl $solver_name:ident, $name:ident, $constraint_func:path, ($($extra:expr),*), $($field:ident : $type:ty),+) => {
         #[pyclass]
         #[derive(Clone)]
         pub(crate) struct $name {
@@ -28,71 +44,77 @@ macro_rules! python_constraint {
         impl $name {
             pub fn post(
                 self,
-                solver: &mut pumpkin_solver::Solver,
+                $solver_name: &mut pumpkin_solver::Solver,
             ) -> Result<(), pumpkin_solver::core::ConstraintOperationError> {
-                pumpkin_constraints::$constraint_func(
-                    $(<$type as super::arguments::PythonConstraintArg>::to_solver_constraint_argument(self.$field)),+ ,
-                    self.constraint_tag.0,
-                ).post(solver)
+                $solver_name
+                    .add_constraint($constraint_func(
+                        $(<$type as super::arguments::PythonConstraintArg>::to_solver_constraint_argument(self.$field)),+ ,
+                        self.constraint_tag.0,
+                        $($extra,)*
+                    ))
+                    .post()
             }
 
             pub fn implied_by(
                 self,
-                solver: &mut pumpkin_solver::Solver,
+                $solver_name: &mut pumpkin_solver::Solver,
                 reification_literal: pumpkin_solver::core::variables::Literal,
             ) -> Result<(), pumpkin_solver::core::ConstraintOperationError> {
-                pumpkin_constraints::$constraint_func(
-                    $(<$type as super::arguments::PythonConstraintArg>::to_solver_constraint_argument(self.$field)),+ ,
-                    self.constraint_tag.0,
-                ).implied_by(solver, reification_literal)
+                $solver_name
+                    .add_constraint($constraint_func(
+                        $(<$type as super::arguments::PythonConstraintArg>::to_solver_constraint_argument(self.$field)),+ ,
+                        self.constraint_tag.0,
+                        $($extra,)*
+                    ))
+                    .implied_by(reification_literal)
             }
         }
     };
 }
 
 python_constraint! {
-    Absolute: absolute {
+    Absolute: pumpkin_constraints::absolute {
         signed: IntExpression,
         absolute: IntExpression,
     }
 }
 
 python_constraint! {
-    AllDifferent: all_different {
+    AllDifferent: pumpkin_constraints::all_different {
         variables: Vec<IntExpression>,
     }
 }
 
 python_constraint! {
-    BinaryEquals: binary_equals {
+    BinaryEquals: pumpkin_constraints::binary_equals [equality] {
         lhs: IntExpression,
         rhs: IntExpression,
     }
 }
 
 python_constraint! {
-    BinaryLessThan: binary_less_than {
+    BinaryLessThan: pumpkin_constraints::binary_less_than {
         lhs: IntExpression,
         rhs: IntExpression,
     }
 }
 
 python_constraint! {
-    BinaryLessThanEqual: binary_less_than_or_equals {
+    BinaryLessThanEqual: pumpkin_constraints::binary_less_than_or_equals {
         lhs: IntExpression,
         rhs: IntExpression,
     }
 }
 
 python_constraint! {
-    BinaryNotEquals: binary_not_equals {
+    BinaryNotEquals: pumpkin_constraints::binary_not_equals [equality] {
         lhs: IntExpression,
         rhs: IntExpression,
     }
 }
 
 python_constraint! {
-    Cumulative: cumulative {
+    Cumulative: pumpkin_constraints::cumulative {
         start_times: Vec<IntExpression>,
         durations: Vec<i32>,
         resource_requirements: Vec<i32>,
@@ -101,7 +123,7 @@ python_constraint! {
 }
 
 python_constraint! {
-    Division: division {
+    Division: pumpkin_constraints::division {
         numerator: IntExpression,
         denominator: IntExpression,
         rhs: IntExpression,
@@ -109,7 +131,7 @@ python_constraint! {
 }
 
 python_constraint! {
-    Element: element {
+    Element: pumpkin_constraints::element {
         index: IntExpression,
         array: Vec<IntExpression>,
         rhs: IntExpression,
@@ -117,42 +139,42 @@ python_constraint! {
 }
 
 python_constraint! {
-    Equals: equals {
+    Equals: pumpkin_constraints::equals [equality] {
         terms: Vec<IntExpression>,
         rhs: i32,
     }
 }
 
 python_constraint! {
-    LessThanOrEquals: less_than_or_equals {
+    LessThanOrEquals: pumpkin_constraints::less_than_or_equals {
         terms: Vec<IntExpression>,
         rhs: i32,
     }
 }
 
 python_constraint! {
-    Maximum: maximum {
+    Maximum: pumpkin_constraints::maximum {
         choices: Vec<IntExpression>,
         rhs: IntExpression,
     }
 }
 
 python_constraint! {
-    Minimum: minimum {
+    Minimum: pumpkin_constraints::minimum {
         choices: Vec<IntExpression>,
         rhs: IntExpression,
     }
 }
 
 python_constraint! {
-    NotEquals: not_equals {
+    NotEquals: pumpkin_constraints::not_equals [equality] {
         terms: Vec<IntExpression>,
         rhs: i32,
     }
 }
 
 python_constraint! {
-    Plus: plus {
+    Plus: pumpkin_constraints::plus {
         a: IntExpression,
         b: IntExpression,
         c: IntExpression,
@@ -160,34 +182,58 @@ python_constraint! {
 }
 
 python_constraint! {
-    Times: times {
+    Times: pumpkin_constraints::times {
         a: IntExpression,
         b: IntExpression,
         c: IntExpression,
     }
 }
 
+fn conjunction(
+    literals: impl IntoIterator<Item = Literal>,
+    constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
+) -> impl NegatableConstraint {
+    pumpkin_constraints::conjunction(
+        literals.into_iter().map(|lit| lit.get_true_predicate()),
+        constraint_tag,
+        propagator_handle,
+    )
+}
+
+fn clause(
+    literals: impl IntoIterator<Item = Literal>,
+    constraint_tag: ConstraintTag,
+    propagator_handle: PropagatorHandle<NogoodPropagator>,
+) -> impl NegatableConstraint {
+    pumpkin_constraints::clause(
+        literals.into_iter().map(|lit| lit.get_true_predicate()),
+        constraint_tag,
+        propagator_handle,
+    )
+}
+
 python_constraint! {
-    Conjunction: conjunction {
+    Conjunction: conjunction [nogood] {
         literals: Vec<BoolExpression>,
     }
 }
 
 python_constraint! {
-    Clause: clause {
+    Clause: clause [nogood] {
         literals: Vec<BoolExpression>,
     }
 }
 
 python_constraint! {
-    Table: table {
+    Table: pumpkin_constraints::table [nogood] {
         variables: Vec<IntExpression>,
         table: Vec<Vec<i32>>,
     }
 }
 
 python_constraint! {
-    NegativeTable: negative_table {
+    NegativeTable: pumpkin_constraints::negative_table [nogood] {
         variables: Vec<IntExpression>,
         table: Vec<Vec<i32>>,
     }

--- a/pumpkin-solver-py/src/model.rs
+++ b/pumpkin-solver-py/src/model.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
 use pumpkin_solver::Solver;
+use pumpkin_solver::core::DefaultBrancher;
 use pumpkin_solver::core::containers::HashMap;
 use pumpkin_solver::core::containers::StorageKey;
 use pumpkin_solver::core::optimisation::OptimisationDirection;
@@ -86,7 +87,8 @@ impl Model {
         };
 
         let solver = Solver::with_options(options);
-        let brancher = PythonBrancher::new(solver.default_brancher());
+        let brancher =
+            PythonBrancher::new(DefaultBrancher::default_over_all_variables(solver.state()));
 
         Ok(Model { solver, brancher })
     }

--- a/pumpkin-solver/examples/bibd.rs
+++ b/pumpkin-solver/examples/bibd.rs
@@ -14,6 +14,8 @@
 //! Hence, the problem is defined in terms of v, k, and l.
 
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
+use pumpkin_core::DefaultBrancher;
+use pumpkin_solver::EqualityConsistency;
 use pumpkin_solver::Solver;
 use pumpkin_solver::core::results::ProblemSolution;
 use pumpkin_solver::core::results::SatisfactionResult;
@@ -101,6 +103,7 @@ fn main() {
                 row.clone(),
                 bibd.row_sum as i32,
                 constraint_tag,
+                EqualityConsistency::Bound,
             ))
             .post();
     }
@@ -112,6 +115,7 @@ fn main() {
                 row,
                 bibd.column_sum as i32,
                 constraint_tag,
+                EqualityConsistency::Bound,
             ))
             .post();
     }
@@ -145,7 +149,7 @@ fn main() {
         }
     }
 
-    let mut brancher = solver.default_brancher();
+    let mut brancher = DefaultBrancher::default_over_all_variables(solver.state());
     let mut resolver = ResolutionResolver::default();
 
     match solver.satisfy(&mut brancher, &mut Indefinite, &mut resolver) {

--- a/pumpkin-solver/examples/disjunctive_scheduling.rs
+++ b/pumpkin-solver/examples/disjunctive_scheduling.rs
@@ -10,6 +10,7 @@
 //! the two possibilities, and then post the constraint (l_xy \/ l_yx).
 
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
+use pumpkin_core::DefaultBrancher;
 use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_solver::Solver;
 use pumpkin_solver::core::results::ProblemSolution;
@@ -69,12 +70,14 @@ fn main() {
             // equivelent to literal <=> (s_x - s_y <= -p_x)
             // So the variables are -s_y and s_x, and the rhs is -p_x
             let variables = vec![start_variables[y].scaled(-1), start_variables[x].scaled(1)];
-            let _ = pumpkin_constraints::less_than_or_equals(
-                variables,
-                -(processing_times[x] as i32),
-                constraint_tag,
-            )
-            .reify(&mut solver, literal);
+            solver
+                .add_constraint(pumpkin_constraints::less_than_or_equals(
+                    variables,
+                    -(processing_times[x] as i32),
+                    constraint_tag,
+                ))
+                .reify(literal)
+                .expect("not inconsistent");
 
             // Either x starts before y or y start before x
             let _ = solver.add_clause(
@@ -87,7 +90,7 @@ fn main() {
         }
     }
 
-    let mut brancher = solver.default_brancher();
+    let mut brancher = DefaultBrancher::default_over_all_variables(solver.state());
     let mut resolver = ResolutionResolver::default();
     if matches!(
         solver.satisfy(&mut brancher, &mut Indefinite, &mut resolver),

--- a/pumpkin-solver/examples/disjunctive_scheduling.rs
+++ b/pumpkin-solver/examples/disjunctive_scheduling.rs
@@ -11,7 +11,6 @@
 
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
 use pumpkin_core::DefaultBrancher;
-use pumpkin_core::constraints::NegatableConstraint;
 use pumpkin_solver::Solver;
 use pumpkin_solver::core::results::ProblemSolution;
 use pumpkin_solver::core::results::SatisfactionResult;

--- a/pumpkin-solver/examples/nqueens.rs
+++ b/pumpkin-solver/examples/nqueens.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
+use pumpkin_core::DefaultBrancher;
 use pumpkin_solver::Solver;
 use pumpkin_solver::core::options::SolverOptions;
 use pumpkin_solver::core::proof::ProofLog;
@@ -87,7 +88,7 @@ fn main() {
         .add_constraint(pumpkin_constraints::all_different(diag2, c3_tag))
         .post();
 
-    let mut brancher = solver.default_brancher();
+    let mut brancher = DefaultBrancher::default_over_all_variables(solver.state());
     let mut resolver = ResolutionResolver::default();
 
     match solver.satisfy(&mut brancher, &mut Indefinite, &mut resolver) {

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/collect_domains.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/collect_domains.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use flatzinc::Annotation;
 use pumpkin_core::Solver;
 use pumpkin_core::containers::HashMap;
+use pumpkin_core::state::State;
 use pumpkin_core::variables::DomainId;
 use pumpkin_solver::core::variables::Literal;
 
@@ -32,7 +33,7 @@ pub(crate) fn run(
                     .entry(Rc::clone(&representative))
                     .or_insert_with(|| {
                         create_integer_domain(
-                            context.solver,
+                            context.state,
                             &mut context.constant_domain_ids,
                             representative,
                             domain,
@@ -60,7 +61,7 @@ pub(crate) fn run(
                     .entry(Rc::clone(&representative))
                     .or_insert_with(|| {
                         create_integer_domain(
-                            context.solver,
+                            context.state,
                             &mut context.constant_domain_ids,
                             representative,
                             domain,
@@ -78,7 +79,7 @@ pub(crate) fn run(
 }
 
 fn create_integer_domain(
-    solver: &mut Solver,
+    state: &mut State,
     constant_domains: &mut HashMap<i32, DomainId>,
     identifier: Rc<str>,
     domain: Domain,
@@ -91,9 +92,9 @@ fn create_integer_domain(
 
         *constant_domains
             .entry(value)
-            .or_insert_with(|| domain.into_variable(solver, value.to_string()))
+            .or_insert_with(|| domain.into_variable(state, value.to_string()))
     } else {
-        domain.into_variable(solver, identifier.to_string())
+        domain.into_variable(state, identifier.to_string())
     }
 }
 

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/collect_domains.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/collect_domains.rs
@@ -3,7 +3,6 @@
 use std::rc::Rc;
 
 use flatzinc::Annotation;
-use pumpkin_core::Solver;
 use pumpkin_core::containers::HashMap;
 use pumpkin_core::state::State;
 use pumpkin_core::variables::DomainId;

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/context.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/context.rs
@@ -689,7 +689,7 @@ impl Domain {
             Domain::IntervalDomain { lb, ub } => {
                 state.new_interval_variable(lb, ub, Some(name.into()))
             }
-            Domain::SparseDomain { values } => state.new_sparse_variable(values, Some(name.into())),
+            Domain::SparseDomain { values } => state.new_sparse_variable(values, Some(name)),
         }
     }
 }

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/context.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/context.rs
@@ -4,11 +4,9 @@ use std::collections::BTreeSet;
 use std::rc::Rc;
 
 use log::warn;
-use pumpkin_core::predicates::Predicate;
 use pumpkin_core::propagators::nogoods::NogoodPropagator;
 use pumpkin_core::state::PropagatorHandle;
 use pumpkin_core::state::State;
-use pumpkin_solver::Solver;
 use pumpkin_solver::core::containers::HashMap;
 use pumpkin_solver::core::containers::HashSet;
 use pumpkin_solver::core::proof::ConstraintTag;

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/context.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/context.rs
@@ -4,6 +4,10 @@ use std::collections::BTreeSet;
 use std::rc::Rc;
 
 use log::warn;
+use pumpkin_core::predicates::Predicate;
+use pumpkin_core::propagators::nogoods::NogoodPropagator;
+use pumpkin_core::state::PropagatorHandle;
+use pumpkin_core::state::State;
 use pumpkin_solver::Solver;
 use pumpkin_solver::core::containers::HashMap;
 use pumpkin_solver::core::containers::HashSet;
@@ -15,8 +19,10 @@ use crate::flatzinc::FlatZincError;
 use crate::flatzinc::instance::Output;
 
 pub(crate) struct CompilationContext<'a> {
-    /// The solver to compile the FlatZinc into.
-    pub(crate) solver: &'a mut Solver,
+    /// The state to compile the FlatZinc into.
+    pub(crate) state: &'a mut State,
+    /// The nogood propagator to use for nogoods/clauses.
+    pub(crate) nogood_propagator_handle: PropagatorHandle<NogoodPropagator>,
 
     /// All identifiers occuring in the model. The identifiers are interned, to support cheap
     /// cloning.
@@ -37,10 +43,6 @@ pub(crate) struct CompilationContext<'a> {
     /// is posted or an array is created).
     pub(crate) variable_map: HashMap<Rc<str>, DomainId>,
 
-    /// Literal which is always true
-    pub(crate) true_literal: Literal,
-    /// Literal which is always false
-    pub(crate) false_literal: Literal,
     /// All boolean parameters.
     pub(crate) boolean_parameters: HashMap<Rc<str>, bool>,
     /// All boolean array parameters.
@@ -74,19 +76,18 @@ pub(crate) enum Set {
 }
 
 impl CompilationContext<'_> {
-    pub(crate) fn new(solver: &mut Solver) -> CompilationContext<'_> {
-        let true_literal = solver.get_true_literal();
-        let false_literal = solver.get_false_literal();
-
+    pub(crate) fn new(
+        state: &mut State,
+        nogood_propagator_handle: PropagatorHandle<NogoodPropagator>,
+    ) -> CompilationContext<'_> {
         CompilationContext {
-            solver,
+            state,
+            nogood_propagator_handle,
             identifiers: Default::default(),
 
             outputs: Default::default(),
             equivalences: Default::default(),
 
-            true_literal,
-            false_literal,
             boolean_parameters: Default::default(),
             boolean_array_parameters: Default::default(),
             boolean_variable_arrays: Default::default(),
@@ -106,14 +107,6 @@ impl CompilationContext<'_> {
         self.integer_parameters.contains_key(identifier)
     }
 
-    // pub fn resolve_bool_constant(&self, identifier: &str) -> Option<bool> {
-    //     self.boolean_parameters.get(identifier).copied()
-    // }
-
-    // pub fn resolve_int_constant(&self, identifier: &str) -> Option<i32> {
-    //     self.integer_parameters.get(identifier).copied()
-    // }
-
     pub(crate) fn resolve_bool_variable(
         &mut self,
         expr: &flatzinc::Expr,
@@ -122,9 +115,9 @@ impl CompilationContext<'_> {
             flatzinc::Expr::VarParIdentifier(id) => self.resolve_bool_variable_from_identifier(id),
             flatzinc::Expr::Bool(value) => {
                 if *value {
-                    Ok(self.solver.get_true_literal())
+                    Ok(Literal::trivially_true())
                 } else {
-                    Ok(self.solver.get_false_literal())
+                    Ok(Literal::trivially_false())
                 }
             }
             _ => Err(FlatZincError::UnexpectedExpr),
@@ -145,9 +138,9 @@ impl CompilationContext<'_> {
                 .get(&self.equivalences.representative(identifier))
                 .map(|value| {
                     if *value {
-                        self.solver.get_true_literal()
+                        Literal::trivially_true()
                     } else {
-                        self.solver.get_false_literal()
+                        Literal::trivially_false()
                     }
                 })
                 .ok_or_else(|| FlatZincError::InvalidIdentifier {
@@ -173,9 +166,9 @@ impl CompilationContext<'_> {
                                 .iter()
                                 .map(|value| {
                                     if *value {
-                                        self.solver.get_true_literal()
+                                        Literal::trivially_true()
                                     } else {
-                                        self.solver.get_false_literal()
+                                        Literal::trivially_false()
                                     }
                                 })
                                 .collect()
@@ -192,8 +185,8 @@ impl CompilationContext<'_> {
                     flatzinc::BoolExpr::VarParIdentifier(id) => {
                         self.resolve_bool_variable_from_identifier(id)
                     }
-                    flatzinc::BoolExpr::Bool(true) => Ok(self.solver.get_true_literal()),
-                    flatzinc::BoolExpr::Bool(false) => Ok(self.solver.get_false_literal()),
+                    flatzinc::BoolExpr::Bool(true) => Ok(Literal::trivially_true()),
+                    flatzinc::BoolExpr::Bool(false) => Ok(Literal::trivially_false()),
                 })
                 .collect(),
             flatzinc::Expr::ArrayOfInt(array) => array
@@ -259,8 +252,8 @@ impl CompilationContext<'_> {
             identifier.to_owned(),
         ))?;
         Ok(*self.constant_domain_ids.entry(value).or_insert_with(|| {
-            self.solver
-                .new_named_bounded_integer(value, value, identifier.to_owned())
+            self.state
+                .new_interval_variable(value, value, Some(identifier.into()))
         }))
     }
 
@@ -325,10 +318,10 @@ impl CompilationContext<'_> {
                 .constant_domain_ids
                 .entry(*value as i32)
                 .or_insert_with(|| {
-                    self.solver.new_named_bounded_integer(
+                    self.state.new_interval_variable(
                         *value as i32,
                         *value as i32,
-                        value.to_string(),
+                        Some(value.to_string().into()),
                     )
                 })),
             flatzinc::IntExpr::VarParIdentifier(id) => {
@@ -349,8 +342,11 @@ impl CompilationContext<'_> {
                 .constant_domain_ids
                 .entry(*val as i32)
                 .or_insert_with(|| {
-                    self.solver
-                        .new_named_bounded_integer(*val as i32, *val as i32, val.to_string())
+                    self.state.new_interval_variable(
+                        *val as i32,
+                        *val as i32,
+                        Some(val.to_string().into()),
+                    )
                 })),
             _ => Err(FlatZincError::UnexpectedExpr),
         }
@@ -376,8 +372,11 @@ impl CompilationContext<'_> {
                 .get(&self.equivalences.representative(identifier))
                 .map(|value| {
                     *self.constant_domain_ids.entry(*value).or_insert_with(|| {
-                        self.solver
-                            .new_named_bounded_integer(*value, *value, value.to_string())
+                        self.state.new_interval_variable(
+                            *value,
+                            *value,
+                            Some(value.to_string().into()),
+                        )
                     })
                 })
                 .ok_or_else(|| FlatZincError::InvalidIdentifier {
@@ -403,10 +402,10 @@ impl CompilationContext<'_> {
                                 .iter()
                                 .map(|value| {
                                     *self.constant_domain_ids.entry(*value).or_insert_with(|| {
-                                        self.solver.new_named_bounded_integer(
+                                        self.state.new_interval_variable(
                                             *value,
                                             *value,
-                                            value.to_string(),
+                                            Some(value.to_string().into()),
                                         )
                                     })
                                 })
@@ -687,10 +686,12 @@ impl Domain {
         Domain::IntervalDomain { lb, ub }
     }
 
-    pub(crate) fn into_variable(self, solver: &mut Solver, name: String) -> DomainId {
+    pub(crate) fn into_variable(self, state: &mut State, name: String) -> DomainId {
         match self {
-            Domain::IntervalDomain { lb, ub } => solver.new_named_bounded_integer(lb, ub, name),
-            Domain::SparseDomain { values } => solver.new_named_sparse_integer(values, name),
+            Domain::IntervalDomain { lb, ub } => {
+                state.new_interval_variable(lb, ub, Some(name.into()))
+            }
+            Domain::SparseDomain { values } => state.new_sparse_variable(values, Some(name.into())),
         }
     }
 }

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/create_search_strategy.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/create_search_strategy.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use flatzinc::AnnExpr;
+use pumpkin_core::DefaultBrancher;
 use pumpkin_solver::core::branching::Brancher;
 use pumpkin_solver::core::branching::branchers::dynamic_brancher::DynamicBrancher;
 use pumpkin_solver::core::branching::branchers::independent_variable_value_brancher::IndependentVariableValueBrancher;
@@ -210,7 +211,10 @@ fn create_from_search_strategy(
             )),
             None => {}
         }
-        brancher.add_brancher(Box::new(context.solver.default_brancher()));
+
+        brancher.add_brancher(Box::new(DefaultBrancher::default_over_all_variables(
+            context.state,
+        )));
     }
 
     Ok(brancher)

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/define_variable_arrays.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/define_variable_arrays.rs
@@ -36,8 +36,9 @@ pub(crate) fn run(
                         ArrayOfBoolExpr::Array(array) => array
                             .iter()
                             .map(|expr| match expr {
-                                BoolExpr::Bool(true) => context.true_literal,
-                                BoolExpr::Bool(false) => context.false_literal,
+                                BoolExpr::Bool(true) => Literal::trivially_true(),
+                                BoolExpr::Bool(false) => Literal::trivially_false(),
+
                                 BoolExpr::VarParIdentifier(identifier) => {
                                     let other_id = context.identifiers.get_interned(identifier);
                                     let representative =
@@ -85,7 +86,7 @@ pub(crate) fn run(
 
                                 Ok(
                                     *context.constant_domain_ids.entry(value).or_insert_with(
-                                        || context.solver.new_bounded_integer(value, value),
+                                        || context.state.new_interval_variable(value, value, None),
                                     ),
                                 )
                             }

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/merge_equivalences.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/merge_equivalences.rs
@@ -238,7 +238,6 @@ mod tests {
     use flatzinc::SolveItem;
     use pumpkin_core::propagators::nogoods::NogoodPropagatorConstructor;
     use pumpkin_core::state::State;
-    use pumpkin_solver::Solver;
 
     use super::*;
 

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/merge_equivalences.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/merge_equivalences.rs
@@ -236,6 +236,8 @@ mod tests {
     use flatzinc::ConstraintItem;
     use flatzinc::Expr;
     use flatzinc::SolveItem;
+    use pumpkin_core::propagators::nogoods::NogoodPropagatorConstructor;
+    use pumpkin_core::state::State;
     use pumpkin_solver::Solver;
 
     use super::*;
@@ -272,8 +274,9 @@ mod tests {
         });
 
         let mut ast = ast_builder.build().expect("valid ast");
-        let mut solver = Solver::default();
-        let mut context = CompilationContext::new(&mut solver);
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+        let mut context = CompilationContext::new(&mut state, nogood_propagator_handle);
         let options = FlatZincOptions::default();
 
         super::super::reserve_constraint_tags::run(&ast, &mut context)
@@ -321,8 +324,9 @@ mod tests {
         });
 
         let mut ast = ast_builder.build().expect("valid ast");
-        let mut solver = Solver::default();
-        let mut context = CompilationContext::new(&mut solver);
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+        let mut context = CompilationContext::new(&mut state, nogood_propagator_handle);
         let options = FlatZincOptions {
             proof_type: Some(ProofType::Full),
             ..Default::default()

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/mod.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/mod.rs
@@ -15,7 +15,6 @@ use context::CompilationContext;
 use pumpkin_core::propagators::nogoods::NogoodPropagator;
 use pumpkin_core::state::PropagatorHandle;
 use pumpkin_core::state::State;
-use pumpkin_solver::Solver;
 
 use super::FlatZincError;
 use super::FlatZincOptions;

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/mod.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/mod.rs
@@ -12,6 +12,9 @@ mod remove_unused_variables;
 mod reserve_constraint_tags;
 
 use context::CompilationContext;
+use pumpkin_core::propagators::nogoods::NogoodPropagator;
+use pumpkin_core::state::PropagatorHandle;
+use pumpkin_core::state::State;
 use pumpkin_solver::Solver;
 
 use super::FlatZincError;
@@ -21,10 +24,11 @@ use super::instance::FlatZincInstance;
 
 pub(crate) fn compile(
     mut ast: FlatZincAst,
-    solver: &mut Solver,
+    state: &mut State,
+    nogood_propagator_handle: PropagatorHandle<NogoodPropagator>,
     options: FlatZincOptions,
 ) -> Result<FlatZincInstance, FlatZincError> {
-    let mut context = CompilationContext::new(solver);
+    let mut context = CompilationContext::new(state, nogood_propagator_handle);
 
     define_constants::run(&ast, &mut context)?;
     reserve_constraint_tags::run(&ast, &mut context)?;

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
@@ -502,10 +502,8 @@ fn compile_array_int_maximum(
     let array = context.resolve_integer_variable_array(&exprs[1])?;
 
     let _: () = pumpkin_constraints::maximum(array.as_ref().to_owned(), rhs, constraint_tag)
-    .post(context.state);
-    Ok(
-        (),
-    )
+        .post(context.state);
+    Ok(())
 }
 
 fn compile_array_int_minimum(
@@ -519,10 +517,8 @@ fn compile_array_int_minimum(
     let array = context.resolve_integer_variable_array(&exprs[1])?;
 
     let _: () = pumpkin_constraints::minimum(array.as_ref().to_owned(), rhs, constraint_tag)
-    .post(context.state);
-    Ok(
-        (),
-    )
+        .post(context.state);
+    Ok(())
 }
 
 fn compile_set_in_reif(
@@ -603,10 +599,8 @@ fn compile_array_var_int_element(
     let rhs = context.resolve_integer_variable(&exprs[2])?;
 
     let _: () = pumpkin_constraints::element(index, array.as_ref().to_owned(), rhs, constraint_tag)
-    .post(context.state);
-    Ok(
-        (),
-    )
+        .post(context.state);
+    Ok(())
 }
 
 fn compile_bool_not(

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
@@ -452,7 +452,7 @@ fn compile_disjunctive_strict(
 
     assert_eq!(start_times.len(), durations.len());
 
-    let post_result = pumpkin_constraints::disjunctive_strict(
+    pumpkin_constraints::disjunctive_strict(
         start_times
             .iter()
             .zip(durations.iter())
@@ -463,7 +463,7 @@ fn compile_disjunctive_strict(
         constraint_tag,
     )
     .post(context.state);
-    Ok(post_result)
+    Ok(())
 }
 
 fn compile_cumulative(
@@ -479,7 +479,7 @@ fn compile_cumulative(
     let resource_requirements = context.resolve_array_integer_constants(&exprs[2])?;
     let resource_capacity = context.resolve_integer_constant_from_expr(&exprs[3])?;
 
-    let post_result = pumpkin_constraints::cumulative_with_options(
+    pumpkin_constraints::cumulative_with_options(
         start_times.iter().copied(),
         durations.iter().copied(),
         resource_requirements.iter().copied(),
@@ -488,7 +488,7 @@ fn compile_cumulative(
         constraint_tag,
     )
     .post(context.state);
-    Ok(post_result)
+    Ok(())
 }
 
 fn compile_array_int_maximum(
@@ -501,9 +501,10 @@ fn compile_array_int_maximum(
     let rhs = context.resolve_integer_variable(&exprs[0])?;
     let array = context.resolve_integer_variable_array(&exprs[1])?;
 
+    let _: () = pumpkin_constraints::maximum(array.as_ref().to_owned(), rhs, constraint_tag)
+    .post(context.state);
     Ok(
-        pumpkin_constraints::maximum(array.as_ref().to_owned(), rhs, constraint_tag)
-            .post(context.state),
+        (),
     )
 }
 
@@ -517,9 +518,10 @@ fn compile_array_int_minimum(
     let rhs = context.resolve_integer_variable(&exprs[0])?;
     let array = context.resolve_integer_variable_array(&exprs[1])?;
 
+    let _: () = pumpkin_constraints::minimum(array.as_ref().to_owned(), rhs, constraint_tag)
+    .post(context.state);
     Ok(
-        pumpkin_constraints::minimum(array.as_ref().to_owned(), rhs, constraint_tag)
-            .post(context.state),
+        (),
     )
 }
 
@@ -534,7 +536,7 @@ fn compile_set_in_reif(
     let set = context.resolve_set_constant(&exprs[1])?;
     let reif = context.resolve_bool_variable(&exprs[2])?;
 
-    let success = match set {
+    match set {
         Set::Interval {
             lower_bound,
             upper_bound,
@@ -586,7 +588,7 @@ fn compile_set_in_reif(
         }
     };
 
-    Ok(success)
+    Ok(())
 }
 
 fn compile_array_var_int_element(
@@ -600,9 +602,10 @@ fn compile_array_var_int_element(
     let array = context.resolve_integer_variable_array(&exprs[1])?;
     let rhs = context.resolve_integer_variable(&exprs[2])?;
 
+    let _: () = pumpkin_constraints::element(index, array.as_ref().to_owned(), rhs, constraint_tag)
+    .post(context.state);
     Ok(
-        pumpkin_constraints::element(index, array.as_ref().to_owned(), rhs, constraint_tag)
-            .post(context.state),
+        (),
     )
 }
 
@@ -873,7 +876,8 @@ fn compile_ternary_int_predicate<C: Constraint>(
     let c = context.resolve_integer_variable(&exprs[2])?;
 
     let constraint = create_constraint(a, b, c, constraint_tag);
-    Ok(constraint.post(context.state))
+    constraint.post(context.state);
+    Ok(())
 }
 
 fn compile_binary_int_predicate<C: Constraint>(
@@ -890,7 +894,8 @@ fn compile_binary_int_predicate<C: Constraint>(
     let b = context.resolve_integer_variable(&exprs[1])?;
 
     let constraint = create_constraint(a, b, constraint_tag);
-    Ok(constraint.post(context.state))
+    constraint.post(context.state);
+    Ok(())
 }
 
 fn compile_reified_binary_int_predicate<C: NegatableConstraint>(
@@ -908,7 +913,8 @@ fn compile_reified_binary_int_predicate<C: NegatableConstraint>(
     let reif = context.resolve_bool_variable(&exprs[2])?;
 
     let constraint = create_constraint(a, b, constraint_tag);
-    Ok(constraint.reify(context.state, reif))
+    let _: () = constraint.reify(context.state, reif);
+    Ok(())
 }
 
 fn weighted_vars(weights: Rc<[i32]>, vars: Rc<[DomainId]>) -> Box<[AffineView<DomainId>]> {
@@ -936,7 +942,8 @@ fn compile_int_lin_predicate<C: Constraint>(
     let terms = weighted_vars(weights, vars);
 
     let constraint = create_constraint(terms, rhs, constraint_tag);
-    Ok(constraint.post(context.state))
+    constraint.post(context.state);
+    Ok(())
 }
 
 fn compile_reified_int_lin_predicate<C: NegatableConstraint>(
@@ -957,7 +964,8 @@ fn compile_reified_int_lin_predicate<C: NegatableConstraint>(
     let terms = weighted_vars(weights, vars);
 
     let constraint = create_constraint(terms, rhs, constraint_tag);
-    Ok(constraint.reify(context.state, reif))
+    let _: () = constraint.reify(context.state, reif);
+    Ok(())
 }
 
 fn compile_int_lin_imp_predicate<C: Constraint>(
@@ -978,7 +986,8 @@ fn compile_int_lin_imp_predicate<C: Constraint>(
     let terms = weighted_vars(weights, vars);
 
     let constraint = create_constraint(terms, rhs, constraint_tag);
-    Ok(constraint.implied_by(context.state, reif))
+    let _: () = constraint.implied_by(context.state, reif);
+    Ok(())
 }
 
 fn compile_binary_int_imp<C: Constraint>(
@@ -996,7 +1005,8 @@ fn compile_binary_int_imp<C: Constraint>(
     let reif = context.resolve_bool_variable(&exprs[2])?;
 
     let constraint = create_constraint(a, b, constraint_tag);
-    Ok(constraint.implied_by(context.state, reif))
+    let _: () = constraint.implied_by(context.state, reif);
+    Ok(())
 }
 
 fn compile_bool_lin_eq_predicate(
@@ -1010,13 +1020,14 @@ fn compile_bool_lin_eq_predicate(
     let bools = context.resolve_bool_variable_array(&exprs[1])?;
     let rhs = context.resolve_integer_variable(&exprs[2])?;
 
-    Ok(pumpkin_constraints::boolean_equals(
+    let _: () = pumpkin_constraints::boolean_equals(
         weights.as_ref().to_owned(),
         bools.as_ref().to_owned(),
         rhs,
         constraint_tag,
     )
-    .post(context.state))
+    .post(context.state);
+    Ok(())
 }
 
 fn compile_bool_lin_le_predicate(
@@ -1030,13 +1041,14 @@ fn compile_bool_lin_le_predicate(
     let bools = context.resolve_bool_variable_array(&exprs[1])?;
     let rhs = context.resolve_integer_constant_from_expr(&exprs[2])?;
 
-    Ok(pumpkin_constraints::boolean_less_than_or_equals(
+    let _: () = pumpkin_constraints::boolean_less_than_or_equals(
         weights.as_ref().to_owned(),
         bools.as_ref().to_owned(),
         rhs,
         constraint_tag,
     )
-    .post(context.state))
+    .post(context.state);
+    Ok(())
 }
 
 fn compile_all_different(
@@ -1048,7 +1060,8 @@ fn compile_all_different(
     check_parameters!(exprs, 1, "fzn_all_different");
 
     let variables = context.resolve_integer_variable_array(&exprs[0])?.to_vec();
-    Ok(pumpkin_constraints::all_different(variables, constraint_tag).post(context.state))
+    let _: () = pumpkin_constraints::all_different(variables, constraint_tag).post(context.state);
+    Ok(())
 }
 
 fn compile_table(
@@ -1064,13 +1077,14 @@ fn compile_table(
     let flat_table = context.resolve_array_integer_constants(&exprs[1])?;
     let table = create_table(flat_table, variables.len());
 
-    Ok(pumpkin_constraints::table(
+    let _: () = pumpkin_constraints::table(
         variables,
         table,
         constraint_tag,
         context.nogood_propagator_handle,
     )
-    .post(context.state))
+    .post(context.state);
+    Ok(())
 }
 
 fn compile_table_reif(
@@ -1088,13 +1102,14 @@ fn compile_table_reif(
 
     let reified = context.resolve_bool_variable(&exprs[2])?;
 
-    Ok(pumpkin_constraints::table(
+    let _: () = pumpkin_constraints::table(
         variables,
         table,
         constraint_tag,
         context.nogood_propagator_handle,
     )
-    .reify(context.state, reified))
+    .reify(context.state, reified);
+    Ok(())
 }
 
 fn create_table(flat_table: Rc<[i32]>, num_variables: usize) -> Vec<Vec<i32>> {

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
@@ -758,8 +758,10 @@ fn compile_bool_xor(
         .resolve_bool_variable(&exprs[1])?
         .get_true_predicate();
 
-    pumpkin_constraints::clause([!a, !b], constraint_tag, context.nogood_propagator_handle);
-    pumpkin_constraints::clause([b, a], constraint_tag, context.nogood_propagator_handle);
+    pumpkin_constraints::clause([!a, !b], constraint_tag, context.nogood_propagator_handle)
+        .post(context.state);
+    pumpkin_constraints::clause([b, a], constraint_tag, context.nogood_propagator_handle)
+        .post(context.state);
 
     Ok(())
 }

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/post_constraints.rs
@@ -3,6 +3,7 @@
 use std::rc::Rc;
 
 use pumpkin_propagators::disjunctive::ArgDisjunctiveTask;
+use pumpkin_solver::EqualityConsistency;
 use pumpkin_solver::core::constraints::Constraint;
 use pumpkin_solver::core::constraints::NegatableConstraint;
 use pumpkin_solver::core::predicate;
@@ -26,9 +27,16 @@ pub(crate) fn run(
     for (constraint_tag, constraint_item) in std::mem::take(&mut context.constraints) {
         let flatzinc::ConstraintItem { id, exprs, annos } = &constraint_item;
 
-        let is_satisfiable: bool = match id.as_str() {
+        // When we are logging a proof, we should not use domain consistent propagation
+        // at all for equality constraints.
+        let equality_consistency = match options.proof_type {
+            Some(_) => EqualityConsistency::Bound,
+            None => EqualityConsistency::Domain,
+        };
+
+        match id.as_str() {
             "pumpkin_disjunctive_strict" => {
-                compile_disjunctive_strict(context, exprs, constraint_tag)?
+                compile_disjunctive_strict(context, exprs, constraint_tag)?;
             }
             "array_int_maximum" => compile_array_int_maximum(context, exprs, constraint_tag)?,
             "array_int_minimum" => compile_array_int_minimum(context, exprs, constraint_tag)?,
@@ -52,7 +60,7 @@ pub(crate) fn run(
             // We rewrite `array_int_element` to `array_var_int_element`.
             "array_int_element" => compile_array_var_int_element(context, exprs, constraint_tag)?,
             "array_var_int_element" => {
-                compile_array_var_int_element(context, exprs, constraint_tag)?
+                compile_array_var_int_element(context, exprs, constraint_tag)?;
             }
 
             "int_eq_imp" => compile_binary_int_imp(
@@ -61,7 +69,14 @@ pub(crate) fn run(
                 annos,
                 "int_eq_imp",
                 constraint_tag,
-                pumpkin_constraints::binary_equals,
+                |lhs, rhs, constraint_tag| {
+                    pumpkin_constraints::binary_equals(
+                        lhs,
+                        rhs,
+                        constraint_tag,
+                        equality_consistency,
+                    )
+                },
             )?,
             "int_ge_imp" => compile_binary_int_imp(
                 context,
@@ -101,7 +116,14 @@ pub(crate) fn run(
                 annos,
                 "int_ne_imp",
                 constraint_tag,
-                pumpkin_constraints::binary_not_equals,
+                |lhs, rhs, constraint_tag| {
+                    pumpkin_constraints::binary_not_equals(
+                        lhs,
+                        rhs,
+                        constraint_tag,
+                        equality_consistency,
+                    )
+                },
             )?,
 
             "int_lin_eq_imp" => compile_int_lin_imp_predicate(
@@ -110,7 +132,9 @@ pub(crate) fn run(
                 annos,
                 "int_lin_eq_imp",
                 constraint_tag,
-                pumpkin_constraints::equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::equals(terms, rhs, constraint_tag, equality_consistency)
+                },
             )?,
             "int_lin_ge_imp" => compile_int_lin_imp_predicate(
                 context,
@@ -150,7 +174,14 @@ pub(crate) fn run(
                 annos,
                 "int_lin_ne_imp",
                 constraint_tag,
-                pumpkin_constraints::not_equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::not_equals(
+                        terms,
+                        rhs,
+                        constraint_tag,
+                        equality_consistency,
+                    )
+                },
             )?,
 
             "int_lin_ne" => compile_int_lin_predicate(
@@ -159,7 +190,14 @@ pub(crate) fn run(
                 annos,
                 "int_lin_ne",
                 constraint_tag,
-                pumpkin_constraints::not_equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::not_equals(
+                        terms,
+                        rhs,
+                        constraint_tag,
+                        equality_consistency,
+                    )
+                },
             )?,
             "int_lin_ne_reif" => compile_reified_int_lin_predicate(
                 context,
@@ -167,7 +205,14 @@ pub(crate) fn run(
                 annos,
                 "int_lin_ne_reif",
                 constraint_tag,
-                pumpkin_constraints::not_equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::not_equals(
+                        terms,
+                        rhs,
+                        constraint_tag,
+                        equality_consistency,
+                    )
+                },
             )?,
             "int_lin_le" => compile_int_lin_predicate(
                 context,
@@ -191,7 +236,9 @@ pub(crate) fn run(
                 annos,
                 "int_lin_eq",
                 constraint_tag,
-                pumpkin_constraints::equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::equals(terms, rhs, constraint_tag, equality_consistency)
+                },
             )?,
             "int_lin_eq_reif" => compile_reified_int_lin_predicate(
                 context,
@@ -199,7 +246,9 @@ pub(crate) fn run(
                 annos,
                 "int_lin_eq_reif",
                 constraint_tag,
-                pumpkin_constraints::equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::equals(terms, rhs, constraint_tag, equality_consistency)
+                },
             )?,
             "int_ne" => compile_binary_int_predicate(
                 context,
@@ -207,7 +256,14 @@ pub(crate) fn run(
                 annos,
                 "int_ne",
                 constraint_tag,
-                pumpkin_constraints::binary_not_equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::binary_not_equals(
+                        terms,
+                        rhs,
+                        constraint_tag,
+                        equality_consistency,
+                    )
+                },
             )?,
             "int_ne_reif" => compile_reified_binary_int_predicate(
                 context,
@@ -215,7 +271,14 @@ pub(crate) fn run(
                 annos,
                 "int_ne_reif",
                 constraint_tag,
-                pumpkin_constraints::binary_not_equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::binary_not_equals(
+                        terms,
+                        rhs,
+                        constraint_tag,
+                        equality_consistency,
+                    )
+                },
             )?,
             "int_eq" => compile_binary_int_predicate(
                 context,
@@ -223,7 +286,14 @@ pub(crate) fn run(
                 annos,
                 "int_eq",
                 constraint_tag,
-                pumpkin_constraints::binary_equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::binary_equals(
+                        terms,
+                        rhs,
+                        constraint_tag,
+                        equality_consistency,
+                    )
+                },
             )?,
             "int_eq_reif" => compile_reified_binary_int_predicate(
                 context,
@@ -231,7 +301,14 @@ pub(crate) fn run(
                 annos,
                 "int_eq_reif",
                 constraint_tag,
-                pumpkin_constraints::binary_equals,
+                |terms, rhs, constraint_tag| {
+                    pumpkin_constraints::binary_equals(
+                        terms,
+                        rhs,
+                        constraint_tag,
+                        equality_consistency,
+                    )
+                },
             )?,
             "int_le" => compile_binary_int_predicate(
                 context,
@@ -338,7 +415,6 @@ pub(crate) fn run(
             "set_in" => {
                 // 'set_in' constraints are handled in pre-processing steps.
                 // TODO: remove it from the AST, so it does not need to be matched here
-                true
             }
 
             "pumpkin_cumulative" => compile_cumulative(context, exprs, options, constraint_tag)?,
@@ -346,10 +422,6 @@ pub(crate) fn run(
                 "The `cumulative` constraint with variable duration/resource consumption/bound is not implemented yet!"
             ),
             unknown => todo!("unsupported constraint {unknown}"),
-        };
-
-        if !is_satisfiable {
-            break;
         }
     }
 
@@ -372,7 +444,7 @@ fn compile_disjunctive_strict(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, "pumpkin_cumulative");
 
     let start_times = context.resolve_integer_variable_array(&exprs[0])?;
@@ -390,8 +462,8 @@ fn compile_disjunctive_strict(
             }),
         constraint_tag,
     )
-    .post(context.solver);
-    Ok(post_result.is_ok())
+    .post(context.state);
+    Ok(post_result)
 }
 
 fn compile_cumulative(
@@ -399,7 +471,7 @@ fn compile_cumulative(
     exprs: &[flatzinc::Expr],
     options: &FlatZincOptions,
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 4, "pumpkin_cumulative");
 
     let start_times = context.resolve_integer_variable_array(&exprs[0])?;
@@ -415,15 +487,15 @@ fn compile_cumulative(
         options.cumulative_options,
         constraint_tag,
     )
-    .post(context.solver);
-    Ok(post_result.is_ok())
+    .post(context.state);
+    Ok(post_result)
 }
 
 fn compile_array_int_maximum(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, "array_int_maximum");
 
     let rhs = context.resolve_integer_variable(&exprs[0])?;
@@ -431,8 +503,7 @@ fn compile_array_int_maximum(
 
     Ok(
         pumpkin_constraints::maximum(array.as_ref().to_owned(), rhs, constraint_tag)
-            .post(context.solver)
-            .is_ok(),
+            .post(context.state),
     )
 }
 
@@ -440,7 +511,7 @@ fn compile_array_int_minimum(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, "array_int_minimum");
 
     let rhs = context.resolve_integer_variable(&exprs[0])?;
@@ -448,8 +519,7 @@ fn compile_array_int_minimum(
 
     Ok(
         pumpkin_constraints::minimum(array.as_ref().to_owned(), rhs, constraint_tag)
-            .post(context.solver)
-            .is_ok(),
+            .post(context.state),
     )
 }
 
@@ -457,7 +527,7 @@ fn compile_set_in_reif(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, "set_in_reif");
 
     let variable = context.resolve_integer_variable(&exprs[0])?;
@@ -471,57 +541,48 @@ fn compile_set_in_reif(
         } => {
             // `reif -> x \in S`
             // Decomposed to `reif -> x >= lb /\ reif -> x <= ub`
-            let forward = context
-                .solver
-                .add_clause(
-                    [
-                        !reif.get_true_predicate(),
-                        predicate![variable >= lower_bound],
-                    ],
-                    constraint_tag,
-                )
-                .is_ok()
-                && context
-                    .solver
-                    .add_clause(
-                        [
-                            !reif.get_true_predicate(),
-                            !predicate![variable >= upper_bound + 1],
-                        ],
-                        constraint_tag,
-                    )
-                    .is_ok();
+            pumpkin_constraints::clause(
+                [
+                    !reif.get_true_predicate(),
+                    predicate![variable >= lower_bound],
+                ],
+                constraint_tag,
+                context.nogood_propagator_handle,
+            )
+            .post(context.state);
+
+            pumpkin_constraints::clause(
+                [
+                    !reif.get_true_predicate(),
+                    !predicate![variable >= upper_bound + 1],
+                ],
+                constraint_tag,
+                context.nogood_propagator_handle,
+            )
+            .post(context.state);
 
             // `!reif -> x \notin S`
             // Decomposed to `!reif -> (x < lb \/ x > ub)`
-            let backward = context
-                .solver
-                .add_clause(
-                    [
-                        reif.get_true_predicate(),
-                        !predicate![variable >= lower_bound],
-                        predicate![variable >= upper_bound + 1],
-                    ],
-                    constraint_tag,
-                )
-                .is_ok();
-
-            forward && backward
+            pumpkin_constraints::clause(
+                [
+                    reif.get_true_predicate(),
+                    !predicate![variable >= lower_bound],
+                    predicate![variable >= upper_bound + 1],
+                ],
+                constraint_tag,
+                context.nogood_propagator_handle,
+            )
+            .post(context.state);
         }
 
         Set::Sparse { values } => {
             let clause = values
                 .iter()
-                .map(|&value| {
-                    context
-                        .solver
-                        .new_literal_for_predicate(predicate![variable == value], constraint_tag)
-                })
+                .map(|&value| predicate![variable == value])
                 .collect::<Vec<_>>();
 
-            pumpkin_constraints::clause(clause, constraint_tag)
-                .reify(context.solver, reif)
-                .is_ok()
+            pumpkin_constraints::clause(clause, constraint_tag, context.nogood_propagator_handle)
+                .reify(context.state, reif)
         }
     };
 
@@ -532,7 +593,7 @@ fn compile_array_var_int_element(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, "array_var_int_element");
 
     let index = context.resolve_integer_variable(&exprs[0])?.offset(-1);
@@ -541,8 +602,7 @@ fn compile_array_var_int_element(
 
     Ok(
         pumpkin_constraints::element(index, array.as_ref().to_owned(), rhs, constraint_tag)
-            .post(context.solver)
-            .is_ok(),
+            .post(context.state),
     )
 }
 
@@ -550,7 +610,7 @@ fn compile_bool_not(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     // TODO: Take this constraint into account when creating variables, as these can be opposite
     // literals of the same PropositionalVariable. Unsure how often this actually appears in models
     // though.
@@ -560,32 +620,32 @@ fn compile_bool_not(
     let a = context.resolve_bool_variable(&exprs[0])?;
     let b = context.resolve_bool_variable(&exprs[1])?;
 
-    Ok(pumpkin_constraints::binary_not_equals(a, b, constraint_tag)
-        .post(context.solver)
-        .is_ok())
+    pumpkin_constraints::binary_not_equals(a, b, constraint_tag, EqualityConsistency::Bound)
+        .post(context.state);
+    Ok(())
 }
 
 fn compile_bool_eq_reif(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, "bool_eq_reif");
 
     let a = context.resolve_bool_variable(&exprs[0])?;
     let b = context.resolve_bool_variable(&exprs[1])?;
     let r = context.resolve_bool_variable(&exprs[2])?;
 
-    Ok(pumpkin_constraints::binary_equals(a, b, constraint_tag)
-        .reify(context.solver, r)
-        .is_ok())
+    pumpkin_constraints::binary_equals(a, b, constraint_tag, EqualityConsistency::Bound)
+        .reify(context.state, r);
+    Ok(())
 }
 
 fn compile_bool_eq(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     // TODO: Take this constraint into account when merging equivalence classes. Unsure how often
     // this actually appears in models though.
     check_parameters!(exprs, 2, "bool_eq");
@@ -593,16 +653,16 @@ fn compile_bool_eq(
     let a = context.resolve_bool_variable(&exprs[0])?;
     let b = context.resolve_bool_variable(&exprs[1])?;
 
-    Ok(pumpkin_constraints::binary_equals(a, b, constraint_tag)
-        .post(context.solver)
-        .is_ok())
+    pumpkin_constraints::binary_equals(a, b, constraint_tag, EqualityConsistency::Bound)
+        .post(context.state);
+    Ok(())
 }
 
 fn compile_bool_clause(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, "bool_clause");
 
     let clause_1 = context.resolve_bool_variable_array(&exprs[0])?;
@@ -615,30 +675,37 @@ fn compile_bool_clause(
         .map(|literal| literal.get_true_predicate())
         .collect();
 
-    Ok(context.solver.add_clause(clause, constraint_tag).is_ok())
+    pumpkin_constraints::clause(clause, constraint_tag, context.nogood_propagator_handle)
+        .post(context.state);
+    Ok(())
 }
 
 fn compile_bool_and(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, "bool_and");
 
     let a = context.resolve_bool_variable(&exprs[0])?;
     let b = context.resolve_bool_variable(&exprs[1])?;
     let r = context.resolve_bool_variable(&exprs[2])?;
 
-    Ok(pumpkin_constraints::conjunction([a, b], constraint_tag)
-        .reify(context.solver, r)
-        .is_ok())
+    pumpkin_constraints::conjunction(
+        [a.get_true_predicate(), b.get_true_predicate()],
+        constraint_tag,
+        context.nogood_propagator_handle,
+    )
+    .reify(context.state, r);
+
+    Ok(())
 }
 
 fn compile_bool2int(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     // TODO: Perhaps we want to add a phase in the compiler that directly uses the literal
     // corresponding to the predicate [b = 1] for the boolean parameter in this constraint.
     // See https://emir-demirovic.atlassian.net/browse/PUM-89
@@ -648,33 +715,40 @@ fn compile_bool2int(
     let a = context.resolve_bool_variable(&exprs[0])?;
     let b = context.resolve_integer_variable(&exprs[1])?;
 
-    Ok(
-        pumpkin_constraints::binary_equals(a.get_integer_variable(), b.scaled(1), constraint_tag)
-            .post(context.solver)
-            .is_ok(),
+    pumpkin_constraints::binary_equals(
+        a.get_integer_variable(),
+        b.scaled(1),
+        constraint_tag,
+        EqualityConsistency::Bound,
     )
+    .post(context.state);
+    Ok(())
 }
 
 fn compile_bool_or(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, "bool_or");
 
     let clause = context.resolve_bool_variable_array(&exprs[0])?;
     let r = context.resolve_bool_variable(&exprs[1])?;
 
-    Ok(pumpkin_constraints::clause(clause.as_ref(), constraint_tag)
-        .reify(context.solver, r)
-        .is_ok())
+    pumpkin_constraints::clause(
+        clause.iter().map(|lit| lit.get_true_predicate()),
+        constraint_tag,
+        context.nogood_propagator_handle,
+    )
+    .reify(context.state, r);
+    Ok(())
 }
 
 fn compile_bool_xor(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, "pumpkin_bool_xor");
 
     let a = context
@@ -684,37 +758,66 @@ fn compile_bool_xor(
         .resolve_bool_variable(&exprs[1])?
         .get_true_predicate();
 
-    let c1 = context.solver.add_clause([!a, !b], constraint_tag).is_ok();
-    let c2 = context.solver.add_clause([b, a], constraint_tag).is_ok();
+    pumpkin_constraints::clause([!a, !b], constraint_tag, context.nogood_propagator_handle);
+    pumpkin_constraints::clause([b, a], constraint_tag, context.nogood_propagator_handle);
 
-    Ok(c1 && c2)
+    Ok(())
 }
 
 fn compile_bool_xor_reif(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, "pumpkin_bool_xor_reif");
 
     let a = context.resolve_bool_variable(&exprs[0])?;
     let b = context.resolve_bool_variable(&exprs[1])?;
     let r = context.resolve_bool_variable(&exprs[2])?;
 
-    let c1 = pumpkin_constraints::clause([!a, !b, !r], constraint_tag)
-        .post(context.solver)
-        .is_ok();
-    let c2 = pumpkin_constraints::clause([!a, b, r], constraint_tag)
-        .post(context.solver)
-        .is_ok();
-    let c3 = pumpkin_constraints::clause([a, !b, r], constraint_tag)
-        .post(context.solver)
-        .is_ok();
-    let c4 = pumpkin_constraints::clause([a, b, !r], constraint_tag)
-        .post(context.solver)
-        .is_ok();
+    pumpkin_constraints::clause(
+        [
+            a.get_false_predicate(),
+            b.get_false_predicate(),
+            r.get_false_predicate(),
+        ],
+        constraint_tag,
+        context.nogood_propagator_handle,
+    )
+    .post(context.state);
 
-    Ok(c1 && c2 && c3 && c4)
+    pumpkin_constraints::clause(
+        [
+            a.get_false_predicate(),
+            b.get_true_predicate(),
+            r.get_true_predicate(),
+        ],
+        constraint_tag,
+        context.nogood_propagator_handle,
+    )
+    .post(context.state);
+    pumpkin_constraints::clause(
+        [
+            a.get_true_predicate(),
+            b.get_false_predicate(),
+            r.get_true_predicate(),
+        ],
+        constraint_tag,
+        context.nogood_propagator_handle,
+    )
+    .post(context.state);
+    pumpkin_constraints::clause(
+        [
+            a.get_true_predicate(),
+            b.get_true_predicate(),
+            r.get_false_predicate(),
+        ],
+        constraint_tag,
+        context.nogood_propagator_handle,
+    )
+    .post(context.state);
+
+    Ok(())
 }
 
 fn compile_array_var_bool_element(
@@ -722,35 +825,35 @@ fn compile_array_var_bool_element(
     exprs: &[flatzinc::Expr],
     name: &str,
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, name);
 
     let index = context.resolve_integer_variable(&exprs[0])?.offset(-1);
     let array = context.resolve_bool_variable_array(&exprs[1])?;
     let rhs = context.resolve_bool_variable(&exprs[2])?;
 
-    Ok(
-        pumpkin_constraints::element(index, array.iter().cloned(), rhs, constraint_tag)
-            .post(context.solver)
-            .is_ok(),
-    )
+    pumpkin_constraints::element(index, array.iter().cloned(), rhs, constraint_tag)
+        .post(context.state);
+    Ok(())
 }
 
 fn compile_array_bool_and(
     context: &mut CompilationContext<'_>,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, "array_bool_and");
 
     let conjunction = context.resolve_bool_variable_array(&exprs[0])?;
     let r = context.resolve_bool_variable(&exprs[1])?;
 
-    Ok(
-        pumpkin_constraints::conjunction(conjunction.as_ref(), constraint_tag)
-            .reify(context.solver, r)
-            .is_ok(),
+    pumpkin_constraints::conjunction(
+        conjunction.iter().map(|lit| lit.get_true_predicate()),
+        constraint_tag,
+        context.nogood_propagator_handle,
     )
+    .reify(context.state, r);
+    Ok(())
 }
 
 fn compile_ternary_int_predicate<C: Constraint>(
@@ -760,7 +863,7 @@ fn compile_ternary_int_predicate<C: Constraint>(
     predicate_name: &str,
     constraint_tag: ConstraintTag,
     create_constraint: impl FnOnce(DomainId, DomainId, DomainId, ConstraintTag) -> C,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, predicate_name);
 
     let a = context.resolve_integer_variable(&exprs[0])?;
@@ -768,7 +871,7 @@ fn compile_ternary_int_predicate<C: Constraint>(
     let c = context.resolve_integer_variable(&exprs[2])?;
 
     let constraint = create_constraint(a, b, c, constraint_tag);
-    Ok(constraint.post(context.solver).is_ok())
+    Ok(constraint.post(context.state))
 }
 
 fn compile_binary_int_predicate<C: Constraint>(
@@ -778,14 +881,14 @@ fn compile_binary_int_predicate<C: Constraint>(
     predicate_name: &str,
     constraint_tag: ConstraintTag,
     create_constraint: impl FnOnce(DomainId, DomainId, ConstraintTag) -> C,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, predicate_name);
 
     let a = context.resolve_integer_variable(&exprs[0])?;
     let b = context.resolve_integer_variable(&exprs[1])?;
 
     let constraint = create_constraint(a, b, constraint_tag);
-    Ok(constraint.post(context.solver).is_ok())
+    Ok(constraint.post(context.state))
 }
 
 fn compile_reified_binary_int_predicate<C: NegatableConstraint>(
@@ -795,7 +898,7 @@ fn compile_reified_binary_int_predicate<C: NegatableConstraint>(
     predicate_name: &str,
     constraint_tag: ConstraintTag,
     create_constraint: impl FnOnce(DomainId, DomainId, ConstraintTag) -> C,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, predicate_name);
 
     let a = context.resolve_integer_variable(&exprs[0])?;
@@ -803,7 +906,7 @@ fn compile_reified_binary_int_predicate<C: NegatableConstraint>(
     let reif = context.resolve_bool_variable(&exprs[2])?;
 
     let constraint = create_constraint(a, b, constraint_tag);
-    Ok(constraint.reify(context.solver, reif).is_ok())
+    Ok(constraint.reify(context.state, reif))
 }
 
 fn weighted_vars(weights: Rc<[i32]>, vars: Rc<[DomainId]>) -> Box<[AffineView<DomainId>]> {
@@ -821,7 +924,7 @@ fn compile_int_lin_predicate<C: Constraint>(
     predicate_name: &str,
     constraint_tag: ConstraintTag,
     create_constraint: impl FnOnce(Box<[AffineView<DomainId>]>, i32, ConstraintTag) -> C,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, predicate_name);
 
     let weights = context.resolve_array_integer_constants(&exprs[0])?;
@@ -831,7 +934,7 @@ fn compile_int_lin_predicate<C: Constraint>(
     let terms = weighted_vars(weights, vars);
 
     let constraint = create_constraint(terms, rhs, constraint_tag);
-    Ok(constraint.post(context.solver).is_ok())
+    Ok(constraint.post(context.state))
 }
 
 fn compile_reified_int_lin_predicate<C: NegatableConstraint>(
@@ -841,7 +944,7 @@ fn compile_reified_int_lin_predicate<C: NegatableConstraint>(
     predicate_name: &str,
     constraint_tag: ConstraintTag,
     create_constraint: impl FnOnce(Box<[AffineView<DomainId>]>, i32, ConstraintTag) -> C,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 4, predicate_name);
 
     let weights = context.resolve_array_integer_constants(&exprs[0])?;
@@ -852,7 +955,7 @@ fn compile_reified_int_lin_predicate<C: NegatableConstraint>(
     let terms = weighted_vars(weights, vars);
 
     let constraint = create_constraint(terms, rhs, constraint_tag);
-    Ok(constraint.reify(context.solver, reif).is_ok())
+    Ok(constraint.reify(context.state, reif))
 }
 
 fn compile_int_lin_imp_predicate<C: Constraint>(
@@ -862,7 +965,7 @@ fn compile_int_lin_imp_predicate<C: Constraint>(
     predicate_name: &str,
     constraint_tag: ConstraintTag,
     create_constraint: impl FnOnce(Box<[AffineView<DomainId>]>, i32, ConstraintTag) -> C,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 4, predicate_name);
 
     let weights = context.resolve_array_integer_constants(&exprs[0])?;
@@ -873,7 +976,7 @@ fn compile_int_lin_imp_predicate<C: Constraint>(
     let terms = weighted_vars(weights, vars);
 
     let constraint = create_constraint(terms, rhs, constraint_tag);
-    Ok(constraint.implied_by(context.solver, reif).is_ok())
+    Ok(constraint.implied_by(context.state, reif))
 }
 
 fn compile_binary_int_imp<C: Constraint>(
@@ -883,7 +986,7 @@ fn compile_binary_int_imp<C: Constraint>(
     predicate_name: &str,
     constraint_tag: ConstraintTag,
     create_constraint: impl FnOnce(DomainId, DomainId, ConstraintTag) -> C,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, predicate_name);
 
     let a = context.resolve_integer_variable(&exprs[0])?;
@@ -891,14 +994,14 @@ fn compile_binary_int_imp<C: Constraint>(
     let reif = context.resolve_bool_variable(&exprs[2])?;
 
     let constraint = create_constraint(a, b, constraint_tag);
-    Ok(constraint.implied_by(context.solver, reif).is_ok())
+    Ok(constraint.implied_by(context.state, reif))
 }
 
 fn compile_bool_lin_eq_predicate(
     context: &mut CompilationContext,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, "bool_lin_eq");
 
     let weights = context.resolve_array_integer_constants(&exprs[0])?;
@@ -911,15 +1014,14 @@ fn compile_bool_lin_eq_predicate(
         rhs,
         constraint_tag,
     )
-    .post(context.solver)
-    .is_ok())
+    .post(context.state))
 }
 
 fn compile_bool_lin_le_predicate(
     context: &mut CompilationContext,
     exprs: &[flatzinc::Expr],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, "bool_lin_le");
 
     let weights = context.resolve_array_integer_constants(&exprs[0])?;
@@ -932,8 +1034,7 @@ fn compile_bool_lin_le_predicate(
         rhs,
         constraint_tag,
     )
-    .post(context.solver)
-    .is_ok())
+    .post(context.state))
 }
 
 fn compile_all_different(
@@ -941,15 +1042,11 @@ fn compile_all_different(
     exprs: &[flatzinc::Expr],
     _: &[flatzinc::Annotation],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 1, "fzn_all_different");
 
     let variables = context.resolve_integer_variable_array(&exprs[0])?.to_vec();
-    Ok(
-        pumpkin_constraints::all_different(variables, constraint_tag)
-            .post(context.solver)
-            .is_ok(),
-    )
+    Ok(pumpkin_constraints::all_different(variables, constraint_tag).post(context.state))
 }
 
 fn compile_table(
@@ -957,7 +1054,7 @@ fn compile_table(
     exprs: &[flatzinc::Expr],
     _: &[flatzinc::Annotation],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 2, "pumpkin_table_int");
 
     let variables = context.resolve_integer_variable_array(&exprs[0])?.to_vec();
@@ -965,9 +1062,13 @@ fn compile_table(
     let flat_table = context.resolve_array_integer_constants(&exprs[1])?;
     let table = create_table(flat_table, variables.len());
 
-    Ok(pumpkin_constraints::table(variables, table, constraint_tag)
-        .post(context.solver)
-        .is_ok())
+    Ok(pumpkin_constraints::table(
+        variables,
+        table,
+        constraint_tag,
+        context.nogood_propagator_handle,
+    )
+    .post(context.state))
 }
 
 fn compile_table_reif(
@@ -975,7 +1076,7 @@ fn compile_table_reif(
     exprs: &[flatzinc::Expr],
     _: &[flatzinc::Annotation],
     constraint_tag: ConstraintTag,
-) -> Result<bool, FlatZincError> {
+) -> Result<(), FlatZincError> {
     check_parameters!(exprs, 3, "pumpkin_table_int_reif");
 
     let variables = context.resolve_integer_variable_array(&exprs[0])?.to_vec();
@@ -985,9 +1086,13 @@ fn compile_table_reif(
 
     let reified = context.resolve_bool_variable(&exprs[2])?;
 
-    Ok(pumpkin_constraints::table(variables, table, constraint_tag)
-        .reify(context.solver, reified)
-        .is_ok())
+    Ok(pumpkin_constraints::table(
+        variables,
+        table,
+        constraint_tag,
+        context.nogood_propagator_handle,
+    )
+    .reify(context.state, reified))
 }
 
 fn create_table(flat_table: Rc<[i32]>, num_variables: usize) -> Vec<Vec<i32>> {

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/prepare_variables.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/prepare_variables.rs
@@ -91,7 +91,6 @@ mod tests {
 
     use pumpkin_core::propagators::nogoods::NogoodPropagatorConstructor;
     use pumpkin_core::state::State;
-    use pumpkin_solver::Solver;
 
     use super::*;
     use crate::flatzinc::ast::SearchStrategy;

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/prepare_variables.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/prepare_variables.rs
@@ -89,6 +89,8 @@ pub(crate) fn run(
 #[cfg(test)]
 mod tests {
 
+    use pumpkin_core::propagators::nogoods::NogoodPropagatorConstructor;
+    use pumpkin_core::state::State;
     use pumpkin_solver::Solver;
 
     use super::*;
@@ -104,8 +106,9 @@ mod tests {
             annos: vec![],
         }]);
 
-        let mut solver = Solver::default();
-        let mut context = CompilationContext::new(&mut solver);
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+        let mut context = CompilationContext::new(&mut state, nogood_propagator_handle);
 
         run(&ast, &mut context).expect("no errors");
 
@@ -128,8 +131,9 @@ mod tests {
             },
         ]);
 
-        let mut solver = Solver::default();
-        let mut context = CompilationContext::new(&mut solver);
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+        let mut context = CompilationContext::new(&mut state, nogood_propagator_handle);
 
         run(&ast, &mut context).expect("no errors");
 
@@ -151,8 +155,9 @@ mod tests {
             annos: vec![],
         }]);
 
-        let mut solver = Solver::default();
-        let mut context = CompilationContext::new(&mut solver);
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+        let mut context = CompilationContext::new(&mut state, nogood_propagator_handle);
         let _ = context.boolean_parameters.insert("FalsePar".into(), false);
 
         run(&ast, &mut context).expect("no errors");
@@ -171,8 +176,9 @@ mod tests {
             annos: vec![],
         }]);
 
-        let mut solver = Solver::default();
-        let mut context = CompilationContext::new(&mut solver);
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+        let mut context = CompilationContext::new(&mut state, nogood_propagator_handle);
 
         run(&ast, &mut context).expect("no errors");
 
@@ -192,8 +198,9 @@ mod tests {
             annos: vec![],
         }]);
 
-        let mut solver = Solver::default();
-        let mut context = CompilationContext::new(&mut solver);
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+        let mut context = CompilationContext::new(&mut state, nogood_propagator_handle);
 
         run(&ast, &mut context).expect("no errors");
 
@@ -213,8 +220,9 @@ mod tests {
             annos: vec![],
         }]);
 
-        let mut solver = Solver::default();
-        let mut context = CompilationContext::new(&mut solver);
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+        let mut context = CompilationContext::new(&mut state, nogood_propagator_handle);
         let _ = context.integer_parameters.insert("IntPar".into(), 3);
 
         run(&ast, &mut context).expect("no errors");

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/reserve_constraint_tags.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/compiler/reserve_constraint_tags.rs
@@ -12,7 +12,7 @@ pub(crate) fn run(
     context: &mut CompilationContext,
 ) -> Result<(), FlatZincError> {
     for decl in &ast.constraint_decls {
-        let tag = context.solver.new_constraint_tag();
+        let tag = context.state.new_constraint_tag();
         context.constraints.push((tag, decl.clone()));
     }
 

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/mod.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/mod.rs
@@ -447,180 +447,6 @@ fn print_solution_from_solver(solution: SolutionReference, outputs: &[Output]) {
 mod tests {
     use super::*;
 
-    // TODO: The following tests rely on observing the interal state of the solver. This is not good
-    // design, and these tests should be re-done.
-    //
-    // #[test]
-    // fn single_bool_gets_compiled_to_literal() {
-    //     let model = r#"
-    //         var bool: SomeVar;
-    //         solve satisfy;
-    //     "#;
-
-    //     let mut solver = ConstraintSatisfactionSolver::default();
-
-    //     let starting_variables = solver
-    //         .get_propositional_assignments()
-    //         .num_propositional_variables();
-
-    //     let _ =
-    //         parse_and_compile(&mut solver, model.as_bytes()).expect("compilation should
-    // succeed");
-
-    //     let final_variables = solver
-    //         .get_propositional_assignments()
-    //         .num_propositional_variables();
-
-    //     assert_eq!(1, final_variables - starting_variables);
-    // }
-
-    // #[test]
-    // fn output_annotation_is_interpreted_on_bools() {
-    //     let model = r#"
-    //         var bool: SomeVar ::output_var;
-    //         solve satisfy;
-    //     "#;
-
-    //     let mut solver = ConstraintSatisfactionSolver::default();
-
-    //     let instance =
-    //         parse_and_compile(&mut solver, model.as_bytes()).expect("compilation should
-    // succeed");
-
-    //     let literal = Literal::new(
-    //         PropositionalVariable::new(
-    //             solver
-    //                 .get_propositional_assignments()
-    //                 .num_propositional_variables()
-    //                 - 1,
-    //         ),
-    //         true,
-    //     );
-
-    //     let outputs = instance.outputs().collect::<Vec<_>>();
-    //     assert_eq!(1, outputs.len());
-
-    //     let output = outputs[0].clone();
-    //     assert_eq!(output, Output::bool("SomeVar".into(), literal));
-    // }
-
-    // #[test]
-    // fn equivalent_bools_refer_to_the_same_literal() {
-    //     let model = r#"
-    //         var bool: SomeVar;
-    //         var bool: OtherVar = SomeVar;
-    //         solve satisfy;
-    //     "#;
-
-    //     let mut solver = ConstraintSatisfactionSolver::default();
-
-    //     let starting_variables = solver
-    //         .get_propositional_assignments()
-    //         .num_propositional_variables();
-
-    //     let _ =
-    //         parse_and_compile(&mut solver, model.as_bytes()).expect("compilation should
-    // succeed");
-
-    //     let final_variables = solver
-    //         .get_propositional_assignments()
-    //         .num_propositional_variables();
-
-    //     assert_eq!(1, final_variables - starting_variables);
-    // }
-
-    // #[test]
-    // fn bool_equivalent_to_true_uses_builtin_true_literal() {
-    //     let model = r#"
-    //         var bool: SomeVar = true;
-    //         solve satisfy;
-    //     "#;
-
-    //     let mut solver = ConstraintSatisfactionSolver::default();
-
-    //     let starting_variables = solver
-    //         .get_propositional_assignments()
-    //         .num_propositional_variables();
-
-    //     let _ =
-    //         parse_and_compile(&mut solver, model.as_bytes()).expect("compilation should
-    // succeed");
-
-    //     let final_variables = solver
-    //         .get_propositional_assignments()
-    //         .num_propositional_variables();
-
-    //     assert_eq!(0, final_variables - starting_variables);
-    // }
-
-    // #[test]
-    // fn single_variable_gets_compiled_to_domain_id() {
-    //     let instance = "var 1..5: SomeVar;\nsolve satisfy;";
-    //     let mut solver = ConstraintSatisfactionSolver::default();
-
-    //     let _ = parse_and_compile(&mut solver, instance.as_bytes())
-    //         .expect("compilation should succeed");
-
-    //     let domains = solver
-    //         .get_integer_assignments()
-    //         .get_domains()
-    //         .collect::<Vec<DomainId>>();
-
-    //     assert_eq!(1, domains.len());
-
-    //     let domain = domains[0];
-    //     assert_eq!(1, solver.get_integer_assignments().get_lower_bound(domain));
-    //     assert_eq!(5, solver.get_integer_assignments().get_upper_bound(domain));
-    // }
-
-    // #[test]
-    // fn equal_integer_variables_use_one_domain_id() {
-    //     let instance = r#"
-    //          var 1..10: SomeVar;
-    //          var 0..11: OtherVar = SomeVar;
-    //          solve satisfy;
-    //      "#;
-    //     let mut solver = ConstraintSatisfactionSolver::default();
-
-    //     let _ = parse_and_compile(&mut solver, instance.as_bytes())
-    //         .expect("compilation should succeed");
-
-    //     let domains = solver
-    //         .get_integer_assignments()
-    //         .get_domains()
-    //         .collect::<Vec<DomainId>>();
-
-    //     assert_eq!(1, domains.len());
-
-    //     let domain = domains[0];
-    //     assert_eq!(1, solver.get_integer_assignments().get_lower_bound(domain));
-    //     assert_eq!(10, solver.get_integer_assignments().get_upper_bound(domain));
-    // }
-
-    // #[test]
-    // fn var_equal_to_constant_reuse_domain_id() {
-    //     let instance = r#"
-    //          var 1..10: SomeVar = 5;
-    //          var 0..11: OtherVar = 5;
-    //          solve satisfy;
-    //      "#;
-    //     let mut solver = ConstraintSatisfactionSolver::default();
-
-    //     let _ = parse_and_compile(&mut solver, instance.as_bytes())
-    //         .expect("compilation should succeed");
-
-    //     let domains = solver
-    //         .get_integer_assignments()
-    //         .get_domains()
-    //         .collect::<Vec<DomainId>>();
-
-    //     assert_eq!(1, domains.len());
-
-    //     let domain = domains[0];
-    //     assert_eq!(5, solver.get_integer_assignments().get_lower_bound(domain));
-    //     assert_eq!(5, solver.get_integer_assignments().get_upper_bound(domain));
-    // }
-
     #[test]
     fn array_1d_of_boolean_variables() {
         let instance = r#"
@@ -629,11 +455,17 @@ mod tests {
             array [1..2] of var bool: xs :: output_array([1..2]) = [x1,x2];
             solve satisfy;
         "#;
-        let mut solver = Solver::default();
 
-        let instance =
-            parse_and_compile(&mut solver, instance.as_bytes(), FlatZincOptions::default())
-                .expect("compilation should succeed");
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+
+        let instance = parse_and_compile(
+            &mut state,
+            nogood_propagator_handle,
+            instance.as_bytes(),
+            FlatZincOptions::default(),
+        )
+        .expect("compilation should succeed");
 
         let outputs = instance.outputs().collect::<Vec<_>>();
         assert_eq!(1, outputs.len());
@@ -651,11 +483,17 @@ mod tests {
             array [1..4] of var bool: xs :: output_array([1..2, 1..2]) = [x1,x2,x3,x4];
             solve satisfy;
         "#;
-        let mut solver = Solver::default();
 
-        let instance =
-            parse_and_compile(&mut solver, instance.as_bytes(), FlatZincOptions::default())
-                .expect("compilation should succeed");
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+
+        let instance = parse_and_compile(
+            &mut state,
+            nogood_propagator_handle,
+            instance.as_bytes(),
+            FlatZincOptions::default(),
+        )
+        .expect("compilation should succeed");
 
         let outputs = instance.outputs().collect::<Vec<_>>();
         assert_eq!(1, outputs.len());
@@ -669,11 +507,17 @@ mod tests {
             array [1..2] of var int: xs :: output_array([1..2]) = [x1,x2];
             solve satisfy;
         "#;
-        let mut solver = Solver::default();
 
-        let instance =
-            parse_and_compile(&mut solver, instance.as_bytes(), FlatZincOptions::default())
-                .expect("compilation should succeed");
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+
+        let instance = parse_and_compile(
+            &mut state,
+            nogood_propagator_handle,
+            instance.as_bytes(),
+            FlatZincOptions::default(),
+        )
+        .expect("compilation should succeed");
 
         let outputs = instance.outputs().collect::<Vec<_>>();
         assert_eq!(1, outputs.len());
@@ -691,11 +535,17 @@ mod tests {
             array [1..4] of var 1..10: xs :: output_array([1..2, 1..2]) = [x1,x2,x3,x4];
             solve satisfy;
         "#;
-        let mut solver = Solver::default();
 
-        let instance =
-            parse_and_compile(&mut solver, instance.as_bytes(), FlatZincOptions::default())
-                .expect("compilation should succeed");
+        let mut state = State::default();
+        let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::default());
+
+        let instance = parse_and_compile(
+            &mut state,
+            nogood_propagator_handle,
+            instance.as_bytes(),
+            FlatZincOptions::default(),
+        )
+        .expect("compilation should succeed");
 
         let outputs = instance.outputs().collect::<Vec<_>>();
         assert_eq!(1, outputs.len());

--- a/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/mod.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/flatzinc/mod.rs
@@ -15,7 +15,16 @@ use pumpkin_core::branching::branchers::alternating::AlternatingBrancher;
 use pumpkin_core::branching::branchers::alternating::every_x_restarts::EveryXRestarts;
 use pumpkin_core::branching::branchers::alternating::until_solution::UntilSolution;
 use pumpkin_core::conflict_resolving::ConflictResolver;
+use pumpkin_core::options::SolverOptions;
+use pumpkin_core::propagation::PredicateId;
+use pumpkin_core::propagators::nogoods::NogoodPropagator;
+use pumpkin_core::propagators::nogoods::NogoodPropagatorConstructor;
+use pumpkin_core::state::PropagatorHandle;
+use pumpkin_core::state::State;
+use pumpkin_core::statistics::StatisticLogger;
+use pumpkin_core::statistics::log_solver_statistics;
 use pumpkin_core::statistics::log_statistic;
+use pumpkin_core::statistics::log_statistic_postfix;
 use pumpkin_propagators::cumulative::options::CumulativeOptions;
 use pumpkin_solver::Solver;
 use pumpkin_solver::core::branching::Brancher;
@@ -84,14 +93,16 @@ fn log_statistics(
     resolver: &impl ConflictResolver,
     verbose: bool,
     init_time: Duration,
-    objective_value: Option<i64>,
+    objective_value: Option<i32>,
 ) {
     log_statistic("initTime", init_time.as_secs_f64());
-    if let Some(objective) = objective_value {
-        solver.log_statistics_with_objective(brancher, resolver, objective, verbose);
-    } else {
-        solver.log_statistics(brancher, resolver, verbose);
-    }
+    log_solver_statistics(
+        solver,
+        resolver,
+        brancher,
+        objective_value.map(i64::from),
+        verbose,
+    );
 }
 
 #[allow(clippy::too_many_arguments, reason = "Should be refactored")]
@@ -104,26 +115,19 @@ fn solution_callback(
     solver: &Solver,
     solution: SolutionReference,
     verbose: bool,
-    init_time: Duration,
 ) {
     if options_all_solutions || instance_objective_function.is_none() {
-        if let Some(objective) = instance_objective_function {
-            log_statistic("initTime", init_time.as_secs_f64());
-            solver.log_statistics_with_objective(
-                brancher,
-                resolver,
-                solution.get_integer_value(objective) as i64,
-                verbose,
-            );
-        } else {
-            solver.log_statistics(brancher, resolver, verbose)
-        }
+        let objective =
+            instance_objective_function.map(|var| solution.get_integer_value(var).into());
+
+        log_solver_statistics(solver, resolver, brancher, objective, verbose);
+
         print_solution_from_solver(solution, outputs);
     }
 }
 
 pub(crate) fn solve<R: ConflictResolver>(
-    mut solver: Solver,
+    solver_options: SolverOptions,
     instance: impl AsRef<Path>,
     time_limit: Option<Duration>,
     options: FlatZincOptions,
@@ -138,7 +142,34 @@ pub(crate) fn solve<R: ConflictResolver>(
         time_limit.map(TimeBudget::starting_now),
     );
 
-    let instance = parse_and_compile(&mut solver, instance, options)?;
+    let mut state = State::default();
+    let nogood_propagator_handle = state.add_propagator(NogoodPropagatorConstructor::new(
+        (solver_options.memory_preallocated * 1_000_000) / size_of::<PredicateId>(),
+        solver_options.learning_options,
+    ));
+
+    let instance = parse_and_compile(&mut state, nogood_propagator_handle, instance, options)?;
+
+    let mut solver = match Solver::from_state(solver_options, state, nogood_propagator_handle) {
+        Ok(solver) => solver,
+        Err(state) => {
+            let init_time = init_start_time.elapsed();
+
+            println!("{MSG_UNSATISFIABLE}");
+
+            log_statistic("nodes", 0);
+            log_statistic("restarts", 0);
+            log_statistic("peakDepth", 0);
+            log_statistic("solveTime", init_time.as_secs_f64());
+            state.log_statistics(true);
+
+            resolver.log_statistics(StatisticLogger::default());
+            log_statistic_postfix();
+
+            return Ok(());
+        }
+    };
+
     let outputs = instance.outputs.clone();
 
     let init_time = init_start_time.elapsed();
@@ -149,7 +180,7 @@ pub(crate) fn solve<R: ConflictResolver>(
             // If there is an objective, then we use the provided search until the first solution,
             // and then we switch to default search
             DynamicBrancher::new(vec![Box::new(AlternatingBrancher::new(
-                &solver,
+                solver.state(),
                 instance.search.expect("Expected a search to be defined"),
                 UntilSolution::new(EveryXRestarts::new(1)),
             ))])
@@ -157,7 +188,7 @@ pub(crate) fn solve<R: ConflictResolver>(
             // If there is no objective, then we alternate between the provided strategy and the
             // default search every restart
             DynamicBrancher::new(vec![Box::new(AlternatingBrancher::new(
-                &solver,
+                solver.state(),
                 instance.search.expect("Expected a search to be defined"),
                 EveryXRestarts::new(1),
             ))])
@@ -197,7 +228,6 @@ pub(crate) fn solve<R: ConflictResolver>(
             solver,
             solution,
             options.verbose,
-            init_time,
         );
 
         ControlFlow::Continue(())
@@ -223,7 +253,7 @@ pub(crate) fn solve<R: ConflictResolver>(
             unreachable!("the callback will never return ControlFlow::Break")
         }
         OptimisationResult::Optimal(optimal_solution) => {
-            let objective_value = optimal_solution.get_integer_value(objective) as i64;
+            let objective_value = optimal_solution.get_integer_value(objective);
             if !options.all_solutions {
                 log_statistics(
                     &solver,
@@ -247,7 +277,7 @@ pub(crate) fn solve<R: ConflictResolver>(
         }
         OptimisationResult::Satisfiable(solution) => {
             // Solutions are printed in the callback.
-            let objective_value = solution.get_integer_value(objective) as i64;
+            let objective_value = solution.get_integer_value(objective);
             log_statistics(
                 &solver,
                 &brancher,
@@ -310,7 +340,6 @@ fn satisfy(
                         solver,
                         solution.as_reference(),
                         options.verbose,
-                        init_time,
                     );
                 }
                 IteratedSolution::Finished => {
@@ -366,7 +395,6 @@ fn satisfy(
                 satisfiable.solver(),
                 satisfiable.solution(),
                 options.verbose,
-                init_time,
             ),
             SatisfactionResult::Unsatisfiable(solver, brancher, resolver) => {
                 println!("{MSG_UNSATISFIABLE}");
@@ -381,12 +409,13 @@ fn satisfy(
 }
 
 fn parse_and_compile(
-    solver: &mut Solver,
+    state: &mut State,
+    nogood_propagator_handle: PropagatorHandle<NogoodPropagator>,
     instance: impl Read,
     options: FlatZincOptions,
 ) -> Result<FlatZincInstance, FlatZincError> {
     let ast = parser::parse(instance)?;
-    compiler::compile(ast, solver, options)
+    compiler::compile(ast, state, nogood_propagator_handle, options)
 }
 
 /// Prints the current solution.

--- a/pumpkin-solver/src/bin/pumpkin-solver/main.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/main.rs
@@ -27,6 +27,8 @@ use parsers::dimacs::parse_cnf;
 use pumpkin_conflict_resolvers::resolvers::AnalysisMode;
 use pumpkin_conflict_resolvers::resolvers::NoLearningResolver;
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
+use pumpkin_core::DefaultBrancher;
+use pumpkin_core::statistics::log_solver_statistics;
 use pumpkin_propagators::cumulative::options::CumulativeOptions;
 use pumpkin_propagators::cumulative::options::CumulativePropagationMethod;
 use pumpkin_propagators::cumulative::time_table::CumulativeExplanationType;
@@ -593,7 +595,7 @@ fn run() -> PumpkinResult<()> {
         )?,
         FileFormat::FlatZinc => match args.conflict_resolver {
             ConflictResolverType::NoLearning => flatzinc::solve(
-                Solver::with_options(solver_options),
+                solver_options,
                 instance_path,
                 time_limit,
                 FlatZincOptions {
@@ -613,7 +615,7 @@ fn run() -> PumpkinResult<()> {
                 NoLearningResolver,
             )?,
             ConflictResolverType::UIP => flatzinc::solve(
-                Solver::with_options(solver_options),
+                solver_options,
                 instance_path,
                 time_limit,
                 FlatZincOptions {
@@ -652,16 +654,19 @@ fn cnf_problem(
 
     let mut termination =
         TimeBudget::starting_now(time_limit.unwrap_or(Duration::from_secs(u64::MAX)));
-    let mut brancher = solver.default_brancher();
+    let mut brancher = DefaultBrancher::default_over_all_variables(solver.state());
     let mut resolver = ResolutionResolver::default();
 
     match solver.satisfy(&mut brancher, &mut termination, &mut resolver) {
         SatisfactionResult::Satisfiable(satisfiable) => {
-            satisfiable.solver().log_statistics(
-                satisfiable.brancher(),
+            log_solver_statistics(
+                satisfiable.solver(),
                 satisfiable.conflict_resolver(),
+                satisfiable.brancher(),
+                None,
                 true,
             );
+
             println!("s SATISFIABLE");
             println!(
                 "v {}",
@@ -673,12 +678,12 @@ fn cnf_problem(
             );
         }
         SatisfactionResult::Unsatisfiable(solver, brancher, resolver) => {
-            solver.log_statistics(brancher, resolver, true);
+            log_solver_statistics(solver, resolver, brancher, None, true);
 
             println!("s UNSATISFIABLE");
         }
         SatisfactionResult::Unknown(solver, brancher, resolver) => {
-            solver.log_statistics(brancher, resolver, true);
+            log_solver_statistics(solver, resolver, brancher, None, true);
             println!("s UNKNOWN");
         }
     }

--- a/pumpkin-solver/src/bin/pumpkin-solver/maxsat/mod.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/maxsat/mod.rs
@@ -9,6 +9,7 @@ use optimisation::linear_search::LinearSearch;
 use optimisation::optimisation_result::MaxSatOptimisationResult;
 use optimisation::optimisation_solver::OptimisationSolver;
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
+use pumpkin_core::DefaultBrancher;
 use pumpkin_solver::core::options::SolverOptions;
 use pumpkin_solver::core::termination::TimeBudget;
 
@@ -32,7 +33,7 @@ pub(crate) fn wcnf_problem(
         ..
     } = parse_wcnf::<SolverDimacsSink>(instance_file, SolverArgs::new(solver_options))?;
 
-    let brancher = solver.default_brancher();
+    let brancher = DefaultBrancher::default_over_all_variables(solver.state());
     let mut termination = time_limit.map(TimeBudget::starting_now);
     let resolver = ResolutionResolver::default();
 

--- a/pumpkin-solver/src/bin/pumpkin-solver/maxsat/optimisation/linear_search.rs
+++ b/pumpkin-solver/src/bin/pumpkin-solver/maxsat/optimisation/linear_search.rs
@@ -1,5 +1,6 @@
 use log::info;
 use pumpkin_core::conflict_resolving::ConflictResolver;
+use pumpkin_core::statistics::log_solver_statistics;
 use pumpkin_solver::Solver;
 use pumpkin_solver::core::Function;
 use pumpkin_solver::core::asserts::pumpkin_assert_moderate;
@@ -40,10 +41,11 @@ impl LinearSearch {
         let mut best_objective_value =
             objective_function.evaluate_assignment(best_solution.as_reference());
 
-        solver.log_statistics_with_objective(
-            &brancher,
+        log_solver_statistics(
+            solver,
             resolver,
-            best_objective_value as i64,
+            &brancher,
+            Some(best_objective_value as i64),
             true,
         );
         println!("o {best_objective_value}");
@@ -61,10 +63,11 @@ impl LinearSearch {
 
         loop {
             if best_objective_value == objective_function.get_constant_term() {
-                solver.log_statistics_with_objective(
-                    &brancher,
+                log_solver_statistics(
+                    solver,
                     resolver,
-                    best_objective_value as i64,
+                    &brancher,
+                    Some(best_objective_value as i64),
                     true,
                 );
                 return MaxSatOptimisationResult::Optimal {
@@ -78,10 +81,11 @@ impl LinearSearch {
             // in case some cases infeasibility can be detected while constraining the upper bound
             //  meaning the current best solution is optimal
             if encoding_status.is_err() {
-                solver.log_statistics_with_objective(
-                    &brancher,
+                log_solver_statistics(
+                    solver,
                     resolver,
-                    best_objective_value as i64,
+                    &brancher,
+                    Some(best_objective_value as i64),
                     true,
                 );
                 return MaxSatOptimisationResult::Optimal {
@@ -107,10 +111,11 @@ impl LinearSearch {
                     best_objective_value = new_objective_value;
                     best_solution = satisfiable.solution().into();
 
-                    satisfiable.solver().log_statistics_with_objective(
-                        satisfiable.brancher(),
+                    log_solver_statistics(
+                        satisfiable.solver(),
                         satisfiable.conflict_resolver(),
-                        best_objective_value as i64,
+                        satisfiable.brancher(),
+                        Some(best_objective_value as i64),
                         true,
                     );
 
@@ -123,10 +128,11 @@ impl LinearSearch {
                     );
                 }
                 SatisfactionResult::Unsatisfiable(solver, brancher, resolver) => {
-                    solver.log_statistics_with_objective(
-                        brancher,
+                    log_solver_statistics(
+                        solver,
                         resolver,
-                        best_objective_value as i64,
+                        brancher,
+                        Some(best_objective_value as i64),
                         true,
                     );
 
@@ -135,10 +141,11 @@ impl LinearSearch {
                     };
                 }
                 SatisfactionResult::Unknown(solver, brancher, resolver) => {
-                    solver.log_statistics_with_objective(
-                        brancher,
+                    log_solver_statistics(
+                        solver,
                         resolver,
-                        best_objective_value as i64,
+                        brancher,
+                        Some(best_objective_value as i64),
                         true,
                     );
                     return MaxSatOptimisationResult::Satisfiable { best_solution };

--- a/pumpkin-solver/tests/core_extraction.rs
+++ b/pumpkin-solver/tests/core_extraction.rs
@@ -1,6 +1,7 @@
 #![cfg(test)] // workaround for https://github.com/rust-lang/rust-clippy/issues/11024
 
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
+use pumpkin_core::DefaultBrancher;
 use pumpkin_core::Solver;
 use pumpkin_core::predicate;
 use pumpkin_core::results::SatisfactionResultUnderAssumptions;
@@ -30,7 +31,7 @@ fn basic_core_extraction() {
     // We create a termination condition which allows the solver to run indefinitely
     let mut termination = Indefinite;
     // And we create a search strategy (in this case, simply the default)
-    let mut brancher = solver.default_brancher();
+    let mut brancher = DefaultBrancher::default_over_all_variables(solver.state());
 
     let mut resolver = ResolutionResolver::default();
 

--- a/pumpkin-solver/tests/iteration_test.rs
+++ b/pumpkin-solver/tests/iteration_test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)] // workaround for https://github.com/rust-lang/rust-clippy/issues/11024
 
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
+use pumpkin_core::DefaultBrancher;
 use pumpkin_solver::Solver;
 use pumpkin_solver::core::results::ProblemSolution;
 use pumpkin_solver::core::results::solution_iterator::IteratedSolution;
@@ -29,7 +30,7 @@ fn iterator_finds_all_solutions() {
     // We create a termination condition which allows the solver to run indefinitely
     let mut termination = Indefinite;
     // And we create a search strategy (in this case, simply the default)
-    let mut brancher = solver.default_brancher();
+    let mut brancher = DefaultBrancher::default_over_all_variables(solver.state());
     let mut resolver = ResolutionResolver::default();
 
     // Then we solve to satisfaction

--- a/pumpkin-solver/tests/solver_test.rs
+++ b/pumpkin-solver/tests/solver_test.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use pumpkin_conflict_resolvers::resolvers::ResolutionResolver;
+use pumpkin_core::DefaultBrancher;
 use pumpkin_solver::Solver;
 use pumpkin_solver::core::options::SolverOptions;
 use pumpkin_solver::core::predicate;
@@ -23,7 +24,11 @@ fn proof_with_reified_literals() {
     let literal = solver.new_literal_for_predicate(predicate![variable == 5], constraint_tag);
 
     solver
-        .add_constraint(pumpkin_constraints::clause(vec![literal], constraint_tag))
+        .add_constraint(pumpkin_constraints::clause(
+            vec![literal.get_true_predicate()],
+            constraint_tag,
+            solver.nogood_propagator_handle(),
+        ))
         .post()
         .expect("no error");
 
@@ -32,11 +37,12 @@ fn proof_with_reified_literals() {
             [variable],
             5,
             constraint_tag,
+            pumpkin_solver::EqualityConsistency::Bound,
         ))
         .post()
         .expect_err("unsat");
 
-    let mut brancher = solver.default_brancher();
+    let mut brancher = DefaultBrancher::default_over_all_variables(solver.state());
     let mut resolver = ResolutionResolver::default();
 
     let result = solver.satisfy(&mut brancher, &mut Indefinite, &mut resolver);
@@ -60,6 +66,7 @@ fn proof_with_equality_unit_nogood_step() {
             x1,
             x2,
             constraint_tag,
+            pumpkin_solver::EqualityConsistency::Bound,
         ))
         .post()
         .expect("no conflict");
@@ -73,7 +80,7 @@ fn proof_with_equality_unit_nogood_step() {
         .post()
         .expect_err("conflict");
 
-    let mut brancher = solver.default_brancher();
+    let mut brancher = DefaultBrancher::default_over_all_variables(solver.state());
     let mut resolver = ResolutionResolver::default();
 
     let result = solver.satisfy(&mut brancher, &mut Indefinite, &mut resolver);


### PR DESCRIPTION
We change when we run root-level propagation. Previously, we ran propagation after every individual constraint was added. This is slightly slower than running all propagation at once, but more importantly, running the root-propagation once makes debugging a lot simpler :).

This PR encompasses the following change:
- The `Constraint::post` function takes a `State` instead of a `Solver`
- The `Constraint::post` function does not return a `Result` anymore, since it cannot detect a `ConstraintOperationError`.
- Whether `equals` can use domain propagation is now an argument of the various constraint functions, since it does not have access to whether the solver is proof logging or not
- The nogood propagator handle used by the solver is publicly exposed, to allow adding of nogoods through the `conjunction` and `clause` constraints
- Introduced `Solver::from_state` to construct the solver from a preconfigured `State`.

Note that `Solver::add_constraint` still exists.

Aside from these changes, there are various test cleanups to now use `State` directly, rather than construct `Assignments`, `NotificationEngine`, etc.