### PR TITLE
refactor(pumpkin-propagators): Simplify conflict detection incremental updates

### DIFF
--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/checks.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/checks.rs
@@ -107,13 +107,15 @@ pub(crate) fn split_profile_added_part_starts_after_profile_start<
 
 /// Determines whether a new profile which contains the overlap between `profile` and the added
 /// mandatory part should be added.
+///
+/// Returns `true` if the addition caused an overflow of the capacity.
 pub(crate) fn overlap_updated_profile<Var: IntegerVariable + 'static>(
     update_range: &Range<i32>,
     profile: &ResourceProfile<Var>,
     to_add: &mut Vec<ResourceProfile<Var>>,
     task: &Rc<Task<Var>>,
     capacity: i32,
-) -> Result<(), ResourceProfile<Var>> {
+) -> bool {
     // Now we create a new profile which consists of the part of the
     // profile covered by the update range
     // This means that we are adding the contribution of the updated
@@ -152,15 +154,10 @@ pub(crate) fn overlap_updated_profile<Var: IntegerVariable + 'static>(
         if profile.height + task.resource_usage > capacity {
             // The addition of the new mandatory part to the profile
             // caused an overflow of the resource
-            return Err(ResourceProfile {
-                start: new_profile_lower_bound,
-                end: new_profile_upper_bound,
-                profile_tasks: new_profile_tasks,
-                height: profile.height + task.resource_usage,
-            });
+            return true;
         }
     }
-    Ok(())
+    false
 }
 
 /// Determines whether the current profile is split by the added mandatory part due to the end

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/insertion.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/insertion.rs
@@ -30,7 +30,7 @@ pub(crate) fn conflicting_after_insertion_of_overlapping_mandatory<
     let mut to_add = Vec::new();
 
     // We keep track of whether a conflict has been found
-    let mut conflict = false;
+    let mut found_conflict = false;
 
     // Go over all indices of the profiles which overlap with the updated
     // one and determine which one need to be updated
@@ -74,14 +74,14 @@ pub(crate) fn conflicting_after_insertion_of_overlapping_mandatory<
         // between the current profile and the added mandatory part
         //
         // The addition of the mandatory part can lead to an overflow
-        let result = checks::overlap_updated_profile(
+        let conflicting = checks::overlap_updated_profile(
             update_range,
             profile,
             &mut to_add,
             updated_task,
             capacity,
         );
-        conflict |= result;
+        found_conflict |= conflicting;
 
         // Check whether the current profile is split by the added mandatory
         // part (end of profile remains unchanged)
@@ -106,7 +106,7 @@ pub(crate) fn conflicting_after_insertion_of_overlapping_mandatory<
     // the right place to ensure the ordering invariant
     let _ = time_table.splice(start_index..end_index + 1, to_add);
 
-    conflict
+    found_conflict
 }
 
 /// The new mandatory part added by `updated_task` (spanning `update_range`) does not overlap

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/insertion.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/insertion.rs
@@ -15,7 +15,9 @@ use crate::propagators::cumulative::time_table::over_interval_incremental_propag
 /// The new mandatory part added by `updated_task` (spanning `update_range`) overlaps with the
 /// profiles in `[start_index, end_index]`. This function calculates the added, and updated
 /// profiles and adds them to the `time-table` at the correct position.
-pub(crate) fn insert_profiles_overlapping_with_added_mandatory_part<
+///
+/// Return `true`, if a conflict was found.
+pub(crate) fn conflicting_after_insertion_of_overlapping_mandatory<
     Var: IntegerVariable + 'static,
 >(
     time_table: &mut OverIntervalTimeTableType<Var>,
@@ -24,11 +26,11 @@ pub(crate) fn insert_profiles_overlapping_with_added_mandatory_part<
     update_range: &Range<i32>,
     updated_task: &Rc<Task<Var>>,
     capacity: i32,
-) -> Result<(), ResourceProfile<Var>> {
+) -> bool {
     let mut to_add = Vec::new();
 
     // We keep track of whether a conflict has been found
-    let mut conflict = None;
+    let mut conflict = false;
 
     // Go over all indices of the profiles which overlap with the updated
     // one and determine which one need to be updated
@@ -79,9 +81,7 @@ pub(crate) fn insert_profiles_overlapping_with_added_mandatory_part<
             updated_task,
             capacity,
         );
-        if result.is_err() && conflict.is_none() {
-            conflict = Some(result)
-        }
+        conflict |= result;
 
         // Check whether the current profile is split by the added mandatory
         // part (end of profile remains unchanged)
@@ -106,11 +106,7 @@ pub(crate) fn insert_profiles_overlapping_with_added_mandatory_part<
     // the right place to ensure the ordering invariant
     let _ = time_table.splice(start_index..end_index + 1, to_add);
 
-    if let Some(conflict) = conflict {
-        conflict
-    } else {
-        Ok(())
-    }
+    conflict
 }
 
 /// The new mandatory part added by `updated_task` (spanning `update_range`) does not overlap

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
@@ -184,13 +184,14 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
 
     /// Adds the added parts in the provided [`MandatoryPartAdjustments`] to the time-table; note
     /// that all of the adjustments are applied even if a conflict is found.
-    fn add_to_time_table(
+    ///
+    /// Returns true if the addition to the time-table caused an overflow of the capacity.
+    fn conflicting_after_addition_to_time_table(
         &mut self,
-        mut context: Domains,
         mandatory_part_adjustments: &MandatoryPartAdjustments,
         task: &Rc<Task<Var>>,
-    ) -> PropagationStatusCP {
-        let mut conflict = None;
+    ) -> bool {
+        let mut conflict = false;
         // We consider both of the possible update ranges
         // Note that the upper update range is first considered to avoid any issues with the
         // indices when processing the other update range
@@ -198,7 +199,7 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
             // First we attempt to find overlapping profiles
             match determine_profiles_to_update(&self.time_table, &update_range) {
                 Ok((start_index, end_index)) => {
-                    let result = insertion::insert_profiles_overlapping_with_added_mandatory_part(
+                    let result = insertion::conflicting_after_insertion_of_overlapping_mandatory(
                         &mut self.time_table,
                         start_index,
                         end_index,
@@ -206,18 +207,7 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
                         task,
                         self.parameters.capacity,
                     );
-                    if let Err(conflict_tasks) = result
-                        && conflict.is_none()
-                    {
-                        conflict = Some(Err(create_conflict_explanation(
-                            context.reborrow(),
-                            self.inference_code.as_ref().unwrap(),
-                            &conflict_tasks,
-                            self.parameters.options.explanation_type,
-                            self.parameters.capacity,
-                        )
-                        .into()));
-                    }
+                    conflict |= result;
                 }
                 Err(index_to_insert) => insertion::insert_profile_new_mandatory_part(
                     &mut self.time_table,
@@ -227,11 +217,8 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
                 ),
             }
         }
-        if let Some(conflict) = conflict {
-            conflict
-        } else {
-            Ok(())
-        }
+
+        conflict
     }
 
     /// Removes the removed parts in the provided [`MandatoryPartAdjustments`] from the time-table
@@ -306,14 +293,13 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
             //
             // Note that the inconsistency returned here does not necessarily hold since other
             // updates could remove from the profile
-            let result = self.add_to_time_table(
-                context.domains(),
+            let result = self.conflicting_after_addition_to_time_table(
                 &mandatory_part_adjustments,
                 &updated_task,
             );
 
             // If we have found an overflow then we mark that we need to check the profile
-            found_conflict |= result.is_err();
+            found_conflict |= result;
 
             // Then we reset the update for the task since it has been processed
             self.updatable_structures

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
@@ -191,7 +191,7 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
         mandatory_part_adjustments: &MandatoryPartAdjustments,
         task: &Rc<Task<Var>>,
     ) -> bool {
-        let mut conflict = false;
+        let mut found_conflict = false;
         // We consider both of the possible update ranges
         // Note that the upper update range is first considered to avoid any issues with the
         // indices when processing the other update range
@@ -199,15 +199,16 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
             // First we attempt to find overlapping profiles
             match determine_profiles_to_update(&self.time_table, &update_range) {
                 Ok((start_index, end_index)) => {
-                    let result = insertion::conflicting_after_insertion_of_overlapping_mandatory(
-                        &mut self.time_table,
-                        start_index,
-                        end_index,
-                        &update_range,
-                        task,
-                        self.parameters.capacity,
-                    );
-                    conflict |= result;
+                    let conflicting =
+                        insertion::conflicting_after_insertion_of_overlapping_mandatory(
+                            &mut self.time_table,
+                            start_index,
+                            end_index,
+                            &update_range,
+                            task,
+                            self.parameters.capacity,
+                        );
+                    found_conflict |= conflicting;
                 }
                 Err(index_to_insert) => insertion::insert_profile_new_mandatory_part(
                     &mut self.time_table,
@@ -218,7 +219,7 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
             }
         }
 
-        conflict
+        found_conflict
     }
 
     /// Removes the removed parts in the provided [`MandatoryPartAdjustments`] from the time-table
@@ -293,13 +294,13 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool>
             //
             // Note that the inconsistency returned here does not necessarily hold since other
             // updates could remove from the profile
-            let result = self.conflicting_after_addition_to_time_table(
+            let conflicting = self.conflicting_after_addition_to_time_table(
                 &mandatory_part_adjustments,
                 &updated_task,
             );
 
             // If we have found an overflow then we mark that we need to check the profile
-            found_conflict |= result;
+            found_conflict |= conflicting;
 
             // Then we reset the update for the task since it has been processed
             self.updatable_structures

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
@@ -173,16 +173,17 @@ impl<Var: IntegerVariable + 'static + Debug, const SYNCHRONISE: bool>
 
     /// Adds the added parts in the provided [`MandatoryPartAdjustments`] to the time-table; note
     /// that all of the adjustments are applied even if a conflict is found.
-    fn add_to_time_table(
+    ///
+    /// Returns true if the addition of the mandatory parts caused an overflow.
+    fn conflicting_after_addition_to_time_table(
         &mut self,
-        mut context: Domains,
         mandatory_part_adjustments: &MandatoryPartAdjustments,
         task: &Rc<Task<Var>>,
-    ) -> PropagationStatusCP {
+    ) -> bool {
         // Go over all of the updated tasks and calculate the added mandatory part (we know
         // that for each of these tasks, a mandatory part exists, otherwise it would not
         // have been added (see [`should_propagate`]))
-        let mut conflict = None;
+        let mut conflict = false;
 
         for time_point in mandatory_part_adjustments.get_added_parts().flatten() {
             pumpkin_assert_extreme!(
@@ -208,25 +209,10 @@ impl<Var: IntegerVariable + 'static + Debug, const SYNCHRONISE: bool>
             current_profile.height += task.resource_usage;
             current_profile.profile_tasks.push(Rc::clone(task));
 
-            if current_profile.height > self.parameters.capacity && conflict.is_none() {
-                // The newly introduced mandatory part(s) caused an overflow of the resource
-                conflict = Some(Err(create_conflict_explanation(
-                    context.reborrow(),
-                    self.inference_code.as_ref().unwrap(),
-                    current_profile,
-                    self.parameters.options.explanation_type,
-                    self.parameters.capacity,
-                )
-                .into()));
-            }
+            conflict |= current_profile.height > self.parameters.capacity;
         }
 
-        // If we have found a conflict then we report it
-        if let Some(conflict) = conflict {
-            conflict
-        } else {
-            Ok(())
-        }
+        conflict
     }
 
     /// Removes the removed parts in the provided [`MandatoryPartAdjustments`] from the time-table
@@ -324,14 +310,13 @@ impl<Var: IntegerVariable + 'static + Debug, const SYNCHRONISE: bool>
             //
             // Note that the inconsistency returned here does not necessarily hold since other
             // updates could remove from the profile
-            let result = self.add_to_time_table(
-                context.domains(),
+            let conflicting = self.conflicting_after_addition_to_time_table(
                 &mandatory_part_adjustments,
                 &updated_task,
             );
 
             // If we have found an overflow then we mark that we need to check the profile
-            found_conflict |= result.is_err();
+            found_conflict |= conflicting;
 
             // Then we reset the update for the task since it has been processed
             self.updatable_structures


### PR DESCRIPTION
This PR aims to simplify some of the logic/return types used when incrementally creating a time-table during cumulative propagation.