### PR TITLE
chore(pumpkin-solver): Exit test process when not finished

### DIFF
--- a/pumpkin-solver/tests/helpers/mod.rs
+++ b/pumpkin-solver/tests/helpers/mod.rs
@@ -95,7 +95,11 @@ pub(crate) fn run_solver_with_options(
         .expect("Failed to run solver.");
 
     match child.wait_timeout(TEST_TIMEOUT) {
-        Ok(None) => panic!("solver took more than {} seconds", TEST_TIMEOUT.as_secs()),
+        Ok(None) => {
+            child.kill().unwrap();
+            let _ = child.wait().unwrap();
+            panic!("Solver took more than {} seconds", TEST_TIMEOUT.as_secs())
+        }
         Ok(Some(status)) if status.success() => {}
         Ok(Some(e)) => panic!("error solving instance {e}"),
         Err(e) => panic!("error starting solver: {e}"),


### PR DESCRIPTION
Currently, the test process is not killed when it reaches the timeout; this PR addresses this by explicitly killing the process when it has not finished by the timeout.

If this is intended behaviour then this PR can be closed.