### PR TITLE
fix(pumpkin-constraints): Post the missing table clause direction

### DIFF
--- a/pumpkin-crates/constraints/src/constraints/table.rs
+++ b/pumpkin-crates/constraints/src/constraints/table.rs
@@ -101,6 +101,8 @@ impl<Var: IntegerVariable> Table<Var> {
                 clause.extend(supports.iter().map(|l| l.get_true_predicate()));
                 // Account for possible reification.
                 clause.extend(reification_literal.iter().map(|l| l.get_false_predicate()));
+
+                solver.add_clause(clause, self.constraint_tag)?;
             }
         }
 
@@ -188,5 +190,31 @@ impl<Var: IntegerVariable + 'static> NegatableConstraint for NegativeTable<Var> 
             table,
             constraint_tag,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eliminating_all_supporting_rows_prunes_the_value() {
+        let mut solver = Solver::default();
+
+        let constraint_tag = solver.new_constraint_tag();
+        let x1 = solver.new_named_bounded_integer(1, 2, "x1");
+        let x2 = solver.new_named_sparse_integer([10, 20, 30], "x2");
+
+        // Rows 2 and 3 are the only support for `x2 == 30`, and are exactly the rows that support
+        // `x1 == 2`. Fixing `x1 == 1` should eliminate both of them, which should in turn prune
+        // `30` from the domain of `x2`.
+        let rows = vec![vec![1, 10], vec![1, 20], vec![2, 30], vec![2, 30]];
+        let result = table(vec![x1, x2], rows, constraint_tag).post(&mut solver);
+        assert_eq!(result, Ok(()));
+
+        let result = solver.add_clause([predicate![x1 == 1]], constraint_tag);
+        assert_eq!(result, Ok(()));
+
+        assert_eq!(solver.upper_bound(&x2), 20);
     }
 }

--- a/pumpkin-crates/constraints/src/constraints/table.rs
+++ b/pumpkin-crates/constraints/src/constraints/table.rs
@@ -102,7 +102,7 @@ impl<Var: IntegerVariable> Table<Var> {
                 // Account for possible reification.
                 clause.extend(reification_literal.iter().map(|l| l.get_false_predicate()));
 
-                solver.add_clause(clause, self.constraint_tag)?;
+                solver.add_clause(clause, self.constraint_tag);
             }
         }
 
@@ -195,6 +195,8 @@ impl<Var: IntegerVariable + 'static> NegatableConstraint for NegativeTable<Var> 
 
 #[cfg(test)]
 mod tests {
+    use pumpkin_core::results::CSPSolverExecutionFlag;
+
     use super::*;
 
     #[test]
@@ -209,11 +211,15 @@ mod tests {
         // `x1 == 2`. Fixing `x1 == 1` should eliminate both of them, which should in turn prune
         // `30` from the domain of `x2`.
         let rows = vec![vec![1, 10], vec![1, 20], vec![2, 30], vec![2, 30]];
-        let result = table(vec![x1, x2], rows, constraint_tag).post(&mut solver);
-        assert_eq!(result, Ok(()));
+        table(vec![x1, x2], rows, constraint_tag).post(&mut solver);
 
-        let result = solver.add_clause([predicate![x1 == 1]], constraint_tag);
-        assert_eq!(result, Ok(()));
+        let result = solver.propagate_to_fixpoint();
+        assert_eq!(result, CSPSolverExecutionFlag::Feasible);
+
+        solver.add_clause([predicate![x1 == 1]], constraint_tag);
+
+        let result = solver.propagate_to_fixpoint();
+        assert_eq!(result, CSPSolverExecutionFlag::Feasible);
 
         assert_eq!(solver.upper_bound(&x2), 20);
     }

--- a/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
+++ b/pumpkin-crates/core/src/propagators/nogoods/nogood_propagator.rs
@@ -1189,7 +1189,14 @@ impl NogoodPropagator {
                     // replaced with an upper-bound predicate
                     // - If the propagating predicate is an upper-bound predicate then it is
                     // replaced with a lower-bound predicate
-                    if p != nogood[0]
+                    if p != nogood[0] && nogood[0].implies(p) {
+                        // `p` carries no information beyond what `nogood[0]` already asserts,
+                        // e.g. a `!=` predicate that got absorbed into a tightened bound during
+                        // semantic minimisation (`[x != 1]` becoming `[x >= 2]` when `1` was the
+                        // lower bound). Since `nogood[0]` alone implies `p`, `p` is not needed as
+                        // part of the reason.
+                        None
+                    } else if p != nogood[0]
                         && p.is_equality_predicate()
                         && p.get_domain() == nogood[0].get_domain()
                         && (nogood[0].is_lower_bound_predicate()


### PR DESCRIPTION
`Table::encode` built the `condition -> (\/ supports)` clause but never passed it to `solver.add_clause`, so only the `support -> condition` direction was posted. This made table propagation incomplete: when all rows that supported a value became false (e.g., via elimination in another column), that value was never pruned from the domain.