### PR TITLE
fix(pumpkin-propagators): Synchronisation of time-tabling due to differences in enqueueing

### DIFF
--- a/pumpkin-crates/conflict-resolvers/src/resolvers/resolution_resolver.rs
+++ b/pumpkin-crates/conflict-resolvers/src/resolvers/resolution_resolver.rs
@@ -243,7 +243,6 @@ impl ResolutionResolver {
                 &mut self.predicate_id_generator,
                 self.mode,
                 &mut self.statistics.cpip_statistics,
-                context,
             )
             .collect::<Vec<_>>();
 

--- a/pumpkin-crates/conflict-resolvers/src/resolvers/working_nogood.rs
+++ b/pumpkin-crates/conflict-resolvers/src/resolvers/working_nogood.rs
@@ -1,4 +1,3 @@
-use pumpkin_core::asserts::pumpkin_assert_advanced;
 use pumpkin_core::asserts::pumpkin_assert_eq_simple;
 use pumpkin_core::asserts::pumpkin_assert_simple;
 use pumpkin_core::conflict_resolving::ConflictAnalysisContext;
@@ -79,27 +78,9 @@ impl WorkingNogood {
     ///
     /// **Note** - This can be called multiple times when using CPIP nogoods (see
     /// [`AnalysisMode`]).
-    fn add_asserting_predicate(
-        &mut self,
-        predicate: Predicate,
-        context: &mut ConflictAnalysisContext<'_>,
-        predicate_id_generator: &mut PredicateIdGenerator,
-        mode: AnalysisMode,
-    ) {
+    fn add_asserting_predicate(&mut self, predicate: Predicate) {
         // We push it directly into a vector since we do not need to resolve upon it
         self.processed_nogood_predicates.push(predicate);
-
-        pumpkin_assert_advanced!(
-            !self.iterative_minimisation
-                || !self.is_redundant(
-                    predicate,
-                    context,
-                    predicate_id_generator.get_id(predicate),
-                    predicate_id_generator,
-                    mode
-                ),
-            "The asserting predicate should not be redundant"
-        );
     }
 
     /// Adds a predicate to the current working nogood which is from the current checkpoint.
@@ -247,9 +228,8 @@ impl WorkingNogood {
         predicate_id_generator: &mut PredicateIdGenerator,
         mode: AnalysisMode,
         statistics: &mut CpipStatistics,
-        context: &mut ConflictAnalysisContext,
     ) -> impl Iterator<Item = Predicate> {
-        let num_removed = self.remove_final_predicates(predicate_id_generator, mode, context);
+        let num_removed = self.remove_final_predicates(predicate_id_generator, mode);
 
         pumpkin_assert_eq_simple!(self.num_current_checkpoint(), 0);
 
@@ -278,7 +258,6 @@ impl WorkingNogood {
         &mut self,
         predicate_id_generator: &mut PredicateIdGenerator,
         mode: AnalysisMode,
-        context: &mut ConflictAnalysisContext,
     ) -> usize {
         let num_removed = self.num_current_checkpoint();
 
@@ -303,7 +282,7 @@ impl WorkingNogood {
             );
             previous_predicate = Some(predicate);
 
-            self.add_asserting_predicate(predicate, context, predicate_id_generator, mode);
+            self.add_asserting_predicate(predicate);
         }
 
         num_removed

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
@@ -448,7 +448,12 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool> Propagator
         //
         // However, this could mean that we potentially enqueue even though the time-table is empty
         // after backtracking but has not been recalculated yet.
-        let result = should_enqueue(&self.updatable_structures, &updated_task, context.domains());
+        let result = should_enqueue(
+            &self.updatable_structures,
+            &updated_task,
+            context.domains(),
+            &self.parameters,
+        );
 
         // If there is a task which now has a mandatory part then we store it and process it when
         // the `propagate` method is called

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/over_interval_incremental_propagator/time_table_over_interval_incremental.rs
@@ -461,13 +461,7 @@ impl<Var: IntegerVariable + 'static, const SYNCHRONISE: bool> Propagator
         //
         // However, this could mean that we potentially enqueue even though the time-table is empty
         // after backtracking but has not been recalculated yet.
-        let result = should_enqueue(
-            &self.parameters,
-            &self.updatable_structures,
-            &updated_task,
-            context.domains(),
-            self.time_table.is_empty(),
-        );
+        let result = should_enqueue(&self.updatable_structures, &updated_task, context.domains());
 
         // If there is a task which now has a mandatory part then we store it and process it when
         // the `propagate` method is called

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
@@ -473,7 +473,12 @@ impl<Var: IntegerVariable + 'static + Debug, const SYNCHRONISE: bool> Propagator
         //
         // However, this could mean that we potentially enqueue even though the time-table is empty
         // after backtracking but has not been recalculated yet.
-        let result = should_enqueue(&self.updatable_structures, &updated_task, context.domains());
+        let result = should_enqueue(
+            &self.updatable_structures,
+            &updated_task,
+            context.domains(),
+            &self.parameters,
+        );
 
         // If there is a task which now has a mandatory part then we store it and process it when
         // the `propagate` method is called

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/per_point_incremental_propagator/time_table_per_point_incremental.rs
@@ -488,13 +488,7 @@ impl<Var: IntegerVariable + 'static + Debug, const SYNCHRONISE: bool> Propagator
         //
         // However, this could mean that we potentially enqueue even though the time-table is empty
         // after backtracking but has not been recalculated yet.
-        let result = should_enqueue(
-            &self.parameters,
-            &self.updatable_structures,
-            &updated_task,
-            context.domains(),
-            self.time_table.is_empty(),
-        );
+        let result = should_enqueue(&self.updatable_structures, &updated_task, context.domains());
 
         // If there is a task which now has a mandatory part then we store it and process it when
         // the `propagate` method is called

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_over_interval.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_over_interval.rs
@@ -180,7 +180,12 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTableOverIntervalPropaga
     ) -> EnqueueDecision {
         let updated_task = Rc::clone(&self.parameters.tasks[local_id.unpack() as usize]);
 
-        let result = should_enqueue(&self.updatable_structures, &updated_task, context.domains());
+        let result = should_enqueue(
+            &self.updatable_structures,
+            &updated_task,
+            context.domains(),
+            &self.parameters,
+        );
 
         update_bounds_task(
             context.domains(),

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_over_interval.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_over_interval.rs
@@ -67,8 +67,6 @@ pub(crate) struct Event<Var> {
 /// Computer Science and Software Engineering, 2011.
 #[derive(Debug, Clone)]
 pub struct TimeTableOverIntervalPropagator<Var> {
-    /// Stores whether the time-table is empty
-    is_time_table_empty: bool,
     /// Stores the input parameters to the cumulative constraint
     parameters: CumulativeParameters<Var>,
     /// Stores structures which change during the search; used to store the bounds
@@ -97,7 +95,6 @@ impl<Var: IntegerVariable + 'static> TimeTableOverIntervalPropagator<Var> {
         let updatable_structures = UpdatableStructures::new(&parameters);
 
         TimeTableOverIntervalPropagator {
-            is_time_table_empty: true,
             parameters,
             updatable_structures,
             constraint_tag,
@@ -159,7 +156,6 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTableOverIntervalPropaga
             &self.parameters,
             self.inference_code.as_ref().unwrap(),
         )?;
-        self.is_time_table_empty = time_table.is_empty();
         // No error has been found -> Check for updates (i.e. go over all profiles and all tasks and
         // check whether an update can take place)
         propagate_based_on_timetable(
@@ -183,18 +179,8 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTableOverIntervalPropaga
         event: OpaqueDomainEvent,
     ) -> EnqueueDecision {
         let updated_task = Rc::clone(&self.parameters.tasks[local_id.unpack() as usize]);
-        // Note that it could be the case that `is_time_table_empty` is inaccurate here since it
-        // wasn't updated in `synchronise`; however, `synchronise` will only remove profiles
-        // meaning that `is_time_table_empty` will always return `false` when it is not
-        // empty and it might return `false` even when the time-table is not empty *but* it
-        // will never return `true` when the time-table is not empty.
-        let result = should_enqueue(
-            &self.parameters,
-            &self.updatable_structures,
-            &updated_task,
-            context.domains(),
-            self.is_time_table_empty,
-        );
+
+        let result = should_enqueue(&self.updatable_structures, &updated_task, context.domains());
 
         update_bounds_task(
             context.domains(),

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_per_point.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_per_point.rs
@@ -56,8 +56,6 @@ use crate::propagators::cumulative::time_table::propagation_handler::create_conf
 /// Computer Science and Software Engineering, 2011.
 #[derive(Debug, Clone)]
 pub struct TimeTablePerPointPropagator<Var> {
-    /// Stores whether the time-table is empty
-    is_time_table_empty: bool,
     /// Stores the input parameters to the cumulative constraint
     parameters: CumulativeParameters<Var>,
     /// Stores structures which change during the search; used to store the bounds
@@ -89,7 +87,6 @@ impl<Var: IntegerVariable + 'static> TimeTablePerPointPropagator<Var> {
         let updatable_structures = UpdatableStructures::new(&parameters);
 
         TimeTablePerPointPropagator {
-            is_time_table_empty: true,
             parameters,
             updatable_structures,
             constraint_tag,
@@ -149,7 +146,6 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointPropagator<
             self.inference_code.as_ref().unwrap(),
             &self.parameters,
         )?;
-        self.is_time_table_empty = time_table.is_empty();
         // No error has been found -> Check for updates (i.e. go over all profiles and all tasks and
         // check whether an update can take place)
         propagate_based_on_timetable(
@@ -173,18 +169,8 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointPropagator<
         event: OpaqueDomainEvent,
     ) -> EnqueueDecision {
         let updated_task = Rc::clone(&self.parameters.tasks[local_id.unpack() as usize]);
-        // Note that it could be the case that `is_time_table_empty` is inaccurate here since it
-        // wasn't updated in `synchronise`; however, `synchronise` will only remove profiles
-        // meaning that `is_time_table_empty` will always return `false` when it is not
-        // empty and it might return `false` even when the time-table is not empty *but* it
-        // will never return `true` when the time-table is not empty.
-        let result = should_enqueue(
-            &self.parameters,
-            &self.updatable_structures,
-            &updated_task,
-            context.domains(),
-            self.is_time_table_empty,
-        );
+
+        let result = should_enqueue(&self.updatable_structures, &updated_task, context.domains());
 
         // Note that the non-incremental proapgator does not make use of `result.updated` since it
         // propagates from scratch anyways

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_per_point.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_per_point.rs
@@ -170,7 +170,12 @@ impl<Var: IntegerVariable + 'static> Propagator for TimeTablePerPointPropagator<
     ) -> EnqueueDecision {
         let updated_task = Rc::clone(&self.parameters.tasks[local_id.unpack() as usize]);
 
-        let result = should_enqueue(&self.updatable_structures, &updated_task, context.domains());
+        let result = should_enqueue(
+            &self.updatable_structures,
+            &updated_task,
+            context.domains(),
+            &self.parameters,
+        );
 
         // Note that the non-incremental proapgator does not make use of `result.updated` since it
         // propagates from scratch anyways

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_util.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_util.rs
@@ -43,6 +43,7 @@ pub(crate) fn should_enqueue<Var: IntegerVariable + 'static>(
     updatable_structures: &UpdatableStructures<Var>,
     updated_task: &Rc<Task<Var>>,
     mut context: Domains,
+    parameters: &CumulativeParameters<Var>,
 ) -> ShouldEnqueueResult<Var> {
     pumpkin_assert_extreme!(
         context.lower_bound(&updated_task.start_variable)
@@ -77,7 +78,14 @@ pub(crate) fn should_enqueue<Var: IntegerVariable + 'static>(
         });
     }
 
-    result.decision = EnqueueDecision::Enqueue;
+    if parameters.options.allow_holes_in_domain && result.update.is_none() {
+        // If we allow holes in the domains, then we only need to enqueue when there has been a
+        // change in the time-table since all other values have already been removed, meaning that
+        // a change in the bounds of a task would not lead to a propagation.
+        result.decision = EnqueueDecision::Skip
+    } else {
+        result.decision = EnqueueDecision::Enqueue;
+    }
 
     result
 }

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_util.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_util.rs
@@ -179,7 +179,7 @@ fn debug_check_whether_profiles_are_maximal_and_sorted<'a, Var: IntegerVariable 
 pub(crate) fn propagate_based_on_timetable<'a, Var: IntegerVariable + 'static>(
     context: &mut PropagationContext,
     inference_code: &InferenceCode,
-    time_table: impl Iterator<Item = &'a ResourceProfile<Var>> + Clone,
+    time_table: impl ExactSizeIterator<Item = &'a ResourceProfile<Var>> + Clone,
     parameters: &CumulativeParameters<Var>,
     updatable_structures: &mut UpdatableStructures<Var>,
 ) -> PropagationStatusCP {
@@ -200,6 +200,11 @@ pub(crate) fn propagate_based_on_timetable<'a, Var: IntegerVariable + 'static>(
             .all(|fixed_task| context.is_fixed(&fixed_task.start_variable)),
         "All of the fixed tasks should be fixed at this point"
     );
+
+    if time_table.len() == 0 {
+        // No propagation can take place since the time-table is empty
+        return Ok(());
+    }
 
     if parameters.options.generate_sequence {
         propagate_sequence_of_profiles(

--- a/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_util.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/time_table/time_table_util.rs
@@ -40,11 +40,9 @@ pub(crate) struct ShouldEnqueueResult<Var> {
 /// such task exists). This method should be called in the
 /// [`ConstraintProgrammingPropagator::notify`] method.
 pub(crate) fn should_enqueue<Var: IntegerVariable + 'static>(
-    parameters: &CumulativeParameters<Var>,
     updatable_structures: &UpdatableStructures<Var>,
     updated_task: &Rc<Task<Var>>,
     mut context: Domains,
-    empty_time_table: bool,
 ) -> ShouldEnqueueResult<Var> {
     pumpkin_assert_extreme!(
         context.lower_bound(&updated_task.start_variable)
@@ -79,28 +77,8 @@ pub(crate) fn should_enqueue<Var: IntegerVariable + 'static>(
         });
     }
 
-    result.decision = if parameters.options.allow_holes_in_domain {
-        // If there are updates then propagations might occur due to new mandatory parts being
-        // added. However, if there are no updates then because we allow holes in the domain, no
-        // updates can occur so we can skip propagation!
-        if updatable_structures.has_updates() || result.update.is_some() {
-            EnqueueDecision::Enqueue
-        } else {
-            EnqueueDecision::Skip
-        }
-    } else {
-        // If the time-table is empty and we have not received any updates (e.g. no mandatory parts
-        // have been introduced since the last propagation) then we can determine that no
-        // propagation will take place. It is not sufficient to check whether there have
-        // been no updates since it could be the case that a task which has been updated can
-        // now propagate due to an existing profile (this is due to the fact that we only
-        // propagate bounds and (currently) do not create holes in the domain!).
-        if !empty_time_table || updatable_structures.has_updates() || result.update.is_some() {
-            EnqueueDecision::Enqueue
-        } else {
-            EnqueueDecision::Skip
-        }
-    };
+    result.decision = EnqueueDecision::Enqueue;
+
     result
 }
 

--- a/pumpkin-crates/propagators/src/propagators/cumulative/utils/structs/updatable_structures.rs
+++ b/pumpkin-crates/propagators/src/propagators/cumulative/utils/structs/updatable_structures.rs
@@ -46,11 +46,6 @@ impl<Var: IntegerVariable + 'static> UpdatableStructures<Var> {
         }
     }
 
-    /// Returns whether there are any updates stored which have not been processed
-    pub(crate) fn has_updates(&self) -> bool {
-        !self.updated_tasks.is_empty()
-    }
-
     /// Returns the next updated task and removes it from the updated list
     pub(crate) fn pop_next_updated_task(&mut self) -> Option<Rc<Task<Var>>> {
         if self.updated_tasks.is_empty() {


### PR DESCRIPTION
There were some issues with synchronisation, which infrequently appeared due to differences in updatable structures. This PR fixes this by simplifying the enqueueing check significantly, ensuring that the behaviour is the same across propagators.

## TODO
- [x] Check impact on performance