### PR TITLE
chore: avoid rebuilding unnecessarily

### DIFF
--- a/pumpkin-solver/build.rs
+++ b/pumpkin-solver/build.rs
@@ -51,6 +51,7 @@ fn determine_git_hash() {
 
     // Rerun if HEAD changes (new commits, branch switches, etc.)
     println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
 }
 
 fn compile_c_binary<Source: AsRef<Path>>(

--- a/pumpkin-solver/build.rs
+++ b/pumpkin-solver/build.rs
@@ -48,6 +48,9 @@ fn determine_git_hash() {
         .to_owned();
 
     println!("cargo:rustc-env=GIT_SHA={}", git_sha);
+
+    // Rerun if HEAD changes (new commits, branch switches, etc.)
+    println!("cargo:rerun-if-changed=../.git/HEAD");
 }
 
 fn compile_c_binary<Source: AsRef<Path>>(

--- a/pumpkin-solver/build.rs
+++ b/pumpkin-solver/build.rs
@@ -48,10 +48,6 @@ fn determine_git_hash() {
         .to_owned();
 
     println!("cargo:rustc-env=GIT_SHA={}", git_sha);
-
-    // Rerun if HEAD changes (new commits, branch switches, etc.)
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    println!("cargo:rerun-if-changed=.git/refs");
 }
 
 fn compile_c_binary<Source: AsRef<Path>>(


### PR DESCRIPTION
#438 introduced a `rerun-if-changed` based on git directories. However, this causes rebuilding even if nothing has changed. I propose to remove these lines (i.e., to go back to the rebuilding strategy before #438).