### PR TITLE
chore(pumpkin-conflict-resolvers): Remove incorrect check

### DIFF
--- a/pumpkin-crates/conflict-resolvers/src/resolvers/resolution_resolver.rs
+++ b/pumpkin-crates/conflict-resolvers/src/resolvers/resolution_resolver.rs
@@ -243,7 +243,6 @@ impl ResolutionResolver {
                 &mut self.predicate_id_generator,
                 self.mode,
                 &mut self.statistics.cpip_statistics,
-                context,
             )
             .collect::<Vec<_>>();
 

--- a/pumpkin-crates/conflict-resolvers/src/resolvers/working_nogood.rs
+++ b/pumpkin-crates/conflict-resolvers/src/resolvers/working_nogood.rs
@@ -1,4 +1,3 @@
-use pumpkin_core::asserts::pumpkin_assert_advanced;
 use pumpkin_core::asserts::pumpkin_assert_eq_simple;
 use pumpkin_core::asserts::pumpkin_assert_simple;
 use pumpkin_core::conflict_resolving::ConflictAnalysisContext;
@@ -79,27 +78,9 @@ impl WorkingNogood {
     ///
     /// **Note** - This can be called multiple times when using CPIP nogoods (see
     /// [`AnalysisMode`]).
-    fn add_asserting_predicate(
-        &mut self,
-        predicate: Predicate,
-        context: &mut ConflictAnalysisContext<'_>,
-        predicate_id_generator: &mut PredicateIdGenerator,
-        mode: AnalysisMode,
-    ) {
+    fn add_asserting_predicate(&mut self, predicate: Predicate) {
         // We push it directly into a vector since we do not need to resolve upon it
         self.processed_nogood_predicates.push(predicate);
-
-        pumpkin_assert_advanced!(
-            !self.iterative_minimisation
-                || !self.is_redundant(
-                    predicate,
-                    context,
-                    predicate_id_generator.get_id(predicate),
-                    predicate_id_generator,
-                    mode
-                ),
-            "The asserting predicate should not be redundant"
-        );
     }
 
     /// Adds a predicate to the current working nogood which is from the current checkpoint.
@@ -247,9 +228,8 @@ impl WorkingNogood {
         predicate_id_generator: &mut PredicateIdGenerator,
         mode: AnalysisMode,
         statistics: &mut CpipStatistics,
-        context: &mut ConflictAnalysisContext,
     ) -> impl Iterator<Item = Predicate> {
-        let num_removed = self.remove_final_predicates(predicate_id_generator, mode, context);
+        let num_removed = self.remove_final_predicates(predicate_id_generator, mode);
 
         pumpkin_assert_eq_simple!(self.num_current_checkpoint(), 0);
 
@@ -278,7 +258,6 @@ impl WorkingNogood {
         &mut self,
         predicate_id_generator: &mut PredicateIdGenerator,
         mode: AnalysisMode,
-        context: &mut ConflictAnalysisContext,
     ) -> usize {
         let num_removed = self.num_current_checkpoint();
 
@@ -303,7 +282,7 @@ impl WorkingNogood {
             );
             previous_predicate = Some(predicate);
 
-            self.add_asserting_predicate(predicate, context, predicate_id_generator, mode);
+            self.add_asserting_predicate(predicate);
         }
 
         num_removed


### PR DESCRIPTION
Removes an incorrect check which causes failures when running with `--features=debug-checks`. The check is incorrect because the function to `is_redundant` adjusts internal structures which it should not at that point.