### PR TITLE
refactor(pumpkin-core): Attach `InferenceCode` instead of `Predicate`

### DIFF
--- a/pumpkin-crates/core/src/conflict_resolving/conflict_analysis_context.rs
+++ b/pumpkin-crates/core/src/conflict_resolving/conflict_analysis_context.rs
@@ -333,12 +333,12 @@ impl ConflictAnalysisContext<'_> {
     ) -> Option<InferenceCode> {
         let inference_code = state.get_propagation_reason(predicate, reason_buffer, current_nogood);
 
-        if inference_code.is_some() {
+        if let Some(ref ic) = inference_code {
             let trail_index = state.trail_position(predicate).expect(
                 "an inference code is only present if the propagated predicate is on the trail",
             );
             let trail_entry = state.assignments.get_trail_entry(trail_index);
-            let Some((reason_ref, inference_code)) = trail_entry.reason else {
+            let Some(reason_ref) = trail_entry.reason else {
                 return inference_code;
             };
 
@@ -355,7 +355,7 @@ impl ConflictAnalysisContext<'_> {
                 //
                 // It could be that the predicate is implied by another unit nogood
 
-                let inference_code = unit_nogood_inference_codes
+                let unit_ic = unit_nogood_inference_codes
                     .get(&predicate)
                     .or_else(|| {
                         // It could be the case that we attempt to get the reason for the predicate
@@ -370,7 +370,7 @@ impl ConflictAnalysisContext<'_> {
 
                 let _ = proof_log.log_inference(
                     &mut state.constraint_tags,
-                    inference_code.clone(),
+                    unit_ic.clone(),
                     [],
                     Some(predicate),
                     &state.variable_names,
@@ -380,7 +380,7 @@ impl ConflictAnalysisContext<'_> {
                 // Otherwise we log the inference which was used to derive the nogood
                 let _ = proof_log.log_inference(
                     &mut state.constraint_tags,
-                    inference_code,
+                    ic.clone(),
                     reason_buffer.as_ref().iter().copied(),
                     Some(predicate),
                     &state.variable_names,
@@ -401,7 +401,7 @@ impl ConflictAnalysisContext<'_> {
         // Look up the reason for the bound that changed.
         // The reason for changing the bound cannot be a decision, so we can safely unwrap.
         let mut empty_domain_reason: Vec<Predicate> = vec![];
-        let _ = self.state.reason_store.get_or_compute(
+        let trigger_inference_code = self.state.reason_store.get_or_compute(
             conflict.trigger_reason.expect("in conflict analysis the empty domain conflict is always triggered by a propagation"),
             ExplanationContext::without_working_nogood(
                 &self.state.assignments,
@@ -417,7 +417,7 @@ impl ConflictAnalysisContext<'_> {
         // We also need to log this last propagation to the proof log as an inference.
         let _ = self.proof_log.log_inference(
             &mut self.state.constraint_tags,
-            conflict.trigger_inference_code.expect("in conflict analysis the empty domain conflict is always triggered by a propagation"),
+            trigger_inference_code,
             empty_domain_reason.iter().copied(),
             Some(conflict.trigger_predicate),
             &self.state.variable_names,

--- a/pumpkin-crates/core/src/engine/conflict.rs
+++ b/pumpkin-crates/core/src/engine/conflict.rs
@@ -49,15 +49,10 @@ impl From<PropagatorConflict> for Conflict {
 }
 
 /// A conflict because a domain became empty.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct EmptyDomainConflict {
     /// The predicate that caused a domain to become empty.
     pub trigger_predicate: Predicate,
-    /// The [`InferenceCode`] that accompanies triggered the conflict.
-    ///
-    /// If the empty domain is not triggered by a propagation, this is [`None`].
-    pub trigger_inference_code: Option<InferenceCode>,
-
     /// The reason for [`EmptyDomainConflict::trigger_predicate`] to be true.
     ///
     /// If the empty domain is not triggered by a propagation, this is [`None`].
@@ -77,9 +72,9 @@ impl EmptyDomainConflict {
         state: &mut State,
         reason_buffer: &mut (impl Extend<Predicate> + AsRef<[Predicate]>),
         current_nogood: CurrentNogood,
-    ) {
-        if let Some(reason_ref) = self.trigger_reason {
-            let _ = state.reason_store.get_or_compute(
+    ) -> Option<InferenceCode> {
+        self.trigger_reason.map(|reason_ref| {
+            state.reason_store.get_or_compute(
                 reason_ref,
                 ExplanationContext::new(
                     &state.assignments,
@@ -89,8 +84,8 @@ impl EmptyDomainConflict {
                 ),
                 &mut state.propagators,
                 reason_buffer,
-            );
-        }
+            )
+        })
     }
 }
 

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -755,9 +755,13 @@ impl ConstraintSatisfactionSolver {
 
         for trail_idx in start_trail_index..self.state.trail_len() {
             let entry = self.state.trail_entry(trail_idx);
-            let (_, inference_code) = entry
-                .reason
-                .expect("Added by a propagator and must therefore have a reason");
+
+            // Get the conjunction of predicates explaining the propagation along with the
+            // InferenceCode identifying the explanation algorithm.
+            let mut reason = vec![];
+            let inference_code = self
+                .state
+                .get_propagation_reason_trail_entry(trail_idx, &mut reason);
 
             if !self.internal_parameters.proof_log.is_logging_inferences() {
                 // In case we are not logging inferences, we only need to keep track
@@ -768,11 +772,6 @@ impl ConstraintSatisfactionSolver {
                     .insert(entry.predicate, inference_code);
                 continue;
             }
-
-            // Get the conjunction of predicates explaining the propagation.
-            let mut reason = vec![];
-            self.state
-                .get_propagation_reason_trail_entry(trail_idx, &mut reason);
 
             let propagated = entry.predicate;
 

--- a/pumpkin-crates/core/src/engine/cp/assignments.rs
+++ b/pumpkin-crates/core/src/engine/cp/assignments.rs
@@ -394,15 +394,13 @@ impl Assignments {
     }
 }
 
-pub(crate) type AssignmentReason = ReasonRef;
-
 // methods to change the domains
 impl Assignments {
     fn tighten_lower_bound(
         &mut self,
         domain_id: DomainId,
         new_lower_bound: i32,
-        reason: Option<AssignmentReason>,
+        reason: Option<ReasonRef>,
     ) -> Result<bool, EmptyDomain> {
         // No need to do any changes if the new lower bound is weaker.
         if new_lower_bound <= self.get_lower_bound(domain_id) {
@@ -442,7 +440,7 @@ impl Assignments {
         &mut self,
         domain_id: DomainId,
         new_upper_bound: i32,
-        reason: Option<AssignmentReason>,
+        reason: Option<ReasonRef>,
     ) -> Result<bool, EmptyDomain> {
         // No need to do any changes if the new upper bound is weaker.
         if new_upper_bound >= self.get_upper_bound(domain_id) {
@@ -482,7 +480,7 @@ impl Assignments {
         &mut self,
         domain_id: DomainId,
         assigned_value: i32,
-        reason: Option<AssignmentReason>,
+        reason: Option<ReasonRef>,
     ) -> Result<bool, EmptyDomain> {
         let mut update_took_place = false;
 
@@ -529,7 +527,7 @@ impl Assignments {
         &mut self,
         domain_id: DomainId,
         removed_value_from_domain: i32,
-        reason: Option<AssignmentReason>,
+        reason: Option<ReasonRef>,
     ) -> Result<bool, EmptyDomain> {
         // No need to do any changes if the value is not present anyway.
         if !self.domains[domain_id].contains(removed_value_from_domain) {
@@ -580,7 +578,7 @@ impl Assignments {
     pub(crate) fn post_predicate(
         &mut self,
         predicate: Predicate,
-        reason: Option<AssignmentReason>,
+        reason: Option<ReasonRef>,
         notification_engine: &mut NotificationEngine,
     ) -> Result<bool, EmptyDomain> {
         let (lower_bound_before, upper_bound_before) = self.bounds[predicate.get_domain()];
@@ -797,7 +795,7 @@ pub(crate) struct ConstraintProgrammingTrailEntry {
     /// Stores the a reference to the reason in the `ReasonStore`, only makes sense if a
     /// propagation  took place, e.g., does _not_ make sense in the case of a decision or if
     /// the update was due  to synchronisation from the propositional trail.
-    pub(crate) reason: Option<AssignmentReason>,
+    pub(crate) reason: Option<ReasonRef>,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/pumpkin-crates/core/src/engine/cp/assignments.rs
+++ b/pumpkin-crates/core/src/engine/cp/assignments.rs
@@ -8,7 +8,6 @@ use crate::engine::predicates::predicate::PredicateType;
 use crate::engine::variables::DomainGeneratorIterator;
 use crate::engine::variables::DomainId;
 use crate::predicate;
-use crate::proof::InferenceCode;
 use crate::pumpkin_assert_eq_moderate;
 use crate::pumpkin_assert_eq_simple;
 use crate::pumpkin_assert_moderate;
@@ -108,8 +107,6 @@ impl Assignments {
     }
 
     pub(crate) fn get_trail_entry(&self, index: usize) -> ConstraintProgrammingTrailEntry {
-        // The clone is required because of InferenceCode is not copy. However, it is a
-        // reference-counted type, so cloning is cheap.
         self.trail[index].clone()
     }
 
@@ -397,7 +394,7 @@ impl Assignments {
     }
 }
 
-pub(crate) type AssignmentReason = (ReasonRef, InferenceCode);
+pub(crate) type AssignmentReason = ReasonRef;
 
 // methods to change the domains
 impl Assignments {
@@ -750,15 +747,15 @@ impl Assignments {
     }
 
     /// todo: This is a temporary hack, not to be used in general.
-    pub(crate) fn remove_last_trail_element(&mut self) -> (Predicate, ReasonRef, InferenceCode) {
+    pub(crate) fn remove_last_trail_element(&mut self) -> (Predicate, ReasonRef) {
         let entry = self.trail.pop().unwrap();
         let domain_id = entry.predicate.get_domain();
         self.domains[domain_id].undo_trail_entry(&entry);
         self.update_bounds_snapshot(domain_id);
 
-        let (reason, inference_code) = entry.reason.unwrap();
+        let reason_ref = entry.reason.unwrap();
 
-        (entry.predicate, reason, inference_code)
+        (entry.predicate, reason_ref)
     }
 
     /// Get the number of values pruned from all the domains.
@@ -781,7 +778,7 @@ impl Assignments {
             .iter()
             .find_map(|entry| {
                 if entry.predicate == predicate {
-                    entry.reason.as_ref().map(|(reason_ref, _)| *reason_ref)
+                    entry.reason
                 } else {
                     None
                 }

--- a/pumpkin-crates/core/src/engine/cp/mod.rs
+++ b/pumpkin-crates/core/src/engine/cp/mod.rs
@@ -46,8 +46,10 @@ mod tests {
 
             let result = context.post(
                 predicate![domain >= 2],
-                conjunction!(),
-                &InferenceCode::unknown_label(ConstraintTag::create_from_index(0)),
+                (
+                    conjunction!(),
+                    &InferenceCode::unknown_label(ConstraintTag::create_from_index(0)),
+                ),
             );
             assert!(result.is_ok());
         }
@@ -75,8 +77,10 @@ mod tests {
 
             let result = context.post(
                 predicate![domain <= 15],
-                conjunction!(),
-                &InferenceCode::unknown_label(ConstraintTag::create_from_index(0)),
+                (
+                    conjunction!(),
+                    &InferenceCode::unknown_label(ConstraintTag::create_from_index(0)),
+                ),
             );
             assert!(result.is_ok());
         }
@@ -104,8 +108,10 @@ mod tests {
 
             let result = context.post(
                 predicate![domain != 15],
-                conjunction!(),
-                &InferenceCode::unknown_label(ConstraintTag::create_from_index(0)),
+                (
+                    conjunction!(),
+                    &InferenceCode::unknown_label(ConstraintTag::create_from_index(0)),
+                ),
             );
             assert!(result.is_ok());
         }

--- a/pumpkin-crates/core/src/engine/cp/reason.rs
+++ b/pumpkin-crates/core/src/engine/cp/reason.rs
@@ -5,6 +5,7 @@ use crate::basic_types::Trail;
 #[cfg(doc)]
 use crate::containers::KeyedVec;
 use crate::predicates::Predicate;
+use crate::proof::InferenceCode;
 use crate::propagation::ExplanationContext;
 use crate::propagation::PropagatorId;
 use crate::propagation::store::PropagatorStore;
@@ -33,30 +34,32 @@ impl ReasonStore {
         Slot { store: self }
     }
 
-    /// Evaluate the reason with the given reference, and write the predicates to
-    /// `destination_buffer`.
+    /// Evaluate the reason with the given reference, write the predicates to `destination_buffer`,
+    /// and return the [`InferenceCode`] associated with the reason.
+    ///
+    /// # Panics
+    /// Panics if `reference` does not exist in the store.
     pub(crate) fn get_or_compute(
         &self,
         reference: ReasonRef,
         context: ExplanationContext<'_>,
         propagators: &mut PropagatorStore,
         destination_buffer: &mut impl Extend<Predicate>,
-    ) -> bool {
-        let Some(reason) = self.trail.get(reference.0 as usize) else {
-            return false;
-        };
+    ) -> InferenceCode {
+        let reason = self
+            .trail
+            .get(reference.0 as usize)
+            .expect("reason reference should not be stale");
 
         reason
             .1
-            .compute(context, reason.0, propagators, destination_buffer);
-
-        true
+            .compute(context, reason.0, propagators, destination_buffer)
     }
 
     pub(crate) fn get_lazy_code(&self, reference: ReasonRef) -> Option<&u64> {
         match self.trail.get(reference.0 as usize) {
             Some(reason) => match &reason.1 {
-                StoredReason::Eager(_) => None,
+                StoredReason::Eager(_, _) => None,
                 StoredReason::DynamicLazy(code) => Some(code),
             },
             None => None,
@@ -90,14 +93,15 @@ pub(crate) struct ReasonRef(pub(crate) u32);
 #[derive(Debug)]
 pub enum Reason {
     /// An eager reason contains the propositional conjunction with the reason, without the
-    ///   propagated predicate.
-    Eager(PropositionalConjunction),
+    ///   propagated predicate, and the [`InferenceCode`] identifying the explanation algorithm.
+    Eager(PropositionalConjunction, InferenceCode),
     /// A lazy reason, which is computed on-demand rather than up-front. This is also referred to
     /// as a 'backward' reason.
     ///
     /// A lazy reason contains a payload that propagators can use to identify what type of
     /// propagation the reason is for. The payload should be enough for the propagator to construct
-    /// an explanation based on its internal state.
+    /// an explanation based on its internal state. The [`InferenceCode`] is returned by
+    /// [`crate::propagation::Propagator::lazy_explanation`] on demand.
     DynamicLazy(u64),
 }
 
@@ -105,44 +109,48 @@ pub enum Reason {
 #[derive(Debug, Clone)]
 pub(crate) enum StoredReason {
     /// An eager reason contains the propositional conjunction with the reason, without the
-    ///   propagated predicate.
-    Eager(PropositionalConjunction),
+    ///   propagated predicate, and the [`InferenceCode`] identifying the explanation algorithm.
+    Eager(PropositionalConjunction, InferenceCode),
     /// A lazy reason, which is computed on-demand rather than up-front. This is also referred to
     /// as a 'backward' reason.
     ///
     /// A lazy reason contains a payload that propagators can use to identify what type of
     /// propagation the reason is for. The payload should be enough for the propagator to construct
-    /// an explanation based on its internal state.
+    /// an explanation based on its internal state. The [`InferenceCode`] is returned by
+    /// [`crate::propagation::Propagator::lazy_explanation`] on demand.
     DynamicLazy(u64),
 }
 
 impl StoredReason {
-    /// Evaluate the reason, and write the predicates to the `destination_buffer`.
+    /// Evaluate the reason, write the predicates to `destination_buffer`, and return the
+    /// [`InferenceCode`] associated with the reason.
     pub(crate) fn compute(
         &self,
         context: ExplanationContext<'_>,
         propagator_id: PropagatorId,
         propagators: &mut PropagatorStore,
         destination_buffer: &mut impl Extend<Predicate>,
-    ) {
+    ) -> InferenceCode {
         match self {
             // We do not replace the reason with an eager explanation for dynamic lazy explanations.
             //
             // Benchmarking will have to show whether this should change or not.
-            StoredReason::DynamicLazy(code) => destination_buffer.extend(
-                propagators[propagator_id]
-                    .lazy_explanation(*code, context)
-                    .iter()
-                    .copied(),
-            ),
-            StoredReason::Eager(result) => destination_buffer.extend(result.iter().copied()),
+            StoredReason::DynamicLazy(code) => {
+                let expl = propagators[propagator_id].lazy_explanation(*code, context);
+                destination_buffer.extend(expl.predicates.iter().copied());
+                expl.inference_code
+            }
+            StoredReason::Eager(result, inference_code) => {
+                destination_buffer.extend(result.iter().copied());
+                inference_code.clone()
+            }
         }
     }
 }
 
-impl From<PropositionalConjunction> for Reason {
-    fn from(value: PropositionalConjunction) -> Self {
-        Reason::Eager(value)
+impl From<(PropositionalConjunction, &InferenceCode)> for Reason {
+    fn from((conj, code): (PropositionalConjunction, &InferenceCode)) -> Self {
+        Reason::Eager(conj, code.clone())
     }
 }
 
@@ -178,11 +186,18 @@ impl Slot<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZero;
+
     use super::*;
     use crate::conjunction;
     use crate::engine::Assignments;
     use crate::engine::notifications::NotificationEngine;
     use crate::engine::variables::DomainId;
+    use crate::proof::ConstraintTag;
+
+    fn dummy_inference_code() -> InferenceCode {
+        InferenceCode::unknown_label(ConstraintTag::from_non_zero(NonZero::new(1).unwrap()))
+    }
 
     #[test]
     fn computing_an_eager_reason_returns_a_reference_to_the_conjunction() {
@@ -193,10 +208,10 @@ mod tests {
         let y = DomainId::new(1);
 
         let conjunction = conjunction!([x == 1] & [y == 2]);
-        let reason = StoredReason::Eager(conjunction.clone());
+        let reason = StoredReason::Eager(conjunction.clone(), dummy_inference_code());
 
         let mut out_reason = vec![];
-        reason.compute(
+        let _ = reason.compute(
             ExplanationContext::test_new(&integers, &mut notification_engine),
             PropagatorId(0),
             &mut PropagatorStore::default(),
@@ -216,8 +231,10 @@ mod tests {
         let y = DomainId::new(1);
 
         let conjunction = conjunction!([x == 1] & [y == 2]);
-        let reason_ref =
-            reason_store.push(PropagatorId(0), StoredReason::Eager(conjunction.clone()));
+        let reason_ref = reason_store.push(
+            PropagatorId(0),
+            StoredReason::Eager(conjunction.clone(), dummy_inference_code()),
+        );
 
         assert_eq!(ReasonRef(0), reason_ref);
 

--- a/pumpkin-crates/core/src/engine/debug_helper.rs
+++ b/pumpkin-crates/core/src/engine/debug_helper.rs
@@ -169,8 +169,7 @@ impl DebugHelper {
             let _ = reason_store.get_or_compute(
                 trail_entry
                     .reason
-                    .expect("Expected checked propagation to have a reason")
-                    .0,
+                    .expect("Expected checked propagation to have a reason"),
                 ExplanationContext::without_working_nogood(
                     assignments,
                     trail_index,

--- a/pumpkin-crates/core/src/engine/state.rs
+++ b/pumpkin-crates/core/src/engine/state.rs
@@ -694,12 +694,12 @@ impl State {
         for trail_index in first_propagation_index..self.assignments.num_trail_entries() {
             let entry = self.assignments.get_trail_entry(trail_index);
 
-            let (reason_ref, inference_code) = entry
+            let reason_ref = entry
                 .reason
                 .expect("propagations should only be checked after propagations");
 
             reason_buffer.clear();
-            let reason_exists = self.reason_store.get_or_compute(
+            let inference_code = self.reason_store.get_or_compute(
                 reason_ref,
                 ExplanationContext::without_working_nogood(
                     &self.assignments,
@@ -709,7 +709,6 @@ impl State {
                 &mut self.propagators,
                 &mut reason_buffer,
             );
-            assert!(reason_exists, "all propagations have reasons");
 
             self.run_checker(
                 std::mem::take(&mut reason_buffer),

--- a/pumpkin-crates/core/src/engine/state.rs
+++ b/pumpkin-crates/core/src/engine/state.rs
@@ -12,15 +12,17 @@ use crate::engine::Assignments;
 use crate::engine::ConstraintProgrammingTrailEntry;
 use crate::engine::DebugHelper;
 use crate::engine::PropagatorQueue;
-#[cfg(test)]
-use crate::engine::Reason;
 use crate::engine::TrailedValues;
 use crate::engine::VariableNames;
+#[cfg(test)]
+use crate::engine::cp::reason::StoredReason;
 use crate::engine::notifications::NotificationEngine;
 use crate::engine::reason::ReasonStore;
 use crate::predicate;
 use crate::predicates::Predicate;
 use crate::predicates::PredicateType;
+#[cfg(test)]
+use crate::predicates::PropositionalConjunction;
 use crate::proof::ConstraintTag;
 use crate::proof::InferenceCode;
 use crate::propagation::CurrentNogood;
@@ -446,7 +448,6 @@ impl State {
             .post_predicate(predicate, None, &mut self.notification_engine)
             .map_err(|_| EmptyDomainConflict {
                 trigger_predicate: predicate,
-                trigger_inference_code: None,
                 trigger_reason: None,
             })
     }
@@ -455,7 +456,7 @@ impl State {
     fn post_with_reason(
         &mut self,
         predicate: Predicate,
-        reason: impl Into<Reason>,
+        reason: PropositionalConjunction,
         inference_code: InferenceCode,
         propagator_id: PropagatorId,
     ) -> Result<(), EmptyDomainConflict> {
@@ -463,29 +464,24 @@ impl State {
 
         let modification_result = self.assignments.post_predicate(
             predicate,
-            Some((slot.reason_ref(), inference_code.clone())),
+            Some(slot.reason_ref()),
             &mut self.notification_engine,
         );
 
         match modification_result {
             Ok(false) => Ok(()),
             Ok(true) => {
-                use crate::propagation::build_reason;
-
-                let _ = slot.populate(propagator_id, build_reason(reason, None));
+                let _ = slot.populate(propagator_id, StoredReason::Eager(reason, inference_code));
                 Ok(())
             }
             Err(_) => {
-                use crate::propagation::build_reason;
-
-                let _ = slot.populate(propagator_id, build_reason(reason, None));
-                let (trigger_predicate, trigger_reason, trigger_inference_code) =
+                let _ = slot.populate(propagator_id, StoredReason::Eager(reason, inference_code));
+                let (trigger_predicate, trigger_reason) =
                     self.assignments.remove_last_trail_element();
 
                 Err(EmptyDomainConflict {
                     trigger_predicate,
                     trigger_reason: Some(trigger_reason),
-                    trigger_inference_code: Some(trigger_inference_code),
                 })
             }
         }
@@ -826,12 +822,12 @@ impl State {
         &mut self,
         trail_position: usize,
         reason_buffer: &mut (impl Extend<Predicate> + AsRef<[Predicate]>),
-    ) {
+    ) -> InferenceCode {
         let entry = self.trail_entry(trail_position);
-        let (reason_ref, _) = entry
+        let reason_ref = entry
             .reason
             .expect("Added by a propagator and must therefore have a reason");
-        let _ = self.reason_store.get_or_compute(
+        self.reason_store.get_or_compute(
             reason_ref,
             ExplanationContext::without_working_nogood(
                 &self.assignments,
@@ -840,7 +836,7 @@ impl State {
             ),
             &mut self.propagators,
             reason_buffer,
-        );
+        )
     }
     /// Get the reason for a predicate being true and store it in `reason_buffer`.
     ///
@@ -889,7 +885,7 @@ impl State {
         // We distinguish between three cases:
         // 1) The predicate is explicitly present on the trail.
         if trail_entry.predicate == predicate {
-            let (reason_ref, inference_code) = trail_entry.reason?;
+            let reason_ref = trail_entry.reason?;
 
             let explanation_context = ExplanationContext::new(
                 &self.assignments,
@@ -898,14 +894,12 @@ impl State {
                 &mut self.notification_engine,
             );
 
-            let reason_exists = self.reason_store.get_or_compute(
+            let inference_code = self.reason_store.get_or_compute(
                 reason_ref,
                 explanation_context,
                 &mut self.propagators,
                 reason_buffer,
             );
-
-            assert!(reason_exists, "reason reference should not be stale");
 
             Some(inference_code)
         }

--- a/pumpkin-crates/core/src/propagation/contexts/propagation_context.rs
+++ b/pumpkin-crates/core/src/propagation/contexts/propagation_context.rs
@@ -10,7 +10,6 @@ use crate::engine::reason::Reason;
 use crate::engine::reason::ReasonStore;
 use crate::engine::reason::StoredReason;
 use crate::engine::variables::Literal;
-use crate::proof::InferenceCode;
 use crate::propagation::DomainEvents;
 use crate::propagation::Domains;
 use crate::propagation::HasAssignments;
@@ -240,13 +239,12 @@ impl PropagationContext<'_> {
         &mut self,
         predicate: Predicate,
         reason: impl Into<Reason>,
-        inference_code: &InferenceCode,
     ) -> Result<(), EmptyDomainConflict> {
         let slot = self.reason_store.new_slot();
 
         let modification_result = self.assignments.post_predicate(
             predicate,
-            Some((slot.reason_ref(), inference_code.clone())),
+            Some(slot.reason_ref()),
             self.notification_engine,
         );
 
@@ -264,13 +262,12 @@ impl PropagationContext<'_> {
                     self.propagator_id,
                     build_reason(reason, self.reification_literal),
                 );
-                let (trigger_predicate, trigger_reason, trigger_inference_code) =
+                let (trigger_predicate, trigger_reason) =
                     self.assignments.remove_last_trail_element();
 
                 Err(EmptyDomainConflict {
                     trigger_predicate,
                     trigger_reason: Some(trigger_reason),
-                    trigger_inference_code: Some(trigger_inference_code),
                 })
             }
         }
@@ -282,13 +279,13 @@ pub(crate) fn build_reason(
     reification_literal: Option<Literal>,
 ) -> StoredReason {
     match reason.into() {
-        Reason::Eager(mut conjunction) => {
+        Reason::Eager(mut conjunction, inference_code) => {
             conjunction.extend(
                 reification_literal
                     .iter()
                     .map(|lit| lit.get_true_predicate()),
             );
-            StoredReason::Eager(conjunction)
+            StoredReason::Eager(conjunction, inference_code)
         }
         Reason::DynamicLazy(code) => StoredReason::DynamicLazy(code),
     }

--- a/pumpkin-crates/core/src/propagation/propagator.rs
+++ b/pumpkin-crates/core/src/propagation/propagator.rs
@@ -40,7 +40,7 @@ use crate::statistics::statistic_logger::StatisticLogger;
 pub struct LazyExplanation<'a> {
     /// The predicates that explain the propagation.
     pub predicates: &'a [Predicate],
-    /// The inference code identifying the explanation step.
+    /// The inference code identifying the explanation algorithm.
     pub inference_code: InferenceCode,
 }
 

--- a/pumpkin-crates/core/src/propagation/propagator.rs
+++ b/pumpkin-crates/core/src/propagation/propagator.rs
@@ -16,6 +16,7 @@ use crate::engine::PropagationStatusCP;
 use crate::engine::PropagatorConflict;
 use crate::engine::notifications::OpaqueDomainEvent;
 use crate::predicates::Predicate;
+use crate::proof::InferenceCode;
 #[cfg(doc)]
 use crate::propagation::DomainEvent;
 #[cfg(doc)]
@@ -32,6 +33,16 @@ use crate::pumpkin_asserts::PUMPKIN_ASSERT_EXTREME;
 #[cfg(doc)]
 use crate::state::Conflict;
 use crate::statistics::statistic_logger::StatisticLogger;
+
+/// The result of [`Propagator::lazy_explanation`]: a slice of predicates that form the reason for
+/// a propagation, together with the [`InferenceCode`] that identifies the explanation algorithm.
+#[derive(Clone, Debug)]
+pub struct LazyExplanation<'a> {
+    /// The predicates that explain the propagation.
+    pub predicates: &'a [Predicate],
+    /// The inference code identifying the explanation step.
+    pub inference_code: InferenceCode,
+}
 
 // We need to use this to cast from `Box<dyn Propagator>` to `NogoodPropagator`; rust inherently
 // does not allow downcasting from the trait definition to its concrete type.
@@ -195,7 +206,11 @@ pub trait Propagator: Downcast + DynClone {
     /// explanation is generated); the bounds at the time of the propagation can be retrieved using
     /// methods such as [`ReadDomains::lower_bound_at_trail_position`] in combination
     /// with [`ExplanationContext::get_trail_position`].
-    fn lazy_explanation(&mut self, _code: u64, _context: ExplanationContext) -> &[Predicate] {
+    fn lazy_explanation(
+        &mut self,
+        _code: u64,
+        _context: ExplanationContext,
+    ) -> LazyExplanation<'_> {
         panic!(
             "{}",
             format!(

--- a/pumpkin-crates/core/src/propagators/hypercube_linear/propagator.rs
+++ b/pumpkin-crates/core/src/propagators/hypercube_linear/propagator.rs
@@ -152,8 +152,7 @@ impl HypercubeLinearPropagator {
 
             context.post(
                 predicate![term <= term_upper_bound],
-                reason,
-                &self.inference_code,
+                (reason, &self.inference_code),
             )?;
         }
 
@@ -292,7 +291,7 @@ impl Propagator for HypercubeLinearPropagator {
                         )
                         .collect();
 
-                    context.post(!predicate_in_hypercube, conjunction, &self.inference_code)?;
+                    context.post(!predicate_in_hypercube, (conjunction, &self.inference_code))?;
                 } else if let Some(term_to_propagate) = maybe_term {
                     // The slack is at least 0, but it may be that the linear could propagate
                     // something weaker than `!predicate_in_hypercube`.
@@ -327,8 +326,7 @@ impl Propagator for HypercubeLinearPropagator {
 
                     context.post(
                         predicate![term_to_propagate <= bound],
-                        conjunction,
-                        &self.inference_code,
+                        (conjunction, &self.inference_code),
                     )?;
                 }
             }
@@ -391,7 +389,7 @@ impl Propagator for HypercubeLinearPropagator {
                     )
                     .collect::<PropositionalConjunction>();
 
-                context.post(!unassigned_predicate, reason, &self.inference_code)?;
+                context.post(!unassigned_predicate, (reason, &self.inference_code))?;
             } else if let Some(term) = self
                 .linear
                 .term_for_domain(unassigned_predicate.get_domain())
@@ -412,8 +410,7 @@ impl Propagator for HypercubeLinearPropagator {
 
                 context.post(
                     predicate![term <= new_upper_bound],
-                    reason,
-                    &self.inference_code,
+                    (reason, &self.inference_code),
                 )?;
             }
         } else {

--- a/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
+++ b/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
@@ -22,6 +22,7 @@ use crate::predicate;
 use crate::proof::InferenceCode;
 use crate::propagation::EnqueueDecision;
 use crate::propagation::ExplanationContext;
+use crate::propagation::LazyExplanation;
 use crate::propagation::NotificationContext;
 use crate::propagation::Priority;
 use crate::propagation::PropagationContext;
@@ -176,7 +177,7 @@ impl NogoodPropagator {
                 .get_trail_position(&!notification_engine.get_predicate(nogood[0]))
                 .unwrap();
             let trail_entry = assignments.get_trail_entry(trail_position);
-            if let Some((reason_ref, _)) = trail_entry.reason {
+            if let Some(reason_ref) = trail_entry.reason {
                 let propagator_id = reason_store.get_propagator(reason_ref);
                 let code = reason_store.get_lazy_code(reason_ref);
 
@@ -317,12 +318,7 @@ impl Propagator for NogoodPropagator {
                 let reason = Reason::DynamicLazy(watcher.nogood_id.id as u64);
 
                 let predicate = !context.get_predicate(nogood_predicates[0]);
-                let result = context.post(
-                    predicate,
-                    reason,
-                    &self.inference_codes
-                        [self.nogood_predicates.get_nogood_index(&watcher.nogood_id)],
-                );
+                let result = context.post(predicate, reason);
                 // If the propagation lead to a conflict.
                 if let Err(e) = result {
                     return Err(e.into());
@@ -357,7 +353,11 @@ impl Propagator for NogoodPropagator {
     ///
     /// In case of the noogood propagator, lazy explanations internally also update information
     /// about the LBD and activity of the nogood, which is used when cleaning up nogoods.
-    fn lazy_explanation(&mut self, code: u64, mut context: ExplanationContext) -> &[Predicate] {
+    fn lazy_explanation(
+        &mut self,
+        code: u64,
+        mut context: ExplanationContext,
+    ) -> LazyExplanation<'_> {
         let id = NogoodId { id: code as u32 };
 
         self.temp_nogood_reason = self.nogood_predicates[id][1..]
@@ -415,8 +415,10 @@ impl Propagator for NogoodPropagator {
             // At this point, it is safe to increase the activity value
             self.nogood_info[info_id].activity += self.parameters.activity_bump_increment;
         }
-        // update LBD, so we need code plus assignments as input.
-        &self.temp_nogood_reason
+        LazyExplanation {
+            predicates: self.temp_nogood_reason.as_slice(),
+            inference_code: self.inference_codes[info_id].clone(),
+        }
     }
 }
 
@@ -486,14 +488,12 @@ impl NogoodPropagator {
         // Then we propagate the asserting predicate and as the reason we give the index to the
         // asserting nogood such that we can re-create the reason when asked for it
         let reason = Reason::DynamicLazy(nogood_id.id as u64);
-        let inference_code =
-            &self.inference_codes[self.nogood_predicates.get_nogood_index(&nogood_id)];
 
         let predicate = !context
             .notification_engine
             .get_predicate(self.nogood_predicates[nogood_id][0]);
         context
-            .post(predicate, reason, inference_code)
+            .post(predicate, reason)
             .expect("Cannot fail to add the asserting predicate.");
 
         // We then assign the nogood to the correct tier based on its LBD
@@ -608,8 +608,10 @@ impl NogoodPropagator {
             // Post the negated predicate at the root to respect the nogood.
             context.post(
                 !nogood[0],
-                PropositionalConjunction::from(input_nogood),
-                &inference_code,
+                (
+                    PropositionalConjunction::from(input_nogood),
+                    &inference_code,
+                ),
             )?;
             Ok(())
         }
@@ -1234,7 +1236,7 @@ impl NogoodPropagator {
                 .filter(|&p| p != !propagated_predicate)
                 .collect::<PropositionalConjunction>();
 
-            context.post(propagated_predicate, reason, inference_code)?;
+            context.post(propagated_predicate, (reason, inference_code))?;
         }
         Ok(())
     }

--- a/pumpkin-crates/core/src/propagators/reified_propagator.rs
+++ b/pumpkin-crates/core/src/propagators/reified_propagator.rs
@@ -158,13 +158,12 @@ impl<WrappedPropagator: Propagator + Clone> Propagator for ReifiedPropagator<Wra
 
     fn lazy_explanation(&mut self, code: u64, context: ExplanationContext) -> LazyExplanation<'_> {
         let inner = self.propagator.lazy_explanation(code, context);
-        let preds: Vec<Predicate> = inner.predicates.to_vec();
         let inference_code = inner.inference_code;
 
         self.reason_buffer.clear();
         self.reason_buffer
             .push(self.reification_literal.get_true_predicate());
-        self.reason_buffer.extend(preds);
+        self.reason_buffer.extend(inner.predicates);
 
         LazyExplanation {
             predicates: self.reason_buffer.as_slice(),

--- a/pumpkin-crates/core/src/propagators/reified_propagator.rs
+++ b/pumpkin-crates/core/src/propagators/reified_propagator.rs
@@ -11,6 +11,7 @@ use crate::propagation::Domains;
 use crate::propagation::EnqueueDecision;
 use crate::propagation::ExplanationContext;
 use crate::propagation::InferenceCheckers;
+use crate::propagation::LazyExplanation;
 use crate::propagation::LocalId;
 use crate::propagation::NotificationContext;
 use crate::propagation::Priority;
@@ -155,13 +156,20 @@ impl<WrappedPropagator: Propagator + Clone> Propagator for ReifiedPropagator<Wra
         Ok(())
     }
 
-    fn lazy_explanation(&mut self, code: u64, context: ExplanationContext) -> &[Predicate] {
+    fn lazy_explanation(&mut self, code: u64, context: ExplanationContext) -> LazyExplanation<'_> {
+        let inner = self.propagator.lazy_explanation(code, context);
+        let preds: Vec<Predicate> = inner.predicates.to_vec();
+        let inference_code = inner.inference_code;
+
         self.reason_buffer.clear();
         self.reason_buffer
             .push(self.reification_literal.get_true_predicate());
-        self.reason_buffer
-            .extend(self.propagator.lazy_explanation(code, context));
-        &self.reason_buffer
+        self.reason_buffer.extend(preds);
+
+        LazyExplanation {
+            predicates: self.reason_buffer.as_slice(),
+            inference_code,
+        }
     }
 }
 
@@ -186,8 +194,7 @@ impl<Prop: Propagator + Clone> ReifiedPropagator<Prop> {
         if let Some(conflict) = self.propagator.detect_inconsistency(context.domains()) {
             context.post(
                 self.reification_literal.get_false_predicate(),
-                conflict.conjunction,
-                &conflict.inference_code,
+                (conflict.conjunction, &conflict.inference_code),
             )?;
         }
 
@@ -327,8 +334,10 @@ mod tests {
                     move |mut ctx: PropagationContext| {
                         ctx.post(
                             predicate![var >= 3],
-                            conjunction!(),
-                            &InferenceCode::unknown_label(ConstraintTag::create_from_index(0)),
+                            (
+                                conjunction!(),
+                                &InferenceCode::unknown_label(ConstraintTag::create_from_index(0)),
+                            ),
                         )?;
                         Ok(())
                     },

--- a/pumpkin-crates/propagators/src/propagators/arithmetic/absolute_value.rs
+++ b/pumpkin-crates/propagators/src/propagators/arithmetic/absolute_value.rs
@@ -94,8 +94,7 @@ where
         // zero at the root.
         context.post(
             predicate![self.absolute >= 0],
-            conjunction!(),
-            &self.inference_code,
+            (conjunction!(), &self.inference_code),
         )?;
 
         // Propagating absolute value can be broken into a few cases:
@@ -112,21 +111,27 @@ where
 
         context.post(
             predicate![self.absolute <= signed_absolute_ub],
-            conjunction!([self.signed >= signed_lb] & [self.signed <= signed_ub]),
-            &self.inference_code,
+            (
+                conjunction!([self.signed >= signed_lb] & [self.signed <= signed_ub]),
+                &self.inference_code,
+            ),
         )?;
 
         if signed_lb > 0 {
             context.post(
                 predicate![self.absolute >= signed_lb],
-                conjunction!([self.signed >= signed_lb]),
-                &self.inference_code,
+                (
+                    conjunction!([self.signed >= signed_lb]),
+                    &self.inference_code,
+                ),
             )?;
         } else if signed_ub < 0 {
             context.post(
                 predicate![self.absolute >= signed_ub.abs()],
-                conjunction!([self.signed <= signed_ub]),
-                &self.inference_code,
+                (
+                    conjunction!([self.signed <= signed_ub]),
+                    &self.inference_code,
+                ),
             )?;
         }
 
@@ -134,26 +139,34 @@ where
         let absolute_lb = context.lower_bound(&self.absolute);
         context.post(
             predicate![self.signed >= -absolute_ub],
-            conjunction!([self.absolute <= absolute_ub]),
-            &self.inference_code,
+            (
+                conjunction!([self.absolute <= absolute_ub]),
+                &self.inference_code,
+            ),
         )?;
         context.post(
             predicate![self.signed <= absolute_ub],
-            conjunction!([self.absolute <= absolute_ub]),
-            &self.inference_code,
+            (
+                conjunction!([self.absolute <= absolute_ub]),
+                &self.inference_code,
+            ),
         )?;
 
         if signed_ub <= 0 {
             context.post(
                 predicate![self.signed <= -absolute_lb],
-                conjunction!([self.signed <= 0] & [self.absolute >= absolute_lb]),
-                &self.inference_code,
+                (
+                    conjunction!([self.signed <= 0] & [self.absolute >= absolute_lb]),
+                    &self.inference_code,
+                ),
             )?;
         } else if signed_lb >= 0 {
             context.post(
                 predicate![self.signed >= absolute_lb],
-                conjunction!([self.signed >= 0] & [self.absolute >= absolute_lb]),
-                &self.inference_code,
+                (
+                    conjunction!([self.signed >= 0] & [self.absolute >= absolute_lb]),
+                    &self.inference_code,
+                ),
             )?;
         }
 

--- a/pumpkin-crates/propagators/src/propagators/arithmetic/binary/binary_equals.rs
+++ b/pumpkin-crates/propagators/src/propagators/arithmetic/binary/binary_equals.rs
@@ -22,6 +22,7 @@ use pumpkin_core::propagation::Domains;
 use pumpkin_core::propagation::EnqueueDecision;
 use pumpkin_core::propagation::ExplanationContext;
 use pumpkin_core::propagation::InferenceCheckers;
+use pumpkin_core::propagation::LazyExplanation;
 use pumpkin_core::propagation::LocalId;
 use pumpkin_core::propagation::NotificationContext;
 use pumpkin_core::propagation::OpaqueDomainEvent;
@@ -156,7 +157,6 @@ where
                 .with_predicate_type(predicate_type)
                 .with_value(value)
                 .into_bits(),
-            &self.inference_code,
         )
     }
 }
@@ -305,7 +305,7 @@ where
         Ok(())
     }
 
-    fn lazy_explanation(&mut self, code: u64, _: ExplanationContext) -> &[Predicate] {
+    fn lazy_explanation(&mut self, code: u64, _: ExplanationContext) -> LazyExplanation<'_> {
         use PredicateType::*;
         use Variable::*;
 
@@ -324,7 +324,10 @@ where
 
         self.reason = explanation;
 
-        slice::from_ref(&self.reason)
+        LazyExplanation {
+            predicates: slice::from_ref(&self.reason),
+            inference_code: self.inference_code.clone(),
+        }
     }
 
     fn propagate_from_scratch(&self, mut context: PropagationContext) -> PropagationStatusCP {

--- a/pumpkin-crates/propagators/src/propagators/arithmetic/binary/binary_not_equals.rs
+++ b/pumpkin-crates/propagators/src/propagators/arithmetic/binary/binary_not_equals.rs
@@ -126,8 +126,7 @@ where
         if a_lb == a_ub {
             context.post(
                 predicate!(self.b != a_lb),
-                conjunction!([self.a == a_lb]),
-                &self.inference_code,
+                (conjunction!([self.a == a_lb]), &self.inference_code),
             )?;
         }
 
@@ -135,8 +134,7 @@ where
         if b_lb == b_ub {
             context.post(
                 predicate!(self.a != b_lb),
-                conjunction!([self.b == b_lb]),
-                &self.inference_code,
+                (conjunction!([self.b == b_lb]), &self.inference_code),
             )?;
         }
 
@@ -161,16 +159,14 @@ where
         if a_lb == a_ub {
             context.post(
                 predicate!(self.b != a_lb),
-                conjunction!([self.a == a_lb]),
-                &self.inference_code,
+                (conjunction!([self.a == a_lb]), &self.inference_code),
             )?;
         }
 
         if b_lb == b_ub {
             context.post(
                 predicate!(self.a != b_lb),
-                conjunction!([self.b == b_lb]),
-                &self.inference_code,
+                (conjunction!([self.b == b_lb]), &self.inference_code),
             )?;
         }
 

--- a/pumpkin-crates/propagators/src/propagators/arithmetic/integer_division.rs
+++ b/pumpkin-crates/propagators/src/propagators/arithmetic/integer_division.rs
@@ -224,12 +224,14 @@ fn propagate_positive_domains<VA: IntegerVariable, VB: IntegerVariable, VC: Inte
     if rhs_min < new_min_rhs {
         context.post(
             predicate![rhs >= new_min_rhs],
-            conjunction!(
-                [numerator >= numerator_min]
-                    & [denominator <= denominator_max]
-                    & [denominator >= 1]
+            (
+                conjunction!(
+                    [numerator >= numerator_min]
+                        & [denominator <= denominator_max]
+                        & [denominator >= 1]
+                ),
+                inference_code,
             ),
-            inference_code,
         )?;
     }
 
@@ -241,8 +243,10 @@ fn propagate_positive_domains<VA: IntegerVariable, VB: IntegerVariable, VC: Inte
     if numerator_min < new_min_numerator {
         context.post(
             predicate![numerator >= new_min_numerator],
-            conjunction!([denominator >= denominator_min] & [rhs >= rhs_min]),
-            inference_code,
+            (
+                conjunction!([denominator >= denominator_min] & [rhs >= rhs_min]),
+                inference_code,
+            ),
         )?;
     }
 
@@ -255,13 +259,15 @@ fn propagate_positive_domains<VA: IntegerVariable, VB: IntegerVariable, VC: Inte
         if denominator_max > new_max_denominator {
             context.post(
                 predicate![denominator <= new_max_denominator],
-                conjunction!(
-                    [numerator <= numerator_max]
-                        & [numerator >= 0]
-                        & [rhs >= rhs_min]
-                        & [denominator >= 1]
+                (
+                    conjunction!(
+                        [numerator <= numerator_max]
+                            & [numerator >= 0]
+                            & [rhs >= rhs_min]
+                            & [denominator >= 1]
+                    ),
+                    inference_code,
                 ),
-                inference_code,
             )?;
         }
     }
@@ -279,10 +285,15 @@ fn propagate_positive_domains<VA: IntegerVariable, VB: IntegerVariable, VC: Inte
     if denominator_min < new_min_denominator {
         context.post(
             predicate![denominator >= new_min_denominator],
-            conjunction!(
-                [numerator >= numerator_min] & [rhs <= rhs_max] & [rhs >= 0] & [denominator >= 1]
+            (
+                conjunction!(
+                    [numerator >= numerator_min]
+                        & [rhs <= rhs_max]
+                        & [rhs >= 0]
+                        & [denominator >= 1]
+                ),
+                inference_code,
             ),
-            inference_code,
         )?;
     }
 
@@ -313,8 +324,10 @@ fn propagate_upper_bounds<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerV
     if rhs_max > new_max_rhs {
         context.post(
             predicate![rhs <= new_max_rhs],
-            conjunction!([numerator <= numerator_max] & [denominator >= denominator_min]),
-            inference_code,
+            (
+                conjunction!([numerator <= numerator_max] & [denominator >= denominator_min]),
+                inference_code,
+            ),
         )?;
     }
 
@@ -327,8 +340,12 @@ fn propagate_upper_bounds<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerV
     if numerator_max > new_max_numerator {
         context.post(
             predicate![numerator <= new_max_numerator],
-            conjunction!([denominator <= denominator_max] & [denominator >= 1] & [rhs <= rhs_max]),
-            inference_code,
+            (
+                conjunction!(
+                    [denominator <= denominator_max] & [denominator >= 1] & [rhs <= rhs_max]
+                ),
+                inference_code,
+            ),
         )?;
     }
 
@@ -358,8 +375,10 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if numerator_min >= 0 && rhs_min < 0 {
         context.post(
             predicate![rhs >= 0],
-            conjunction!([numerator >= 0] & [denominator >= 1]),
-            inference_code,
+            (
+                conjunction!([numerator >= 0] & [denominator >= 1]),
+                inference_code,
+            ),
         )?;
     }
 
@@ -367,8 +386,10 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if numerator_min <= 0 && rhs_min > 0 {
         context.post(
             predicate![numerator >= 1],
-            conjunction!([rhs >= 1] & [denominator >= 1]),
-            inference_code,
+            (
+                conjunction!([rhs >= 1] & [denominator >= 1]),
+                inference_code,
+            ),
         )?;
     }
 
@@ -376,8 +397,10 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if numerator_max <= 0 && rhs_max > 0 {
         context.post(
             predicate![rhs <= 0],
-            conjunction!([numerator <= 0] & [denominator >= 1]),
-            inference_code,
+            (
+                conjunction!([numerator <= 0] & [denominator >= 1]),
+                inference_code,
+            ),
         )?;
     }
 
@@ -385,8 +408,10 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if numerator_max >= 0 && rhs_max < 0 {
         context.post(
             predicate![numerator <= -1],
-            conjunction!([rhs <= -1] & [denominator >= 1]),
-            inference_code,
+            (
+                conjunction!([rhs <= -1] & [denominator >= 1]),
+                inference_code,
+            ),
         )?;
     }
 

--- a/pumpkin-crates/propagators/src/propagators/arithmetic/integer_multiplication.rs
+++ b/pumpkin-crates/propagators/src/propagators/arithmetic/integer_multiplication.rs
@@ -133,15 +133,16 @@ fn perform_propagation<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVari
         // hold in the case of a negative lower-bound
         context.post(
             predicate![c <= new_max_c],
-            conjunction!([a >= 0] & [a <= a_max] & [b >= 0] & [b <= b_max]),
-            inference_code,
+            (
+                conjunction!([a >= 0] & [a <= a_max] & [b >= 0] & [b <= b_max]),
+                inference_code,
+            ),
         )?;
 
         // c is larger than the minimum value that a * b can take
         context.post(
             predicate![c >= new_min_c],
-            conjunction!([a >= a_min] & [b >= b_min]),
-            inference_code,
+            (conjunction!([a >= a_min] & [b >= b_min]), inference_code),
         )?;
     }
 
@@ -150,8 +151,10 @@ fn perform_propagation<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVari
         let bound = div_ceil_pos(c_min, b_max);
         context.post(
             predicate![a >= bound],
-            conjunction!([c >= c_min] & [b >= 0] & [b <= b_max]),
-            inference_code,
+            (
+                conjunction!([c >= c_min] & [b >= 0] & [b <= b_max]),
+                inference_code,
+            ),
         )?;
     }
 
@@ -160,8 +163,10 @@ fn perform_propagation<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVari
         let bound = c_max / b_min;
         context.post(
             predicate![a <= bound],
-            conjunction!([c >= 0] & [c <= c_max] & [b >= b_min]),
-            inference_code,
+            (
+                conjunction!([c >= 0] & [c <= c_max] & [b >= b_min]),
+                inference_code,
+            ),
         )?;
     }
 
@@ -170,8 +175,10 @@ fn perform_propagation<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVari
         let bound = c_max / a_min;
         context.post(
             predicate![b <= bound],
-            conjunction!([c >= 0] & [c <= c_max] & [a >= a_min]),
-            inference_code,
+            (
+                conjunction!([c >= 0] & [c <= c_max] & [a >= a_min]),
+                inference_code,
+            ),
         )?;
     }
 
@@ -181,8 +188,10 @@ fn perform_propagation<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVari
 
         context.post(
             predicate![b >= bound],
-            conjunction!([c >= c_min] & [a >= 0] & [a <= a_max]),
-            inference_code,
+            (
+                conjunction!([c >= c_min] & [a >= 0] & [a <= a_max]),
+                inference_code,
+            ),
         )?;
     }
 
@@ -247,8 +256,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if a_min >= 0 && b_min >= 0 {
         context.post(
             predicate![c >= 0],
-            conjunction!([a >= 0] & [b >= 0]),
-            inference_code,
+            (conjunction!([a >= 0] & [b >= 0]), inference_code),
         )?;
     }
 
@@ -256,8 +264,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if a_min >= 1 && c_min >= 1 {
         context.post(
             predicate![b >= 1],
-            conjunction!([a >= 1] & [c >= 1]),
-            inference_code,
+            (conjunction!([a >= 1] & [c >= 1]), inference_code),
         )?;
     }
 
@@ -265,8 +272,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if b_min >= 1 && c_min >= 1 {
         context.post(
             predicate![a >= 1],
-            conjunction!([b >= 1] & [c >= 1]),
-            inference_code,
+            (conjunction!([b >= 1] & [c >= 1]), inference_code),
         )?;
     }
 
@@ -275,8 +281,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if a_max <= 0 && b_max <= 0 {
         context.post(
             predicate![c >= 0],
-            conjunction!([a <= 0] & [b <= 0]),
-            inference_code,
+            (conjunction!([a <= 0] & [b <= 0]), inference_code),
         )?;
     }
 
@@ -284,8 +289,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if a_max <= -1 && c_max <= -1 {
         context.post(
             predicate![b >= 1],
-            conjunction!([a <= -1] & [c <= -1]),
-            inference_code,
+            (conjunction!([a <= -1] & [c <= -1]), inference_code),
         )?;
     }
 
@@ -293,8 +297,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if b_max <= -1 && c_max <= -1 {
         context.post(
             predicate![a >= 1],
-            conjunction!([b <= -1] & [c <= -1]),
-            inference_code,
+            (conjunction!([b <= -1] & [c <= -1]), inference_code),
         )?;
     }
 
@@ -304,8 +307,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if a_max <= 0 && b_min >= 0 {
         context.post(
             predicate![c <= 0],
-            conjunction!([a <= 0] & [b >= 0]),
-            inference_code,
+            (conjunction!([a <= 0] & [b >= 0]), inference_code),
         )?;
     }
 
@@ -313,8 +315,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if a_min >= 0 && b_max <= 0 {
         context.post(
             predicate![c <= 0],
-            conjunction!([a >= 0] & [b <= 0]),
-            inference_code,
+            (conjunction!([a >= 0] & [b <= 0]), inference_code),
         )?;
     }
 
@@ -323,8 +324,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if a_max <= -1 && c_min >= 1 {
         context.post(
             predicate![b <= -1],
-            conjunction!([a <= -1] & [c >= 1]),
-            inference_code,
+            (conjunction!([a <= -1] & [c >= 1]), inference_code),
         )?;
     }
 
@@ -332,8 +332,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if a_min >= 1 && c_max <= -1 {
         context.post(
             predicate![b <= -1],
-            conjunction!([a >= 1] & [c <= -1]),
-            inference_code,
+            (conjunction!([a >= 1] & [c <= -1]), inference_code),
         )?;
     }
 
@@ -342,8 +341,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if b_max <= -1 && c_min >= 1 {
         context.post(
             predicate![a <= -1],
-            conjunction!([b <= -1] & [c >= 1]),
-            inference_code,
+            (conjunction!([b <= -1] & [c >= 1]), inference_code),
         )?;
     }
 
@@ -351,8 +349,7 @@ fn propagate_signs<VA: IntegerVariable, VB: IntegerVariable, VC: IntegerVariable
     if b_min >= 1 && c_max <= -1 {
         context.post(
             predicate![a <= -1],
-            conjunction!([b >= 1] & [c <= -1]),
-            inference_code,
+            (conjunction!([b >= 1] & [c <= -1]), inference_code),
         )?;
     }
 

--- a/pumpkin-crates/propagators/src/propagators/arithmetic/linear_less_or_equal.rs
+++ b/pumpkin-crates/propagators/src/propagators/arithmetic/linear_less_or_equal.rs
@@ -15,6 +15,7 @@ use pumpkin_core::propagation::Domains;
 use pumpkin_core::propagation::EnqueueDecision;
 use pumpkin_core::propagation::ExplanationContext;
 use pumpkin_core::propagation::InferenceCheckers;
+use pumpkin_core::propagation::LazyExplanation;
 use pumpkin_core::propagation::LocalId;
 use pumpkin_core::propagation::NotificationContext;
 use pumpkin_core::propagation::OpaqueDomainEvent;
@@ -166,7 +167,7 @@ where
         "LinearLeq"
     }
 
-    fn lazy_explanation(&mut self, code: u64, context: ExplanationContext) -> &[Predicate] {
+    fn lazy_explanation(&mut self, code: u64, context: ExplanationContext) -> LazyExplanation<'_> {
         let i = code as usize;
 
         self.reason_buffer.clear();
@@ -183,7 +184,10 @@ where
                 }
             }));
 
-        &self.reason_buffer
+        LazyExplanation {
+            predicates: self.reason_buffer.as_slice(),
+            inference_code: self.inference_code.clone(),
+        }
     }
 
     fn propagate(&mut self, mut context: PropagationContext) -> PropagationStatusCP {
@@ -222,7 +226,7 @@ where
             let bound = self.c - (lower_bound_left_hand_side - context.lower_bound(x_i));
 
             if context.upper_bound(x_i) > bound {
-                context.post(predicate![x_i <= bound], i, &self.inference_code)?;
+                context.post(predicate![x_i <= bound], i)?;
             }
         }
 
@@ -279,7 +283,7 @@ where
                     })
                     .collect();
 
-                context.post(predicate![x_i <= bound], reason, &self.inference_code)?;
+                context.post(predicate![x_i <= bound], (reason, &self.inference_code))?;
             }
         }
 

--- a/pumpkin-crates/propagators/src/propagators/arithmetic/linear_not_equal.rs
+++ b/pumpkin-crates/propagators/src/propagators/arithmetic/linear_not_equal.rs
@@ -218,13 +218,15 @@ where
 
                 context.post(
                     predicate![self.terms[unfixed_x_i] != value_to_remove],
-                    self.terms
-                        .iter()
-                        .enumerate()
-                        .filter(|&(i, _)| i != unfixed_x_i)
-                        .map(|(_, x_i)| predicate![x_i == context.lower_bound(x_i)])
-                        .collect::<PropositionalConjunction>(),
-                    &self.inference_code,
+                    (
+                        self.terms
+                            .iter()
+                            .enumerate()
+                            .filter(|&(i, _)| i != unfixed_x_i)
+                            .map(|(_, x_i)| predicate![x_i == context.lower_bound(x_i)])
+                            .collect::<PropositionalConjunction>(),
+                        &self.inference_code,
+                    ),
                 )?;
             }
         } else if self.number_of_fixed_terms == self.terms.len() {
@@ -275,8 +277,7 @@ where
                             .try_into()
                             .expect("Expected to be able to fit i64 into i32")
                 ],
-                reason,
-                &self.inference_code,
+                (reason, &self.inference_code),
             )?;
         } else if num_fixed == self.terms.len() && lhs == self.rhs as i64 {
             let conjunction = self

--- a/pumpkin-crates/propagators/src/propagators/arithmetic/maximum.rs
+++ b/pumpkin-crates/propagators/src/propagators/arithmetic/maximum.rs
@@ -106,8 +106,7 @@ impl<ElementVar: IntegerVariable + 'static, Rhs: IntegerVariable + 'static> Prop
             // UB(a_i) <= UB(rhs, constraint_tag }
             context.post(
                 predicate![var <= rhs_ub],
-                conjunction!([self.rhs <= rhs_ub]),
-                &self.inference_code,
+                (conjunction!([self.rhs <= rhs_ub]), &self.inference_code),
             )?;
 
             let var_lb = context.lower_bound(var);
@@ -126,8 +125,10 @@ impl<ElementVar: IntegerVariable + 'static, Rhs: IntegerVariable + 'static> Prop
         // LB(rhs, constraint_tag } >= max{LB(a_i)}.
         context.post(
             predicate![self.rhs >= max_lb],
-            PropositionalConjunction::from(lb_reason),
-            &self.inference_code,
+            (
+                PropositionalConjunction::from(lb_reason),
+                &self.inference_code,
+            ),
         )?;
 
         // Rule 3.
@@ -142,8 +143,7 @@ impl<ElementVar: IntegerVariable + 'static, Rhs: IntegerVariable + 'static> Prop
                 .collect();
             context.post(
                 predicate![self.rhs <= max_ub],
-                ub_reason,
-                &self.inference_code,
+                (ub_reason, &self.inference_code),
             )?;
         }
 
@@ -175,8 +175,7 @@ impl<ElementVar: IntegerVariable + 'static, Rhs: IntegerVariable + 'static> Prop
                 propagation_reason.push(predicate![self.rhs >= rhs_lb]);
                 context.post(
                     predicate![propagating_variable >= rhs_lb],
-                    propagation_reason,
-                    &self.inference_code,
+                    (propagation_reason, &self.inference_code),
                 )?;
             }
         }

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/explanations/pointwise.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/explanations/pointwise.rs
@@ -85,8 +85,7 @@ pub(crate) fn propagate_lower_bounds_with_pointwise_explanations<Var: IntegerVar
 
             context.post(
                 predicate![propagating_task.start_variable >= time_point + 1],
-                reason,
-                inference_code,
+                (reason, inference_code),
             )?;
         }
 
@@ -203,8 +202,7 @@ pub(crate) fn propagate_upper_bounds_with_pointwise_explanations<Var: IntegerVar
                     propagating_task.start_variable
                         <= time_point - propagating_task.processing_time
                 ],
-                reason,
-                inference_code,
+                (reason, inference_code),
             )?;
         }
 

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/propagation_handler.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/propagation_handler.rs
@@ -147,7 +147,7 @@ impl CumulativePropagationHandler {
                     &full_explanation,
                     context.domains()
                 ));
-                context.post(predicate, full_explanation, &self.inference_code)
+                context.post(predicate, (full_explanation, &self.inference_code))
             }
             CumulativeExplanationType::Pointwise => {
                 pointwise::propagate_lower_bounds_with_pointwise_explanations(
@@ -226,7 +226,7 @@ impl CumulativePropagationHandler {
                     &full_explanation,
                     context.domains()
                 ));
-                context.post(predicate, full_explanation, &self.inference_code)
+                context.post(predicate, (full_explanation, &self.inference_code))
             }
             CumulativeExplanationType::Pointwise => {
                 pointwise::propagate_upper_bounds_with_pointwise_explanations(
@@ -281,7 +281,7 @@ impl CumulativePropagationHandler {
 
                 pumpkin_assert_extreme!(check_explanation(predicate, &reason, context.domains()));
 
-                context.post(predicate, reason, &self.inference_code)
+                context.post(predicate, (reason, &self.inference_code))
             }
             CumulativeExplanationType::Pointwise => {
                 pointwise::propagate_lower_bounds_with_pointwise_explanations(
@@ -340,7 +340,7 @@ impl CumulativePropagationHandler {
 
                 pumpkin_assert_extreme!(check_explanation(predicate, &reason, context.domains()));
 
-                context.post(predicate, reason, &self.inference_code)
+                context.post(predicate, (reason, &self.inference_code))
             }
             CumulativeExplanationType::Pointwise => {
                 pointwise::propagate_upper_bounds_with_pointwise_explanations(
@@ -413,7 +413,7 @@ impl CumulativePropagationHandler {
                         &explanation,
                         context.domains()
                     ));
-                    context.post(predicate, (*explanation).clone(), &self.inference_code)?;
+                    context.post(predicate, ((*explanation).clone(), &self.inference_code))?;
                 }
                 CumulativeExplanationType::Pointwise => {
                     // We split into two cases when determining the explanation of the profile
@@ -449,7 +449,7 @@ impl CumulativePropagationHandler {
                         &explanation,
                         context.domains()
                     ));
-                    context.post(predicate, explanation, &self.inference_code)?;
+                    context.post(predicate, (explanation, &self.inference_code))?;
                 }
             }
         }

--- a/pumpkin-crates/propagators/src/propagators/disjunctive/disjunctive_propagator.rs
+++ b/pumpkin-crates/propagators/src/propagators/disjunctive/disjunctive_propagator.rs
@@ -221,15 +221,17 @@ fn edge_finding<Var: IntegerVariable, SortedTaskVar: IntegerVariable>(
                     let propagated_predicate = predicate!(propagated_variable >= new_bound);
                     context.post(
                         propagated_predicate,
-                        create_propagation_explanation(
-                            tasks,
-                            i,
-                            theta_lambda_tree,
-                            context,
-                            new_bound,
-                            lct_j,
+                        (
+                            create_propagation_explanation(
+                                tasks,
+                                i,
+                                theta_lambda_tree,
+                                context,
+                                new_bound,
+                                lct_j,
+                            ),
+                            inference_code,
                         ),
-                        inference_code,
                     )?;
                 }
 

--- a/pumpkin-crates/propagators/src/propagators/element.rs
+++ b/pumpkin-crates/propagators/src/propagators/element.rs
@@ -19,6 +19,7 @@ use pumpkin_core::proof::InferenceCode;
 use pumpkin_core::propagation::DomainEvents;
 use pumpkin_core::propagation::ExplanationContext;
 use pumpkin_core::propagation::InferenceCheckers;
+use pumpkin_core::propagation::LazyExplanation;
 use pumpkin_core::propagation::LocalId;
 use pumpkin_core::propagation::Priority;
 use pumpkin_core::propagation::PropagationContext;
@@ -138,7 +139,7 @@ where
         Ok(())
     }
 
-    fn lazy_explanation(&mut self, code: u64, context: ExplanationContext) -> &[Predicate] {
+    fn lazy_explanation(&mut self, code: u64, context: ExplanationContext) -> LazyExplanation<'_> {
         let payload = RightHandSideReason::from_bits(code);
 
         self.rhs_reason_buffer.clear();
@@ -158,7 +159,10 @@ where
                 }
             }));
 
-        &self.rhs_reason_buffer
+        LazyExplanation {
+            predicates: self.rhs_reason_buffer.as_slice(),
+            inference_code: self.inference_code.clone(),
+        }
     }
 }
 
@@ -175,13 +179,11 @@ where
     ) -> PropagationStatusCP {
         context.post(
             predicate![self.index >= 0],
-            conjunction!(),
-            &self.inference_code,
+            (conjunction!(), &self.inference_code),
         )?;
         context.post(
             predicate![self.index <= self.array.len() as i32 - 1],
-            conjunction!(),
-            &self.inference_code,
+            (conjunction!(), &self.inference_code),
         )?;
         Ok(())
     }
@@ -212,7 +214,6 @@ where
                     .with_value(rhs_lb)
                     .into_bits(),
             ),
-            &self.inference_code,
         )?;
         context.post(
             predicate![self.rhs <= rhs_ub],
@@ -222,7 +223,6 @@ where
                     .with_value(rhs_ub)
                     .into_bits(),
             ),
-            &self.inference_code,
         )?;
 
         Ok(())
@@ -255,7 +255,10 @@ where
         }
 
         for (idx, reason) in to_remove.drain(..) {
-            context.post(predicate![self.index != idx], reason, &self.inference_code)?;
+            context.post(
+                predicate![self.index != idx],
+                (reason, &self.inference_code),
+            )?;
         }
 
         Ok(())
@@ -274,13 +277,17 @@ where
 
         context.post(
             predicate![lhs >= rhs_lb],
-            conjunction!([self.rhs >= rhs_lb] & [self.index == index]),
-            &self.inference_code,
+            (
+                conjunction!([self.rhs >= rhs_lb] & [self.index == index]),
+                &self.inference_code,
+            ),
         )?;
         context.post(
             predicate![lhs <= rhs_ub],
-            conjunction!([self.rhs <= rhs_ub] & [self.index == index]),
-            &self.inference_code,
+            (
+                conjunction!([self.rhs <= rhs_ub] & [self.index == index]),
+                &self.inference_code,
+            ),
         )?;
         Ok(())
     }

--- a/pumpkin-proof-processor/src/deduction_propagator.rs
+++ b/pumpkin-proof-processor/src/deduction_propagator.rs
@@ -124,7 +124,7 @@ impl Propagator for DeductionPropagator {
                 // This will never fail, as the predicate is known to be unassigned. So
                 // this propagator only returns explicit conflicts and never empty
                 // domain conflicts.
-                context.post(!unassigned_predicate, explanation, &self.inference_code)?;
+                context.post(!unassigned_predicate, (explanation, &self.inference_code))?;
             }
         }
 

--- a/pumpkin-proof-processor/src/processor.rs
+++ b/pumpkin-proof-processor/src/processor.rs
@@ -487,13 +487,13 @@ impl ProofProcessor {
             }
             Conflict::EmptyDomain(empty_domain_confict) => {
                 let mut predicates_to_explain = vec![];
-                empty_domain_confict.get_reason(
+                let maybe_trigger_inference = empty_domain_confict.get_reason(
                     &mut self.state,
                     &mut predicates_to_explain,
                     CurrentNogood::empty(),
                 );
 
-                if let Some(inference_code) = empty_domain_confict.trigger_inference_code {
+                if let Some(inference_code) = maybe_trigger_inference {
                     let generated_by = inference_code.tag();
                     let label = inference_code.label();
 


### PR DESCRIPTION
When calling `PropagationContext::post`, the user must supply an inference code as a parameter. However, when the reason of the propagation is lazy, the inference code of the explanation may differ from the inference that identified the propagation.

A very small other benefit is that on benchmarks with much propagation, the clone of an inference code actually shows up in profiles. With this PR, when a lazy explanation is used, no such clone happens.

For eager reasons: Instead of passing the `InferenceCode` to `PropagationContext::post`, it is part of the eager reason. `From<PropositionalConjunction>` is no longer implemented for `Reason`. Instead, `From<(PropositionalConjunction, &InferenceCode)>` is implemented.

Alternatively, if a lazy explanation is used, instead of returning `&[Predicate]`, `Propagator::lazy_explanation` now returns a `LazyExplanation`. This is a combination of a slice of predicates with an inference code.