### PR TITLE
fix(pumpkin-propagators): Use max for computed upper bound of `c` in division checker

### DIFF
--- a/pumpkin-crates/propagators/src/propagators/arithmetic/integer_division.rs
+++ b/pumpkin-crates/propagators/src/propagators/arithmetic/integer_division.rs
@@ -480,7 +480,7 @@ where
         ]
         .iter()
         .flatten()
-        .min()
+        .max()
         .expect("Expected at least one element to be defined");
 
         let c_lower = self.rhs.induced_lower_bound(&state);
@@ -512,5 +512,48 @@ mod tests {
         });
 
         let _ = state.propagate_to_fixed_point().unwrap_err();
+    }
+
+    #[test]
+    fn checker_does_not_report_false_conflict_for_tight_but_valid_quotient() {
+        use pumpkin_checking::Comparison;
+        use pumpkin_checking::TestAtomic;
+        use pumpkin_checking::VariableState;
+
+        let premises = [
+            TestAtomic {
+                name: "numerator",
+                comparison: Comparison::Equal,
+                value: 7,
+            },
+            TestAtomic {
+                name: "denominator",
+                comparison: Comparison::GreaterEqual,
+                value: 2,
+            },
+            TestAtomic {
+                name: "denominator",
+                comparison: Comparison::LessEqual,
+                value: 3,
+            },
+            TestAtomic {
+                name: "rhs",
+                comparison: Comparison::Equal,
+                value: 3,
+            },
+        ];
+
+        let state = VariableState::prepare_for_conflict_check(premises, None)
+            .expect("no conflicting atomics");
+
+        let checker = IntegerDivisionChecker {
+            numerator: "numerator",
+            denominator: "denominator",
+            rhs: "rhs",
+        };
+
+        // div_floor(7, 2) = 3 is the max corner, so the true upper bound is 3 (matching rhs); a
+        // buggy `.min()` over the floor-corners instead yields 2, which would wrongly conflict.
+        assert!(!checker.check(state, &premises, None));
     }
 }


### PR DESCRIPTION
The upper bound of the achievable quotient range must be the max of the floor-corners, not the min.  This causes the checker to report false-positive conflicts for sound inferences.