### PR TITLE
feat(pumpkin-core): Add additional (coarse) timing statistics

### DIFF
--- a/pumpkin-crates/conflict-resolvers/src/minimisers/recursive_minimiser.rs
+++ b/pumpkin-crates/conflict-resolvers/src/minimisers/recursive_minimiser.rs
@@ -9,8 +9,11 @@ use pumpkin_core::predicates::Predicate;
 use pumpkin_core::propagation::ReadDomains;
 use pumpkin_core::state::CurrentNogood;
 use pumpkin_core::state::PredicateHeap;
+use pumpkin_core::statistics::Statistic;
+use pumpkin_core::statistics::StatisticLogger;
 use pumpkin_core::statistics::moving_averages::CumulativeMovingAverage;
 use pumpkin_core::statistics::moving_averages::MovingAverage;
+use pumpkin_core::termination::Instant;
 
 use crate::minimisers::NogoodMinimiser;
 
@@ -42,10 +45,14 @@ pub struct RecursiveMinimiser {
 create_statistics_struct!(RecursiveMinimiserStatistics {
     /// The average number of atomic constraints removed by recursive minimisation during conflict analysis
     average_number_of_removed_atomic_constraints_recursive: CumulativeMovingAverage<u64>,
+    /// The cumulative number of seconds spent performing recursive minimisation.
+    num_seconds_minimising_recursive: f64,
 });
 
 impl NogoodMinimiser for RecursiveMinimiser {
     fn minimise(&mut self, context: &mut ConflictAnalysisContext, nogood: &mut Vec<Predicate>) {
+        let start_time = Instant::now();
+
         let num_literals_before_minimisation = nogood.len();
 
         self.initialise_minimisation_data_structures(nogood, context);
@@ -91,6 +98,13 @@ impl NogoodMinimiser for RecursiveMinimiser {
         self.statistics
             .average_number_of_removed_atomic_constraints_recursive
             .add_term((num_literals_before_minimisation - nogood.len()) as u64);
+
+        self.statistics.num_seconds_minimising_recursive += start_time.elapsed().as_secs_f64();
+    }
+
+    fn log_statistics(&self, statistic_logger: StatisticLogger) {
+        self.statistics
+            .log(statistic_logger.attach_to_prefix("RecursiveMinimiser"));
     }
 }
 

--- a/pumpkin-crates/conflict-resolvers/src/minimisers/semantic_minimiser.rs
+++ b/pumpkin-crates/conflict-resolvers/src/minimisers/semantic_minimiser.rs
@@ -10,8 +10,11 @@ use pumpkin_core::predicates::Predicate;
 use pumpkin_core::predicates::PredicateType;
 use pumpkin_core::propagation::ReadDomains;
 use pumpkin_core::results::ProblemSolution;
+use pumpkin_core::statistics::Statistic;
+use pumpkin_core::statistics::StatisticLogger;
 use pumpkin_core::statistics::moving_averages::CumulativeMovingAverage;
 use pumpkin_core::statistics::moving_averages::MovingAverage;
+use pumpkin_core::termination::Instant;
 use pumpkin_core::variables::DomainId;
 
 use crate::minimisers::NogoodMinimiser;
@@ -38,6 +41,8 @@ pub struct SemanticMinimiser {
 create_statistics_struct!(SemanticMinimiserStatistics {
     /// The average number of atomic constraints removed by semantic minimisation during conflict analysis
     average_number_of_removed_atomic_constraints_semantic: CumulativeMovingAverage<u64>,
+    /// The cumulative number of seconds spent performing semantic minimisation.
+    num_seconds_minimising_semantic: f64,
 });
 
 impl Default for SemanticMinimiser {
@@ -66,6 +71,8 @@ pub enum SemanticMinimisationMode {
 
 impl NogoodMinimiser for SemanticMinimiser {
     fn minimise(&mut self, context: &mut ConflictAnalysisContext, nogood: &mut Vec<Predicate>) {
+        let start_time = Instant::now();
+
         self.accommodate(context);
         self.clean_up();
         self.apply_predicates(nogood);
@@ -74,11 +81,12 @@ impl NogoodMinimiser for SemanticMinimiser {
 
         // Compile the nogood based on the internal state.
         // Add domain description to the helper.
+        let mut is_inconsistent = false;
         for domain_id in self.present_ids.iter() {
             // If at least one domain is inconsistent, we can stop.
             if self.domains[domain_id].inconsistent {
-                *nogood = vec![Predicate::trivially_false()];
-                return;
+                is_inconsistent = true;
+                break;
             }
             self.domains[domain_id].add_domain_description_to_vector(
                 context,
@@ -88,13 +96,25 @@ impl NogoodMinimiser for SemanticMinimiser {
                 self.mode,
             );
         }
-        *nogood = self.helper.clone();
+
+        if is_inconsistent {
+            *nogood = vec![Predicate::trivially_false()];
+        } else {
+            *nogood = self.helper.clone();
+        }
 
         if self.mode == SemanticMinimisationMode::EnableEqualityMerging {
             self.statistics
                 .average_number_of_removed_atomic_constraints_semantic
                 .add_term((len_before - nogood.len()) as u64);
         }
+
+        self.statistics.num_seconds_minimising_semantic += start_time.elapsed().as_secs_f64();
+    }
+
+    fn log_statistics(&self, statistic_logger: StatisticLogger) {
+        self.statistics
+            .log(statistic_logger.attach_to_prefix("SemanticMinimiser"));
     }
 }
 

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -691,7 +691,13 @@ impl ConstraintSatisfactionSolver {
             rng: &mut self.internal_parameters.random_generator,
         };
 
+        let start_time = Instant::now();
+
         resolver.resolve_conflict(&mut conflict_analysis_context);
+
+        self.solver_statistics
+            .engine_statistics
+            .time_spent_in_conflict_analysis += start_time.elapsed();
 
         self.solver_state.declare_solving();
     }

--- a/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
+++ b/pumpkin-crates/core/src/engine/constraint_satisfaction_solver.rs
@@ -630,7 +630,18 @@ impl ConstraintSatisfactionSolver {
         );
 
         // If there is a next decision, make the decision.
-        let Some(decision_predicate) = brancher.next_decision(context) else {
+        //
+        // Note that we only measure the time spent in the call to the brancher rather than the
+        // time spent in this entire function. Measuring the latter would require restructuring
+        // this function to accommodate its several exit points, which we leave for a later time
+        // since this measurement will do fine.
+        let start_time = Instant::now();
+        let next_decision = brancher.next_decision(context);
+        self.solver_statistics
+            .engine_statistics
+            .time_spent_in_branching += start_time.elapsed();
+
+        let Some(decision_predicate) = next_decision else {
             // Otherwise there are no more decisions to be made,
             // all predicates have been applied without a conflict,
             // meaning the problem is feasible.

--- a/pumpkin-crates/core/src/engine/solver_statistics.rs
+++ b/pumpkin-crates/core/src/engine/solver_statistics.rs
@@ -19,10 +19,14 @@ impl SolverStatistics {
             self.engine_statistics.time_spent_in_solver.as_secs_f64(),
         );
         log_statistic(
-            "conflictAnalysisTime",
+            "numSecondsInConflictAnalysis",
             self.engine_statistics
                 .time_spent_in_conflict_analysis
                 .as_secs_f64(),
+        );
+        log_statistic(
+            "numSecondsInBranching",
+            self.engine_statistics.time_spent_in_branching.as_secs_f64(),
         );
     }
 }
@@ -38,6 +42,8 @@ pub(crate) struct EngineStatistics {
     pub(crate) time_spent_in_solver: Duration,
     /// The amount of time which is spent performing conflict analysis.
     pub(crate) time_spent_in_conflict_analysis: Duration,
+    /// The amount of time which is spent by the brancher selecting decisions.
+    pub(crate) time_spent_in_branching: Duration,
     /// The peak depth of the seach tree
     pub(crate) peak_depth: u64,
 }

--- a/pumpkin-crates/core/src/engine/solver_statistics.rs
+++ b/pumpkin-crates/core/src/engine/solver_statistics.rs
@@ -18,6 +18,12 @@ impl SolverStatistics {
             "solveTime",
             self.engine_statistics.time_spent_in_solver.as_secs_f64(),
         );
+        log_statistic(
+            "conflictAnalysisTime",
+            self.engine_statistics
+                .time_spent_in_conflict_analysis
+                .as_secs_f64(),
+        );
     }
 }
 
@@ -30,6 +36,8 @@ pub(crate) struct EngineStatistics {
     pub(crate) num_restarts: u64,
     /// The amount of time which is spent in the solver.
     pub(crate) time_spent_in_solver: Duration,
+    /// The amount of time which is spent performing conflict analysis.
+    pub(crate) time_spent_in_conflict_analysis: Duration,
     /// The peak depth of the seach tree
     pub(crate) peak_depth: u64,
 }

--- a/pumpkin-crates/core/src/engine/state.rs
+++ b/pumpkin-crates/core/src/engine/state.rs
@@ -5,6 +5,7 @@ use pumpkin_checking::InferenceChecker;
 #[cfg(feature = "check-propagations")]
 use pumpkin_checking::VariableState;
 
+use crate::basic_types::time::Instant;
 use crate::checkers::CheckerStore;
 use crate::containers::KeyGenerator;
 use crate::create_statistics_struct;
@@ -89,6 +90,9 @@ create_statistics_struct!(StateStatistics {
     num_propagators_called: usize,
     num_propagations: usize,
     num_conflicts: usize,
+    /// The cumulative number of seconds spent inside [`State::propagate_to_fixed_point`],
+    /// i.e., propagating all enqueued propagators to a fixed point (or until a conflict is found).
+    num_seconds_in_fixed_point_propagation: f64,
     /// The number of levels which were backjumped.
     ///
     /// For an individual backtrack due to a learned nogood, this is calculated according to the
@@ -135,6 +139,10 @@ impl State {
         log_statistic("failures", self.statistics.num_conflicts);
         log_statistic("propagations", self.statistics.num_propagators_called);
         log_statistic("nogoods", self.statistics.num_conflicts);
+        log_statistic(
+            "numSecondsInFixedPointPropagation",
+            self.statistics.num_seconds_in_fixed_point_propagation,
+        );
         if verbose {
             log_statistic(
                 "numAtomicConstraintsPropagated",
@@ -757,6 +765,8 @@ impl State {
     /// Once the [`State`] is conflicting, then the only operation that is defined is
     /// [`State::restore_to`]. All other operations and queries on the state are unspecified.
     pub fn propagate_to_fixed_point(&mut self) -> Result<(), Conflict> {
+        let start_time = Instant::now();
+
         // The initial domain events are due to the decision predicate.
         self.notification_engine
             .notify_propagators_about_domain_events(
@@ -767,20 +777,30 @@ impl State {
             );
 
         // Keep propagating until there are unprocessed propagators, or a conflict is detected.
+        let mut result = Ok(());
         while let Some(propagator_id) = self.propagator_queue.pop() {
-            self.propagate(propagator_id)?;
+            if let Err(conflict) = self.propagate(propagator_id) {
+                result = Err(conflict);
+                break;
+            }
         }
 
         // Only check fixed point propagation if there was no reported conflict,
         // since otherwise the state may be inconsistent.
-        pumpkin_assert_extreme!(DebugHelper::debug_fixed_point_propagation(
-            &self.trailed_values,
-            &self.assignments,
-            &self.propagators,
-            &self.notification_engine
-        ));
+        pumpkin_assert_extreme!(
+            result.is_err()
+                || DebugHelper::debug_fixed_point_propagation(
+                    &self.trailed_values,
+                    &self.assignments,
+                    &self.propagators,
+                    &self.notification_engine
+                )
+        );
 
-        Ok(())
+        self.statistics.num_seconds_in_fixed_point_propagation +=
+            start_time.elapsed().as_secs_f64();
+
+        result
     }
 }
 

--- a/pumpkin-crates/core/src/statistics/mod.rs
+++ b/pumpkin-crates/core/src/statistics/mod.rs
@@ -55,7 +55,7 @@ macro_rules! create_statistics_struct {
 
         impl $crate::statistics::Statistic for $name {
             fn log(&self, statistic_logger: $crate::statistics::StatisticLogger) {
-                $(self.$field.log(statistic_logger.attach_to_prefix(stringify!($field),)));+
+                $($crate::statistics::Statistic::log(&self.$field, statistic_logger.attach_to_prefix(stringify!($field))));+
             }
         }
     };

--- a/pumpkin-solver/tests/helpers/mod.rs
+++ b/pumpkin-solver/tests/helpers/mod.rs
@@ -247,6 +247,7 @@ pub(crate) fn check_statistic_equality(
         .filter(|line| {
             line.starts_with("%%%mzn-stat")
                 && !line.contains("Time")
+                && !line.to_lowercase().contains("seconds")
                 && !line.contains("propagations")
         })
         .collect::<Vec<&str>>();
@@ -255,6 +256,7 @@ pub(crate) fn check_statistic_equality(
         .filter(|line| {
             line.starts_with("%%%mzn-stat")
                 && !line.contains("Time")
+                && !line.to_lowercase().contains("seconds")
                 && !line.contains("propagations")
         })
         .collect::<Vec<&str>>();


### PR DESCRIPTION
In preparation for larger-scale profiling.

Adding measurements so that we can see how much time is being spent in:
* Fixpoint propagation
* Conflict analysis, and the two nogood minimisation mechanisms
* Branching

This should be inexpensive to measure since we only record this once per fixpoint propagation call or conflict analysis.

I will later open a separate PR where we do a bit more detailed statistics per propagator.

Now this is a draft PR to see if there are any issue, overall it seems ready to me, but I have yet to run it on some instances.