### PR TITLE
fix(pumpkin-core): Upgrade to rand 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chumsky"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +310,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -787,6 +807,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -2029,15 +2050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,33 +2341,20 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -2520,7 +2519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3235,26 +3234,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/pumpkin-crates/core/Cargo.toml
+++ b/pumpkin-crates/core/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.17"
 bitfield = "0.14.0"
 enumset = "1.1.2"
 fnv = "1.0.7" # We require features which are on the `main` branch of the repository but are not on crates.io
-rand = { version = "0.8.5", features = [ "small_rng", "alloc" ] }
+rand = { version = "0.10.1", features = [ "alloc" ] }
 once_cell = "1.19.0"
 downcast-rs = "1.2.1"
 drcp-format = { version = "0.3.1", path = "../../drcp-format" }

--- a/pumpkin-crates/core/src/basic_types/random.rs
+++ b/pumpkin-crates/core/src/basic_types/random.rs
@@ -6,6 +6,7 @@ use std::ops::Range;
     reason = "we implement our random generator using rand"
 )]
 use rand::Rng;
+use rand::RngExt;
 #[allow(
     clippy::disallowed_types,
     reason = "we implement our random generator using rand"
@@ -96,19 +97,19 @@ where
             "It should hold that 0.0 <= {probability} <= 1.0"
         );
 
-        self.gen_bool(probability)
+        self.random_bool(probability)
     }
 
     fn generate_usize_in_range(&mut self, range: Range<usize>) -> usize {
-        self.gen_range(range)
+        self.random_range(range)
     }
 
     fn generate_i32_in_range(&mut self, lb: i32, ub: i32) -> i32 {
-        self.gen_range(lb..=ub)
+        self.random_range(lb..=ub)
     }
 
     fn generate_f64(&mut self) -> f64 {
-        self.gen_range(0.0..1.0)
+        self.random_range(0.0..1.0)
     }
 
     fn get_weighted_choice(&mut self, weights: &[f64]) -> Option<usize> {


### PR DESCRIPTION
The 0.8.5 version we were using has unsound behavior. It triggers cargo-deny and prevents CI from building any other PRs.