### PR TITLE
fix(pumpkin-checker): Incorrect rejection of unsatisfiable optimisation problem

### DIFF
--- a/pumpkin-checker/src/conclusion.rs
+++ b/pumpkin-checker/src/conclusion.rs
@@ -9,13 +9,9 @@ pub fn verify_conclusion(
     conclusion: &drcp_format::Conclusion<Rc<str>, i32>,
 ) -> bool {
     // First we ensure the conclusion type matches the solve item in the model.
-    match (&model.objective, conclusion) {
-        (Some(_), drcp_format::Conclusion::Unsat)
-        | (None, drcp_format::Conclusion::DualBound(_)) => return false,
-
-        _ => {}
+    if let (None, drcp_format::Conclusion::DualBound(_)) = (&model.objective, conclusion) {
+        return false;
     }
-
     // We iterate in reverse order, since it is likely that the conclusion is based on a constraint
     // towards the end of the proof.
     model.iter_constraints().rev().any(|(_, constraint)| {
@@ -103,6 +99,6 @@ mod tests {
         #[allow(trivial_casts, reason = "otherwise we need a temporary variable")]
         let _ = model.add_constraint(constraint_id(1), Nogood::from([] as [Atomic; _]));
 
-        assert!(!verify_conclusion(&model, &Unsat));
+        assert!(verify_conclusion(&model, &Unsat));
     }
 }

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/checker.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/checker.rs
@@ -44,12 +44,14 @@ where
         let mut profile = BTreeMap::new();
 
         for task in self.tasks.iter() {
+            if task.resource_usage > self.capacity {
+                return true;
+            }
             if task.start_time.induced_lower_bound(&state) == IntExt::NegativeInf
                 || task.start_time.induced_upper_bound(&state) == IntExt::PositiveInf
             {
                 continue;
             }
-
             let lst: i32 = task
                 .start_time
                 .induced_upper_bound(&state)


### PR DESCRIPTION
Proposed fixes to the two issues in #514 . The unit test that tested the acceptation of unsatisfiable optimisation problems is also fixed here, as the assertion was opposite to what it was supposed to be.